### PR TITLE
Add an .editorconfig file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+max_line_length = 80

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -173,7 +173,7 @@ Consumer:
 
 Endpoint:
 
-: A Client or Server. 
+: A Client or Server.
 
 Group:
 
@@ -533,7 +533,7 @@ outside the scope of this specification.
 
 The subscriber making the subscribe request is notified of the result of
 the subscription, via SUBSCRIBE_OK ({{message-subscribe-ok}}) or the
-SUBSCRIBE_ERROR {{message-subscribe-error}} control message. 
+SUBSCRIBE_ERROR {{message-subscribe-error}} control message.
 The entity receiving the SUBSCRIBE MUST send only a single response to
 a given SUBSCRIBE of either SUBSCRIBE_OK or SUBSCRIBE_ERROR.
 


### PR DESCRIPTION
It's not a full linter, but it's quite useful to avoid spurious changes, like trailing whitespace and long lines.

Fixes #263