### PR TITLE
Reflow long lines.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 max_line_length = 80
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
         run: make html && mkdir ./_site && mv *.html ./_site
 
       - name: Upload artifact
-        # Automatically uploads an artifact from the './_site' directory by default
+        # Automatically uploads an artifact from the './_site' directory
         uses: actions/upload-pages-artifact@v1
 
   deploy:

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ MoQ Transport is a live media protocol that utilizes QUIC streams.
 
 
 ## Contributing
-All changes need to be made to the markdown file (.md).
-You can find a reference for the synatax [here](https://kramdown.gettalong.org/syntax.html).
-Each sentence is separated with a newline to reduce the number of merge conflicts.
+All changes need to be made to the markdown file (.md). You can find a reference
+for the synatax [here](https://kramdown.gettalong.org/syntax.html).
 
-If you want to locally build, you'll need to install [kramdown-rfc2629](https://github.com/cabo/kramdown-rfc) and [xml2rfc](https://github.com/ietf-tools/xml2rfc):
+If you want to locally build, you'll need to install
+[kramdown-rfc2629](https://github.com/cabo/kramdown-rfc) and
+[xml2rfc](https://github.com/ietf-tools/xml2rfc):
 
 ```bash
 gem install kramdown-rfc

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -163,7 +163,7 @@ Server:
 
 Endpoint:
 
-: A Client or Server. 
+: A Client or Server.
 
 Producer:
 
@@ -430,9 +430,10 @@ SHOULD terminate the session with 'GOAWAY Timeout' after a sufficient timeout if
 there are still open subscriptions on a connection.
 
 The GOAWAY message does not immediately impact subscription state. A subscriber
-SHOULD individually UNSUBSCRIBE for each existing subscription, while a publisher
-MAY reject new SUBSCRIBEs while in the draining state. When the server is
-a subscriber, it SHOULD send a GOAWAY message prior to any UNSUBSCRIBE messages.
+SHOULD individually UNSUBSCRIBE for each existing subscription, while a
+publisher MAY reject new SUBSCRIBEs while in the draining state. When the server
+is a subscriber, it SHOULD send a GOAWAY message prior to any UNSUBSCRIBE
+messages.
 
 After the client receives a GOAWAY, it's RECOMMENDED that the client waits until
 there are no more active subscriptions before closing the session with NO_ERROR.
@@ -729,7 +730,8 @@ The available versions and SETUP parameters are detailed in the next sections.
 
 MoQ Transport versions are a 32-bit unsigned integer, encoded as a varint.
 This version of the specification is identified by the number 0x00000001.
-Versions with the most significant 16 bits of the version number cleared are reserved for use in future IETF consensus documents.
+Versions with the most significant 16 bits of the version number cleared are
+reserved for use in future IETF consensus documents.
 
 The client offers the list of the protocol versions it supports; the
 server MUST reply with one of the versions offered by the client. If the
@@ -740,8 +742,11 @@ corresponding peer MUST close the connection.
 \[\[RFC editor: please remove the remainder of this section before
 publication.]]
 
-The version number for the final version of this specification (0x00000001), is reserved for the version of the protocol that is published as an RFC.
-Version numbers used to identify IETF drafts are created by adding the draft number to 0xff000000. For example, draft-ietf-moq-transport-13 would be identified as 0xff00000D.
+The version number for the final version of this specification (0x00000001), is
+reserved for the version of the protocol that is published as an RFC.
+Version numbers used to identify IETF drafts are created by adding the draft
+number to 0xff000000. For example, draft-ietf-moq-transport-13 would be
+identified as 0xff00000D.
 
 ### SETUP Parameters {#setup-parameters}
 
@@ -921,7 +926,8 @@ Phrase Length` field carries its length.
 
 ## UNSUBSCRIBE {#message-unsubscribe}
 
-A subscriber issues a `UNSUBSCRIBE` message to a publisher indicating it is no longer interested in receiving media for the specified track.
+A subscriber issues a `UNSUBSCRIBE` message to a publisher indicating it is no
+longer interested in receiving media for the specified track.
 
 The format of `UNSUBSCRIBE` is as follows:
 


### PR DESCRIPTION
before: 
```
% editorconfig-checker
.github/workflows/deploy.yml:
	54: Line too long (83 instead of 80)
Makefile:
	12: Wrong amount of left-padding spaces(want multiple of 2)
	13: Wrong amount of left-padding spaces(want multiple of 2)
	16: Wrong amount of left-padding spaces(want multiple of 2)
	19: Wrong amount of left-padding spaces(want multiple of 2)
README.md:
	4: Line too long (84 instead of 80)
	9: Line too long (92 instead of 80)
	10: Line too long (82 instead of 80)
	12: Line too long (163 instead of 80)
draft-ietf-moq-transport.md:
	166: Trailing whitespace
	433: Line too long (81 instead of 80)
	732: Line too long (129 instead of 80)
	743: Line too long (149 instead of 80)
	744: Line too long (174 instead of 80)
	924: Line too long (140 instead of 80)

15 errors found
```

after:
```
% editorconfig-checker
README.md:
	4: Line too long (84 instead of 80)

1 errors found
```

I don't know how to fix that last issue because it's just a long URL. It doesn't matter though.