### PR TITLE
Disallow unknown messages

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -613,18 +613,16 @@ limits.  See section 2.2 in {{QUIC}}.
 Both unidirectional and bidirectional QUIC streams contain sequences of
 length-delimited messages.
 
+An endpoint that receives an unknown message type MUST close the connection.
+
+
 ~~~
 MOQT Message {
   Message Type (i),
-  Message Length (i),
   Message Payload (..),
 }
 ~~~
 {: #moq-transport-message-format title="MOQT Message"}
-
-The Message Length field contains the length of the Message Payload
-field in bytes.  A length of 0 indicates the message is unbounded and
-continues until the end of the stream.
 
 |-------|--------------------------------------------------|
 | ID    | Messages                                         |
@@ -674,11 +672,13 @@ SETUP Parameter {
 Client SETUP Message Payload {
   Number of Supported Versions (i),
   Supported Version (i) ...,
+  Number of Parameters (i) ...,
   SETUP Parameters (..) ...,
 }
 
 Server SETUP Message Payload {
   Selected Version (i),
+  Number of Parameters (i) ...,
   SETUP Parameters (..) ...,
 }
 ~~~
@@ -765,6 +765,7 @@ OBJECT Message {
   Group Sequence (i),
   Object Sequence (i),
   Object Send Order (i),
+  Object Payload Length (i),
   Object Payload (b),
 }
 ~~~
@@ -783,6 +784,10 @@ group.
 * Object Send Order: An integer indicating the object send order
 {{send-order}} or priority {{ordering-by-priorities}} value.
 
+* Object Payload Length: The length of the following Object Payload. The
+sender MAY encode a zero in this field, which means that the message
+continues to the end of the stream.
+
 * Object Payload: An opaque payload intended for the consumer and SHOULD
 NOT be processed by a relay.
 
@@ -797,6 +802,7 @@ The format of SUBSCRIBE REQUEST is as follows:
 SUBSCRIBE REQUEST Message {
   Full Track Name Length (i),
   Full Track Name (...),
+  Number of Parameters (i),
   Track Request Parameters (..) ...
 }
 ~~~
@@ -818,9 +824,9 @@ A `SUBSCRIBE OK` control message is sent for successful subscriptions.
 ~~~
 SUBSCRIBE OK
 {
-  Full Track Name Length(i),
-  Full Track Name(...),
-  Track ID(i),
+  Full Track Name Length (i),
+  Full Track Name (...),
+  Track ID (i),
   Expires (i)
 }
 ~~~
@@ -847,8 +853,8 @@ failed SUBSCRIBE REQUEST.
 ~~~
 SUBSCRIBE ERROR
 {
-  Full Track Name Length(i),
-  Full Track Name(...),
+  Full Track Name Length (i),
+  Full Track Name (...),
   Error Code (i),
   Reason Phrase Length (i),
   Reason Phrase (...),
@@ -892,8 +898,9 @@ publish tracks under this namespace.
 
 ~~~
 ANNOUNCE Message {
-  Track Namespace Length(i),
-  Track Namespace(..),
+  Track Namespace Length (i),
+  Track Namespace (..),
+  Number of Parameters (i),
   Track Request Parameters (..) ...,
 }
 ~~~
@@ -913,8 +920,8 @@ successful authorization and acceptance of an ANNOUNCE message.
 ~~~
 ANNOUNCE OK
 {
-  Track Namespace Length(i),
-  Track Namespace(..),
+  Track Namespace Length (i),
+  Track Namespace (..),
 }
 ~~~
 {: #moq-transport-announce-ok format title="MOQT ANNOUNCE OK Message"}
@@ -940,7 +947,7 @@ ANNOUNCE ERROR
 {: #moq-transport-announce-error format title="MOQT ANNOUNCE ERROR Message"}
 
 * Track Namespace: Identifies the track namespace in the ANNOUNCE
-message for which this response is provided.
+message for which 44this response is provided.
 
 * Error Code: Identifies an integer error code for announcement failure.
 
@@ -976,7 +983,7 @@ The server:
 
 * MAY initiate a graceful shutdown by sending a GOAWAY message.
 * MUST close the QUIC connection after a timeout with the GOAWAY error
-  code ({{session-termination}}).
+  code ({{session-te99rmination}}).
 * MAY close the QUIC connection with a different error code if there is
   a fatal error before shutdown.
 * SHOULD wait until the `GOAWAY` message and any pending streams have

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -615,8 +615,6 @@ length-delimited messages.
 
 An endpoint that receives an unknown message type MUST close the connection.
 
-
-~~~
 MOQT Message {
   Message Type (i),
   Message Payload (..),
@@ -947,7 +945,7 @@ ANNOUNCE ERROR
 {: #moq-transport-announce-error format title="MOQT ANNOUNCE ERROR Message"}
 
 * Track Namespace: Identifies the track namespace in the ANNOUNCE
-message for which 44this response is provided.
+message for which this response is provided.
 
 * Error Code: Identifies an integer error code for announcement failure.
 
@@ -983,7 +981,7 @@ The server:
 
 * MAY initiate a graceful shutdown by sending a GOAWAY message.
 * MUST close the QUIC connection after a timeout with the GOAWAY error
-  code ({{session-te99rmination}}).
+  code ({{session-termination}}).
 * MAY close the QUIC connection with a different error code if there is
   a fatal error before shutdown.
 * SHOULD wait until the `GOAWAY` message and any pending streams have

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -615,6 +615,7 @@ length-delimited messages.
 
 An endpoint that receives an unknown message type MUST close the connection.
 
+~~~
 MOQT Message {
   Message Type (i),
   Message Payload (..),


### PR DESCRIPTION
Fixes #241 and #248.

if messages must be known, explicit message lengths are redundanct except for OBJECT and messages with parameters.

This also eliminates a whole class of potential errors where the message length does not match the actual parsing of the message. Not checking this -- and not have any message type be potentially zero-length -- greatly simplifies the parser.