### PR TITLE
Add support for un-announcing a track namespace

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1039,10 +1039,7 @@ Phrase Length` field carries its length.
 
 The publisher sends the `UNANNOUNCE` control message to indicate 
 its intent to stop accepting new SUBSCRIBE REQUESTs for tracks 
-within the announced Track Namespace. On successfully validating 
-the message, the receiver MUST stop routing new SUBSCRIBE REQUESTs
-to the publisher sending the `UNANNOUNCE` message.
-
+within the provided Track Namespace. 
 
 ~~~
 UNANNOUNCE Message {
@@ -1059,10 +1056,14 @@ UNANNOUNCE Message {
 * Track Request Parameters: The parameters are defined in
 {{track-req-params}}.
 
+The publisher MAY respond with `SUBSCRIBE ERROR` message ({{message-subscribe-error}}) with an appropriate error for any SUBSCRIBE REQUESTs received for track(s) matching the track namespace after sending the unannounce message.
+
 ## UNANNOUNCE OK {#message-unannounce-ok}
 
 The receiver sends an `UNANNOUNCE OK` control message to acknowledge the
-successful authorization and acceptance of the `UNANNOUNCE` message.
+successful authorization and acceptance of the `UNANNOUNCE` message. 
+For tracks within the track namespace provided in the unannounce message, the receiver MUST unsubscribe from all the tracks and stop routing new SUBSCRIBE REQUESTs to the publisher.
+
 
 ~~~
 UNANNOUNCE OK

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -887,7 +887,7 @@ successful authorization and acceptance of an ANNOUNCE message.
 ANNOUNCE OK
 {
   Track Namespace Length(i),
-  Track Namespace(...),
+  Track Namespace(..),
 }
 ~~~
 {: #moq-transport-announce-ok format title="MOQT ANNOUNCE OK Message"}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1065,7 +1065,7 @@ The receiver sends an `UNANNOUNCE OK` control message to acknowledge the
 successful authorization and acceptance of the `UNANNOUNCE` message.
 
 ~~~
-ANNOUNCE OK
+UNANNOUNCE OK
 {
   Track Namespace Length(i),
   Track Namespace
@@ -1082,7 +1082,7 @@ The receiver sends an `UNANNOUNCE ERROR` on failing to validate the
 `UNANNOUNCE` message.
 
 ~~~
-ANNOUNCE ERROR
+UNANNOUNCE ERROR
 {
   Track Namespace Length(i),
   Track Namespace(...),
@@ -1160,7 +1160,7 @@ TODO: fill out currently missing registries:
 * Track Request parameters
 * Subscribe Error codes
 * Announce Error codes
-* UnAnnounce Error codes
+* Unannounce Error codes
 * Unsubscribe Error codes
 * Track format numbers
 * Message types

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -639,25 +639,15 @@ continues until the end of the stream.
 |-------|--------------------------------------------------|
 | 0x5   | SUBSCRIBE ERROR ({{message-subscribe-error}})    |
 |-------|--------------------------------------------------|
-| 0x6   | UNSUBSCRIBE REQUEST ({{message-unsubscribe-req}})|
+| 0x6   | ANNOUNCE  ({{message-announce}})                 |
 |-------|--------------------------------------------------|
-| 0x7   | UNSUBSCRIBE OK ({{message-unsubscribe-ok}})      |
+| 0x7   | ANNOUNCE OK ({{message-announce-ok}})            |
 |-------|--------------------------------------------------|
-| 0x8   | UNSUBSCRIBE ERROR ({{message-unsubscribe-error}})|
+| 0x8   | ANNOUNCE ERROR ({{message-announce-error}})      |
 |-------|--------------------------------------------------|
-| 0x9   | ANNOUNCE  ({{message-announce}})                 |
+| 0x9   | UNANNOUNCE  ({{message-unannounce}})             |
 |-------|--------------------------------------------------|
-| 0x10  | ANNOUNCE OK ({{message-announce-ok}})            |
-|-------|--------------------------------------------------|
-| 0x11  | ANNOUNCE ERROR ({{message-announce-error}})      |
-|-------|--------------------------------------------------|
-| 0x12  | UNANNOUNCE  ({{message-unannounce}})                 |
-|-------|--------------------------------------------------|
-| 0x13  | UNANNOUNCE OK ({{message-unannounce-ok}})            |
-|-------|--------------------------------------------------|
-| 0x14  | UNANNOUNCE ERROR ({{message-unannounce-error}})      |
-|-------|--------------------------------------------------|
-| 0x15  | GOAWAY ({{message-goaway}})                      |
+| 0x10  | GOAWAY ({{message-goaway}})                      |
 |-------|--------------------------------------------------|
 
 ## SETUP {#message-setup}
@@ -866,72 +856,6 @@ this response is provided.
 Phrase Length` field carries its length.
 
 
-## UNSUBSCRIBE REQUEST {#message-unsubscribe-req}
-
-A subscriber issues a `UNSUBSCRIBE REQUEST` message to a publisher indicating it is no longer interested in receiving media for the specified track.
-
-The format of `UNSUBSCRIBE REQUEST` is as follows:
-
-~~~
-UNSUBSCRIBE REQUEST Message {
-  Full Track Name Length (i),
-  Full Track Name (...),
-  Track Request Parameters (..) ...
-}
-~~~
-{: #moq-transport-unsubscribe-format title="MOQT UNSUBSCRIBE REQUEST Message"}
-
-* Full Track Name: Identifies the track as defined in ({{track-name}}).
-
-* Track Request Parameters: As defined in {{track-req-params}}.
-
-
-## UNSUBSCRIBE OK {#message-unsubscribe-ok}
-
-A `UNSUBSCRIBE OK` control message is sent in response to a successful `UNSUBSCRIBE REQUEST` message.
-
-~~~
-UNSUBSCRIBE OK
-{
-  Full Track Name Length(i),
-  Full Track Name(...),
-}
-~~~
-{: #moq-transport-unsubscribe-ok format title="MOQT UNSUBSCRIBE OK Message"}
-
-* Full Track Name: Identifies the track for which this response is
-provided.
-
-On successfully validating the `UNSUBSCRIBE REQUEST` message, the publisher SHOULD cease delivering objects for the track to the subscriber.
-
-
-## UNSUBSCRIBE ERROR {#message-unsubscribe-error}
-
-A publisher sends a `UNSUBSCRIBE ERROR` control message in response to a
-failed `UNSUBSCRIBE REQUEST` message
-
-~~~
-UNSUBSCRIBE ERROR
-{
-  Full Track Name Length(i),
-  Full Track Name(...),
-  Error Code (i),
-  Reason Phrase Length (i),
-  Reason Phrase (...),
-}
-~~~
-{: #moq-transport-unsubscribe-error format title="MOQT UNSUBSCRIBE ERROR Message"}
-
-* Full Track Name: Identifies the track in the request message for which
-this response is provided.
-
-* Error Code: Identifies an integer error code for the failure.
-
-* Reason Phrase Length: The length in bytes of the reason phrase.
-
-* Reason Phrase: Provides the reason for unsubscription error and `Reason
-Phrase Length` field carries its length.
-
 ## ANNOUNCE {#message-announce}
 
 The publisher sends the ANNOUNCE control message to advertise where the
@@ -1000,69 +924,19 @@ Phrase Length` field carries its length.
 ## UNANNOUNCE {#message-unannounce}
 
 The publisher sends the `UNANNOUNCE` control message to indicate 
-its intent to stop accepting new SUBSCRIBE REQUESTs for tracks 
+its intent to stop serving new subscriptions for tracks 
 within the provided Track Namespace. 
 
 ~~~
 UNANNOUNCE Message {
   Track Namespace Length(i),
-  Track Namespace,
-  Track Request Parameters (..) ...,
+  Track Namespace(...),
 }
 ~~~
 {: #moq-transport-unannounce-format title="MOQT UNANNOUNCE Message"}
 
 * Track Namespace: Identifies a track's namespace as defined in
 ({{track-name}}).
-
-* Track Request Parameters: The parameters are defined in
-{{track-req-params}}.
-
-The publisher MAY respond with `SUBSCRIBE ERROR` message ({{message-subscribe-error}}) with an appropriate error for any SUBSCRIBE REQUESTs received for track(s) matching the track namespace after sending the unannounce message.
-
-## UNANNOUNCE OK {#message-unannounce-ok}
-
-The receiver sends an `UNANNOUNCE OK` control message to acknowledge the
-successful authorization and acceptance of the `UNANNOUNCE` message. 
-For tracks within the track namespace provided in the unannounce message, the receiver MUST unsubscribe from all the tracks and stop routing new SUBSCRIBE REQUESTs to the publisher.
-
-
-~~~
-UNANNOUNCE OK
-{
-  Track Namespace Length(i),
-  Track Namespace
-}
-~~~
-{: #moq-transport-unannounce-ok format title="MOQT UNANNOUNCE OK Message"}
-
-* Track Namespace: Identifies the track namespace in the UNANNOUNCE
-message for which this response is provided.
-
-## UNANNOUNCE ERROR {#message-unannounce-error}
-
-The receiver sends an `UNANNOUNCE ERROR` on failing to validate the
-`UNANNOUNCE` message.
-
-~~~
-UNANNOUNCE ERROR
-{
-  Track Namespace Length(i),
-  Track Namespace(...),
-  Error Code (i),
-  Reason Phrase Length (i),
-  Reason Phrase (...),
-}
-~~~
-{: #moq-transport-unannounce-error format title="MOQT UNANNOUNCE ERROR Message"}
-
-* Track Namespace: Identifies the track namespace in the UNANNOUNCE
-message for which this response is provided.
-
-* Error Code: Identifies an integer error code for the failure.
-
-* Reason Phrase: Provides the reason for announcement error and `Reason
-Phrase Length` field carries its length.
 
 
 ## GOAWAY {#message-goaway}
@@ -1165,8 +1039,6 @@ TODO: fill out currently missing registries:
 * Track Request parameters
 * Subscribe Error codes
 * Announce Error codes
-* Unannounce Error codes
-* Unsubscribe Error codes
 * Track format numbers
 * Message types
 * Object headers

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -626,27 +626,33 @@ The Message Length field contains the length of the Message Payload
 field in bytes.  A length of 0 indicates the message is unbounded and
 continues until the end of the stream.
 
-|------|----------------------------------------------|
-| ID   | Messages                                     |
-|-----:|:---------------------------------------------|
-| 0x0  | OBJECT ({{message-object}})                  |
-|------|----------------------------------------------|
-| 0x1  | SETUP ({{message-setup}})                    |
-|------|----------------------------------------------|
-| 0x3  | SUBSCRIBE REQUEST ({{message-subscribe-req}})|
-|------|----------------------------------------------|
-| 0x4  | SUBSCRIBE OK ({{message-subscribe-ok}})      |
-|------|----------------------------------------------|
-| 0x5  | SUBSCRIBE ERROR ({{message-subscribe-error}})|
-|------|----------------------------------------------|
-| 0x6  | ANNOUNCE  ({{message-announce}})             |
-|------|----------------------------------------------|
-| 0x7  | ANNOUNCE OK ({{message-announce-ok}})        |
-|------|----------------------------------------------|
-| 0x8  | ANNOUNCE ERROR ({{message-announce-error}})  |
-|------|----------------------------------------------|
-| 0x10 | GOAWAY ({{message-goaway}})                  |
-|------|----------------------------------------------|
+|-------|--------------------------------------------------|
+| ID    | Messages                                         |
+|------:|:-------------------------------------------------|
+| 0x0   | OBJECT ({{message-object}})                      |
+|-------|--------------------------------------------------|
+| 0x1   | SETUP ({{message-setup}})                        |
+|-------|--------------------------------------------------|
+| 0x3   | SUBSCRIBE REQUEST ({{message-subscribe-req}})    |
+|-------|--------------------------------------------------|
+| 0x4   | SUBSCRIBE OK ({{message-subscribe-ok}})          |
+|-------|--------------------------------------------------|
+| 0x5   | SUBSCRIBE ERROR ({{message-subscribe-error}})    |
+|-------|--------------------------------------------------|
+| 0x6   | UNSUBSCRIBE REQUEST ({{message-unsubscribe-req}})|
+|-------|--------------------------------------------------|
+| 0x7   | UNSUBSCRIBE OK ({{message-unsubscribe-ok}})      |
+|-------|--------------------------------------------------|
+| 0x8   | UNSUBSCRIBE ERROR ({{message-unsubscribe-error}})|
+|-------|--------------------------------------------------|
+| 0x9   | ANNOUNCE  ({{message-announce}})                 |
+|-------|--------------------------------------------------|
+| 0x10  | ANNOUNCE OK ({{message-announce-ok}})            |
+|-------|--------------------------------------------------|
+| 0x11  | ANNOUNCE ERROR ({{message-announce-error}})      |
+|-------|--------------------------------------------------|
+| 0x12  | GOAWAY ({{message-goaway}})                      |
+|-------|--------------------------------------------------|
 
 ## SETUP {#message-setup}
 
@@ -860,6 +866,72 @@ this response is provided.
 Phrase Length` field carries its length.
 
 
+## UNSUBSCRIBE REQUEST {#message-unsubscribe-req}
+
+A subscriber issues a `UNSUBSCRIBE REQUEST` message to a publisher indicating it is no longer interested in receiving media for the specified track.
+
+The format of `UNSUBSCRIBE REQUEST` is as follows:
+
+~~~
+UNSUBSCRIBE REQUEST Message {
+  Full Track Name Length (i),
+  Full Track Name (...),
+  Track Request Parameters (..) ...
+}
+~~~
+{: #moq-transport-unsubscribe-format title="MOQT UNSUBSCRIBE REQUEST Message"}
+
+* Full Track Name: Identifies the track as defined in ({{track-name}}).
+
+* Track Request Parameters: As defined in {{track-req-params}}.
+
+
+## UNSUBSCRIBE OK {#message-unsubscribe-ok}
+
+A `UNSUBSCRIBE OK` control message is sent in response to a successful `UNSUBSCRIBE REQUEST` message.
+
+~~~
+UNSUBSCRIBE OK
+{
+  Full Track Name Length(i),
+  Full Track Name(...),
+}
+~~~
+{: #moq-transport-unsubscribe-ok format title="MOQT UNSUBSCRIBE OK Message"}
+
+* Full Track Name: Identifies the track for which this response is
+provided.
+
+On successfully validating the `UNSUBSCRIBE REQUEST` message, the publisher SHOULD cease delivering objects for the track to the subscriber.
+
+
+## UNSUBSCRIBE ERROR {#message-unsubscribe-error}
+
+A publisher sends a `UNSUBSCRIBE ERROR` control message in response to a
+failed `UNSUBSCRIBE REQUEST` message
+
+~~~
+UNSUBSCRIBE ERROR
+{
+  Full Track Name Length(i),
+  Full Track Name(...),
+  Error Code (i),
+  Reason Phrase Length (i),
+  Reason Phrase (...),
+}
+~~~
+{: #moq-transport-unsubscribe-error format title="MOQT UNSUBSCRIBE ERROR Message"}
+
+* Full Track Name: Identifies the track in the request message for which
+this response is provided.
+
+* Error Code: Identifies an integer error code for the failure.
+
+* Reason Phrase Length: The length in bytes of the reason phrase.
+
+* Reason Phrase: Provides the reason for unsubscription error and `Reason
+Phrase Length` field carries its length.
+
 ## ANNOUNCE {#message-announce}
 
 The publisher sends the ANNOUNCE control message to advertise where the
@@ -911,7 +983,7 @@ SUBSCRIBE REQUEST message.
 AUTHORIZATION INFO parameter (key 0x02) identifies track's authorization
 information. This parameter is populated for cases where the
 authorization is required at the track level. This parameter is
-applicable in SUBSCRIBE REQUEST and ANNOUNCE messages.
+applicable in SUBSCRIBE REQUEST, UNSUBSCRIBE and ANNOUNCE messages.
 
 ## ANNOUNCE OK {#message-announce-ok}
 
@@ -1007,11 +1079,13 @@ reaching a resource limit.
 # IANA Considerations {#iana}
 
 TODO: fill out currently missing registries:
+
 * MOQT version numbers
 * SETUP parameters
 * Track Request parameters
 * Subscribe Error codes
 * Announce Error codes
+* Unsubscribe Error codes
 * Track format numbers
 * Message types
 * Object headers

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -651,6 +651,12 @@ continues until the end of the stream.
 |-------|--------------------------------------------------|
 | 0x11  | ANNOUNCE ERROR ({{message-announce-error}})      |
 |-------|--------------------------------------------------|
+| 0x12  | UNANNOUNCE  ({{message-unannounce}})                 |
+|-------|--------------------------------------------------|
+| 0x13  | UNANNOUNCE OK ({{message-unannounce-ok}})            |
+|-------|--------------------------------------------------|
+| 0x14  | UNANNOUNCE ERROR ({{message-unannounce-error}})      |
+|-------|--------------------------------------------------|
 | 0x12  | GOAWAY ({{message-goaway}})                      |
 |-------|--------------------------------------------------|
 
@@ -993,7 +999,9 @@ successful authorization and acceptance of an ANNOUNCE message.
 ~~~
 ANNOUNCE OK
 {
-  Track Namespace
+  Track Namespace Length(i),
+  Track Namespace,
+  
 }
 ~~~
 {: #moq-transport-announce-ok format title="MOQT ANNOUNCE OK Message"}
@@ -1022,6 +1030,73 @@ ANNOUNCE ERROR
 message for which this response is provided.
 
 * Error Code: Identifies an integer error code for announcement failure.
+
+* Reason Phrase: Provides the reason for announcement error and `Reason
+Phrase Length` field carries its length.
+
+
+## UNANNOUNCE {#message-unannounce}
+
+The publisher sends the `UNANNOUNCE` control message to indicate 
+its intent to stop accepting new SUBSCRIBE REQUESTs for tracks 
+within the announced Track Namespace. On successfully validating 
+the message, the receiver MUST stop routing new SUBSCRIBE REQUESTs
+to the publisher sending the `UNANNOUNCE` message.
+
+
+~~~
+UNANNOUNCE Message {
+  Track Namespace Length(i),
+  Track Namespace,
+  Track Request Parameters (..) ...,
+}
+~~~
+{: #moq-transport-unannounce-format title="MOQT UNANNOUNCE Message"}
+
+* Track Namespace: Identifies a track's namespace as defined in
+({{track-name}}).
+
+* Track Request Parameters: The parameters are defined in
+{{track-req-params}}.
+
+## UNANNOUNCE OK {#message-unannounce-ok}
+
+The receiver sends an `UNANNOUNCE OK` control message to acknowledge the
+successful authorization and acceptance of the `UNANNOUNCE` message.
+
+~~~
+ANNOUNCE OK
+{
+  Track Namespace Length(i),
+  Track Namespace
+}
+~~~
+{: #moq-transport-unannounce-ok format title="MOQT UNANNOUNCE OK Message"}
+
+* Track Namespace: Identifies the track namespace in the UNANNOUNCE
+message for which this response is provided.
+
+## UNANNOUNCE ERROR {#message-unannounce-error}
+
+The receiver sends an `UNANNOUNCE ERROR` on failing to validate the
+`UNANNOUNCE` message.
+
+~~~
+ANNOUNCE ERROR
+{
+  Track Namespace Length(i),
+  Track Namespace(...),
+  Error Code (i),
+  Reason Phrase Length (i),
+  Reason Phrase (...),
+}
+~~~
+{: #moq-transport-unannounce-error format title="MOQT UNANNOUNCE ERROR Message"}
+
+* Track Namespace: Identifies the track namespace in the UNANNOUNCE
+message for which this response is provided.
+
+* Error Code: Identifies an integer error code for the failure.
 
 * Reason Phrase: Provides the reason for announcement error and `Reason
 Phrase Length` field carries its length.
@@ -1085,6 +1160,7 @@ TODO: fill out currently missing registries:
 * Track Request parameters
 * Subscribe Error codes
 * Announce Error codes
+* UnAnnounce Error codes
 * Unsubscribe Error codes
 * Track format numbers
 * Message types

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -866,7 +866,7 @@ publish tracks under this namespace.
 ~~~
 ANNOUNCE Message {
   Track Namespace Length(i),
-  Track Namespace(...),
+  Track Namespace(..),
   Track Request Parameters (..) ...,
 }
 ~~~

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -645,7 +645,7 @@ continues until the end of the stream.
 |-------|--------------------------------------------------|
 | 0x8   | ANNOUNCE ERROR ({{message-announce-error}})      |
 |-------|--------------------------------------------------|
-| 0x9   | UNANNOUNCE  ({{message-unannounce}})             |
+| 0xA   | UNANNOUNCE  ({{message-unannounce}})             |
 |-------|--------------------------------------------------|
 | 0x10  | GOAWAY ({{message-goaway}})                      |
 |-------|--------------------------------------------------|
@@ -930,7 +930,7 @@ within the provided Track Namespace.
 ~~~
 UNANNOUNCE Message {
   Track Namespace Length(i),
-  Track Namespace(...),
+  Track Namespace(..),
 }
 ~~~
 {: #moq-transport-unannounce-format title="MOQT UNANNOUNCE Message"}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -657,7 +657,7 @@ continues until the end of the stream.
 |-------|--------------------------------------------------|
 | 0x14  | UNANNOUNCE ERROR ({{message-unannounce-error}})      |
 |-------|--------------------------------------------------|
-| 0x12  | GOAWAY ({{message-goaway}})                      |
+| 0x15  | GOAWAY ({{message-goaway}})                      |
 |-------|--------------------------------------------------|
 
 ## SETUP {#message-setup}


### PR DESCRIPTION
Following from discussions in #203 , this PR allows a given publishers to un-announce a track namespace to indicate that it is not longer accepting new subscribe requests.

The high-level call flow for happy path is as below

```mermaid
sequenceDiagram
  Alice->>Relay: ANNOUNCE(webex.com/alice/)
  Bob->>Relay: SUBSCRIBE( webex.com/alice/hd-video)
  Relay->>Alice: SUBSCRIBE( webex.com/alice/hd-video)
  loop media
        Alice-->Bob: Media Exchange for hd-video
   end
   Alice->>Relay: UNANNOUNCE(webex.com/alice)
   par Carl to Relay
   Carl ->> Relay: SUBSCRIBE( webex.com/alice/hd-video)
   opt Return error if subscribe cannot be served locally
   Relay ->> Carl: SUBSCRIBE ERROR (...)
   end
   and Relay to Alice
   Relay->> Alice: UNSUBSCRIBE(webex.com/alice/hd-video)
   end
   Relay->>Relay: Clean up publisher state for Alice
```
