### PR TITLE
Add Subscribe Id support

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -622,8 +622,8 @@ providing the result of announcement. The entity receiving the
 ANNOUNCE MUST send only a single response to a given ANNOUNCE of
 either ANNOUNCE_OK or ANNOUNCE_ERROR.
 
-OBJECT message header carry short hop-by-hop `Track ID` that maps to the
-Full Track Name. Relays use the `Track ID`
+OBJECT message header carry short hop-by-hop Track ID that maps to the
+Full Track Name (see {{message-subscribe-ok}}). Relays use the Track ID
 of an incoming OBJECT message to identify its track and find the active
 subscribers for that track. Relays MUST NOT depend on OBJECT payload
 content for making forwarding decisions and MUST only depend on the
@@ -1121,7 +1121,7 @@ SUBSCRIBE_ERROR
 ~~~
 {: #moq-transport-subscribe-error format title="MOQT SUBSCRIBE_ERROR Message"}
 
-* SubscribeID: Subscription Identifer as defined in {{message-subscribe-req}}.
+* Subscribe ID: Subscription Identifer as defined in {{message-subscribe-req}}.
 
 * Error Code: Identifies an integer error code for subscription failure.
 
@@ -1145,7 +1145,7 @@ UNSUBSCRIBE Message {
 ~~~
 {: #moq-transport-unsubscribe-format title="MOQT UNSUBSCRIBE Message"}
 
-* SubscribeID: Subscription Identifer as defined in {{message-subscribe-req}}.
+* Subscribe ID: Subscription Identifer as defined in {{message-subscribe-req}}.
 
 ## SUBSCRIBE_FIN {#message-subscribe-fin}
 
@@ -1190,7 +1190,7 @@ SUBSCRIBE_RST Message {
 ~~~
 {: #moq-transport-subscribe-rst format title="MOQT SUBSCRIBE RST Message"}
 
-* SubscribeI D: Subscription Identifier as defined in {{message-subscribe-req}}.
+* Subscribe ID: Subscription Identifier as defined in {{message-subscribe-req}}.
 
 * Error Code: Identifies an integer error code for subscription failure.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1094,7 +1094,7 @@ SUBSCRIBE_OK
 
 * Track ID: Session specific identifier that is used as an alias for the
 Full Track Name in the Track ID field of the OBJECT ({{message-object}})
-message headers of the requested track. Track IDs are generally shorter than
+message headers of the requested track. Track IDs are shorter than
 Full Track Names and thus reduce the overhead in OBJECT messages
 
 * Subscribe ID: Subscription Identifer from the incoming subscription request

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -987,8 +987,8 @@ SUBSCRIBE Message {
 is monotonically increasing variable length integer and it MUST uniquely
 identify a subscription within a session. `Subscribe ID` is used by
 subscribers and the publishers to identify a given subscription. Subscribers
-generate the `Subscribe ID` and it MUST be copied by the publisher when
-responding to the subscription requests.
+specify the `Subscribe ID` and it is included in the corresponding SUBSCRIBE_OK
+or SUBSCRIBE_ERROR.
 
 * StartGroup: The Location of the requested group.  StartGroup's Mode MUST NOT be
 None.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -622,8 +622,8 @@ providing the result of announcement. The entity receiving the
 ANNOUNCE MUST send only a single response to a given ANNOUNCE of
 either ANNOUNCE_OK or ANNOUNCE_ERROR.
 
-OBJECT message header carry short hop-by-hop Track Id that maps to the
-Full Track Name (see {{message-subscribe-ok}}). Relays use the Track ID
+OBJECT message header carry short hop-by-hop `FullTrackName Alias` that maps to the
+Full Track Name (see {{message-subscribe-ok}}). Relays use the `FullTrackName Alias`
 of an incoming OBJECT message to identify its track and find the active
 subscribers for that track. Relays MUST NOT depend on OBJECT payload
 content for making forwarding decisions and MUST only depend on the
@@ -882,23 +882,23 @@ A OBJECT message contains a range of contiguous bytes from from the
 specified track, as well as associated metadata required to deliver,
 cache, and forward it. There are two subtypes of this message. When the
 message type is 0x00, the optional Object Payload Length field is
-present. When the message type ix 0x02, the field is not present.
+present. When the message type is 0x02, the field is not present.
 
 The format of the OBJECT message is as follows:
 
 ~~~
 OBJECT Message {
-  Track ID (i),
+  FullTrackName Alias (i),
   Group Sequence (i),
   Object Sequence (i),
   Object Send Order (i),
-  [Object Payload Length (i),]
+  [Object Payload Length (i)],
   Object Payload (b),
 }
 ~~~
 {: #moq-transport-object-format title="MOQT OBJECT Message"}
 
-* Track ID: The track identifier obtained as part of subscription and/or
+* FullTrackName Alias : The compressed full track name obtained as part of subscription and/or
 publish control message exchanges.
 
 * Group Sequence : The object is a member of the indicated group
@@ -960,14 +960,15 @@ RelativeNext Value:                               0    1  ...
 {: title="Relative Indexing"}
 
 
-### SUBSCRIBE REQUEST Format
+### SUBSCRIBE Format
 
-The format of SUBSCRIBE REQUEST is as follows:
+The format of SUBSCRIBE is as follows:
 
 ~~~
-SUBSCRIBE REQUEST Message {
+SUBSCRIBE Message {
   Full Track Name Length (i),
   Full Track Name (...),
+  Subscribe ID(i),
   StartGroup (Location),
   StartObject (Location),
   EndGroup (Location),
@@ -981,6 +982,8 @@ SUBSCRIBE REQUEST Message {
 ({{track-name}}).
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
+
+* Subscribe ID: Session unique identifer for a given SUBSCRIBE message.
 
 * StartGroup: The Location of the requested group.  StartGroup's Mode MUST NOT be
 None.
@@ -1069,7 +1072,8 @@ SUBSCRIBE_OK
 {
   Track Namespace (b),
   Track Name (b),
-  Track ID (i),
+  FullTrackName Alias (i),
+
   Expires (i)
 }
 ~~~
@@ -1080,9 +1084,9 @@ SUBSCRIBE_OK
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
-* Track ID: Session specific identifier that is used as an alias for the
-Full Track Name in the Track ID field of the OBJECT ({{message-object}})
-message headers of the requested track. Track IDs are generally shorter
+* FullTrackName Alias: Session specific identifier that is used as an alias for the
+Full Track Name in the `FullTrackName Alias` field of the OBJECT ({{message-object}})
+message headers of the requested track. FullTrackName Aliases are generally shorter
 than Full Track Names and thus reduce the overhead in OBJECT messages.
 
 * Expires: Time in milliseconds after which the subscription is no
@@ -1098,8 +1102,7 @@ failed SUBSCRIBE.
 ~~~
 SUBSCRIBE_ERROR
 {
-  Track Namespace (b),
-  Track Name (b),
+  Subscribe ID (i),
   Error Code (i),
   Reason Phrase Length (i),
   Reason Phrase (...),
@@ -1107,10 +1110,7 @@ SUBSCRIBE_ERROR
 ~~~
 {: #moq-transport-subscribe-error format title="MOQT SUBSCRIBE_ERROR Message"}
 
-* Track Namespace: Identifies the namespace of the track as defined in
-({{track-name}}).
-
-* Track Name: Identifies the track name as defined in ({{track-name}}).
+* Subscribe ID: Subscription identifier obtained from the SUBSCRIBE message.
 
 * Error Code: Identifies an integer error code for subscription failure.
 
@@ -1129,16 +1129,13 @@ The format of `UNSUBSCRIBE` is as follows:
 
 ~~~
 UNSUBSCRIBE Message {
-  Track Namespace (b),
-  Track Name (b),
+  Subscribe ID(i)
 }
 ~~~
 {: #moq-transport-unsubscribe-format title="MOQT UNSUBSCRIBE Message"}
 
-* Track Namespace: Identifies the namespace of the track as defined in
-({{track-name}}).
+* Subscribe ID: Subscription identifier matching SUBSCRIBE message.
 
-* Track Name: Identifies the track name as defined in ({{track-name}}).
 
 ## SUBSCRIBE_FIN {#message-subscribe-fin}
 
@@ -1149,18 +1146,14 @@ The format of `SUBSCRIBE_FIN` is as follows:
 
 ~~~
 SUBSCRIBE_FIN Message {
-  Track Namespace (b),
-  Track Name (b),
+  Subscribe ID(i),
   Final Group (i),
   Final Object (i),
 }
 ~~~
 {: #moq-transport-subscribe-fin-format title="MOQT SUBSCRIBE_FIN Message"}
 
-* Track Namespace: Identifies the namespace of the track as defined in
-({{track-name}}).
-
-* Track Name: Identifies the track name as defined in ({{track-name}}).
+* Subscribe ID: Subscription identifier matching SUBSCRIBE message.
 
 * Final Group: The largest Group Sequence sent by the publisher in an OBJECT
 message in this track.
@@ -1177,8 +1170,7 @@ The format of `SUBSCRIBE_RST` is as follows:
 
 ~~~
 SUBSCRIBE_RST Message {
-  Track Namespace (b),
-  Track Name (b),
+  Subscribe ID(i),
   Error Code (i),
   Reason Phrase Length (i),
   Reason Phrase (...),
@@ -1188,10 +1180,7 @@ SUBSCRIBE_RST Message {
 ~~~
 {: #moq-transport-subscribe-rst format title="MOQT SUBSCRIBE RST Message"}
 
-* Track Namespace: Identifies the namespace of the track as defined in
-({{track-name}}).
-
-* Track Name: Identifies the track name as defined in ({{track-name}}).
+* Subscribe ID: Subscription identifier matching SUBSCRIBE message.
 
 * Error Code: Identifies an integer error code for subscription failure.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1096,8 +1096,7 @@ Full Track Name in the Track ID field of the OBJECT ({{message-object}})
 message headers of the requested track. Track IDs are shorter than
 Full Track Names and thus reduce the overhead in OBJECT messages
 
-* Subscribe ID: Subscription Identifer from the incoming subscription request
-for which this message is the response.
+* Subscribe ID: Subscription Identifier specified in the corresponding SUBSCRIBE message.
 
 * Expires: Time in milliseconds after which the subscription is no
 longer valid. A value of 0 indicates that the subscription stays active

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -622,8 +622,8 @@ providing the result of announcement. The entity receiving the
 ANNOUNCE MUST send only a single response to a given ANNOUNCE of
 either ANNOUNCE_OK or ANNOUNCE_ERROR.
 
-OBJECT message header carry short hop-by-hop `Full Track Name Alias` that maps to the
-Full Track Name (see {{message-subscribe-ok}}). Relays use the `Full Track Name Alias`
+OBJECT message header carry short hop-by-hop `Track Alias` that maps to the
+Full Track Name (see {{message-subscribe-ok}}). Relays use the `Track Alias`
 of an incoming OBJECT message to identify its track and find the active
 subscribers for that track. Relays MUST NOT depend on OBJECT payload
 content for making forwarding decisions and MUST only depend on the
@@ -888,7 +888,7 @@ The format of the OBJECT message is as follows:
 
 ~~~
 OBJECT Message {
-  Full Track Name Alias (i),
+  Track Alias (i),
   Group Sequence (i),
   Object Sequence (i),
   Object Send Order (i),
@@ -898,7 +898,7 @@ OBJECT Message {
 ~~~
 {: #moq-transport-object-format title="MOQT OBJECT Message"}
 
-* Full Track Name Alias : The compressed full track name obtained as part of subscription and/or publish control message exchanges.
+* Track Alias : The compressed full track name obtained as part of subscription and/or publish control message exchanges.
 
 * Group Sequence : The object is a member of the indicated group
 {{model-group}} within the track.
@@ -967,7 +967,7 @@ The format of SUBSCRIBE is as follows:
 SUBSCRIBE Message {
   Full Track Name Length (i),
   Full Track Name (...),
-  SubscribeID (i),
+  Subscribe ID (i),
   StartGroup (Location),
   StartObject (Location),
   EndGroup (Location),
@@ -982,8 +982,7 @@ SUBSCRIBE Message {
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
-* SubscribeID: Session unique identifier for the subscription. `SubscribeID` MUST uniquely identify a subscription within a session and is used by subscribers and publishers to identify a given subscription. Subscribers generate the `SubscribeID` and MUST be
-copied by the publisher when responding to the subscription requests.
+* Subscribe ID: Session unique identifier for the subscription. `Subscribe ID` is monotonically increasing variable length integer and it MUST uniquely identify a subscription within a session. `Subscribe ID` is used by subscribers and the publishers to identify a given subscription. Subscribers generate the `Subscribe ID` and it MUST be copied by the publisher when responding to the subscription requests.
 
 * StartGroup: The Location of the requested group.  StartGroup's Mode MUST NOT be
 None.
@@ -1009,9 +1008,7 @@ If a publisher cannot satisfy the requested start or end for the subscription it
 MAY send a SUBSCRIBE_ERROR with code TBD. A publisher MUST NOT send objects
 from outside the requested start and end.
 
-`SUBSCRIBE` with an existing `SubscribeID` updates the existing subscription and MUST NOT
-create a new subscription state within the publishers.
-
+TODO: Define the flow where subscribe request matches an existing subscribe id (subscription updates.)
 
 ### Examples
 
@@ -1075,8 +1072,8 @@ A SUBSCRIBE_OK control message is sent for successful subscriptions.
 ~~~
 SUBSCRIBE_OK
 {
-  SubscribeID (i),
-  Full Track Name Alias (i),
+  Track Alias (i),
+  Subscribe ID (i),
   Expires (i)
 }
 ~~~
@@ -1085,7 +1082,7 @@ SUBSCRIBE_OK
 * SubscribeID: Subscription Identifer from the incoming subscription request for which this message is the response.
 
 
-* Full Track Name Alias: Session specific identifier that is used as an alias for the Full Track Name in the `Full Track Name Alias` field of the OBJECT ({{message-object}}) message headers of the requested track. `Full Track Name Alias` is generally shorter than Full Track Names and thus reduce the overhead in OBJECT messages.
+* Track Alias: Session specific identifier that is used as an alias for the Full Track Name in the `Track Alias` field of the OBJECT ({{message-object}}) message headers of the requested track. `Track Alias` is generally shorter than Full Track Names and thus reduce the overhead in OBJECT messages.
 
 * Expires: Time in milliseconds after which the subscription is no
 longer valid. A value of 0 indicates that the subscription stays active
@@ -1100,7 +1097,7 @@ failed SUBSCRIBE.
 ~~~
 SUBSCRIBE_ERROR
 {
-  SubscribeID (i),
+  Subscribe ID (i),
   Error Code (i),
   Reason Phrase Length (i),
   Reason Phrase (...),
@@ -1108,8 +1105,7 @@ SUBSCRIBE_ERROR
 ~~~
 {: #moq-transport-subscribe-error format title="MOQT SUBSCRIBE_ERROR Message"}
 
-* SubscribeID: Subscription Identifer from the incoming subscription request for which
-this message is the response.
+* SubscribeID: Subscription Identifer as defined in {{message-subscribe-req}}.
 
 * Error Code: Identifies an integer error code for subscription failure.
 
@@ -1128,12 +1124,12 @@ The format of `UNSUBSCRIBE` is as follows:
 
 ~~~
 UNSUBSCRIBE Message {
-  SubscribeID (i)
+  Subscribe ID (i)
 }
 ~~~
 {: #moq-transport-unsubscribe-format title="MOQT UNSUBSCRIBE Message"}
 
-* SubscribeID: Identifies the subscription.
+* SubscribeID: Subscription Identifer as defined in {{message-subscribe-req}}.
 
 ## SUBSCRIBE_FIN {#message-subscribe-fin}
 
@@ -1144,14 +1140,14 @@ The format of `SUBSCRIBE_FIN` is as follows:
 
 ~~~
 SUBSCRIBE_FIN Message {
-  SubscribeID (i),
+  Subscribe ID (i),
   Final Group (i),
   Final Object (i),
 }
 ~~~
 {: #moq-transport-subscribe-fin-format title="MOQT SUBSCRIBE_FIN Message"}
 
-* SubscribeID: Identifies the subscription.
+* Subscribe ID: Subscription identifier as defined in {{message-subscribe-req}}.
 
 * Final Group: The largest Group Sequence sent by the publisher in an OBJECT
 message in this track.
@@ -1168,7 +1164,7 @@ The format of `SUBSCRIBE_RST` is as follows:
 
 ~~~
 SUBSCRIBE_RST Message {
-  SubscribeID (i),
+  Subscribe ID (i),
   Error Code (i),
   Reason Phrase Length (i),
   Reason Phrase (...),
@@ -1178,7 +1174,7 @@ SUBSCRIBE_RST Message {
 ~~~
 {: #moq-transport-subscribe-rst format title="MOQT SUBSCRIBE RST Message"}
 
-* SubscribeID: Identifies the subscription.
+* SubscribeI D: Subscription Identifier as defined in {{message-subscribe-req}}.
 
 * Error Code: Identifies an integer error code for subscription failure.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -623,7 +623,7 @@ ANNOUNCE MUST send only a single response to a given ANNOUNCE of
 either ANNOUNCE_OK or ANNOUNCE_ERROR.
 
 OBJECT message header carry short hop-by-hop `Track Alias` that maps to the
-Full Track Name (see {{message-subscribe-ok}}). Relays use the `Track Alias`
+Full Track Name. Relays use the `Track Alias`
 of an incoming OBJECT message to identify its track and find the active
 subscribers for that track. Relays MUST NOT depend on OBJECT payload
 content for making forwarding decisions and MUST only depend on the
@@ -1072,7 +1072,6 @@ A SUBSCRIBE_OK control message is sent for successful subscriptions.
 ~~~
 SUBSCRIBE_OK
 {
-  Track Alias (i),
   Subscribe ID (i),
   Expires (i)
 }
@@ -1080,9 +1079,6 @@ SUBSCRIBE_OK
 {: #moq-transport-subscribe-ok format title="MOQT SUBSCRIBE_OK Message"}
 
 * SubscribeID: Subscription Identifer from the incoming subscription request for which this message is the response.
-
-
-* Track Alias: Session specific identifier that is used as an alias for the Full Track Name in the `Track Alias` field of the OBJECT ({{message-object}}) message headers of the requested track. `Track Alias` is generally shorter than Full Track Names and thus reduce the overhead in OBJECT messages.
 
 * Expires: Time in milliseconds after which the subscription is no
 longer valid. A value of 0 indicates that the subscription stays active

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1096,7 +1096,7 @@ Full Track Name in the Track ID field of the OBJECT ({{message-object}})
 message headers of the requested track. Track IDs are shorter than
 Full Track Names and thus reduce the overhead in OBJECT messages
 
-* Subscribe ID: Subscription Identifier specified in the corresponding SUBSCRIBE message.
+* Subscribe ID: Subscription Identifer as defined in {{message-subscribe-req}}.
 
 * Expires: Time in milliseconds after which the subscription is no
 longer valid. A value of 0 indicates that the subscription stays active

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1078,10 +1078,10 @@ A SUBSCRIBE_OK control message is sent for successful subscriptions.
 ~~~
 SUBSCRIBE_OK
 {
+  Subscribe ID (i),
   Track Namespace (b),
   Track Name (b),
   Track ID (i),
-  Subscribe ID (i),
   Expires (i)
 }
 ~~~

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -966,9 +966,9 @@ The format of SUBSCRIBE is as follows:
 
 ~~~
 SUBSCRIBE Message {
+  Subscribe ID (i),
   Full Track Name Length (i),
   Full Track Name (...),
-  Subscribe ID (i),
   StartGroup (Location),
   StartObject (Location),
   EndGroup (Location),

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -622,8 +622,8 @@ providing the result of announcement. The entity receiving the
 ANNOUNCE MUST send only a single response to a given ANNOUNCE of
 either ANNOUNCE_OK or ANNOUNCE_ERROR.
 
-OBJECT message header carry short hop-by-hop `Track Alias` that maps to the
-Full Track Name (see {{message-subscribe-ok}}). Relays use the `Track Alias`
+OBJECT message header carry short hop-by-hop `Full Track Name Alias` that maps to the
+Full Track Name (see {{message-subscribe-ok}}). Relays use the `Full Track Name Alias`
 of an incoming OBJECT message to identify its track and find the active
 subscribers for that track. Relays MUST NOT depend on OBJECT payload
 content for making forwarding decisions and MUST only depend on the
@@ -888,7 +888,7 @@ The format of the OBJECT message is as follows:
 
 ~~~
 OBJECT Message {
-  Track Alias (i),
+  Full Track Name Alias (i),
   Group Sequence (i),
   Object Sequence (i),
   Object Send Order (i),
@@ -898,8 +898,7 @@ OBJECT Message {
 ~~~
 {: #moq-transport-object-format title="MOQT OBJECT Message"}
 
-* Track Alias : The compressed full track name obtained as part of subscription and/or
-publish control message exchanges.
+* Full Track Name Alias : The compressed full track name obtained as part of subscription and/or publish control message exchanges.
 
 * Group Sequence : The object is a member of the indicated group
 {{model-group}} within the track.
@@ -1077,20 +1076,16 @@ A SUBSCRIBE_OK control message is sent for successful subscriptions.
 SUBSCRIBE_OK
 {
   SubscribeID (i),
-  Track Alias (i),
+  Full Track Name Alias (i),
   Expires (i)
 }
 ~~~
 {: #moq-transport-subscribe-ok format title="MOQT SUBSCRIBE_OK Message"}
 
-* SubscribeID: Subscription Identifer from the incoming subscription request for which
-this message is the response.
+* SubscribeID: Subscription Identifer from the incoming subscription request for which this message is the response.
 
 
-* Track Alias: Session specific identifier that is used as an alias for the
-Full Track Name in the `Track Alias` field of the OBJECT ({{message-object}})
-message headers of the requested track. `Track Alias'es` are generally shorter
-than Full Track Names and thus reduce the overhead in OBJECT messages.
+* Full Track Name Alias: Session specific identifier that is used as an alias for the Full Track Name in the `Full Track Name Alias` field of the OBJECT ({{message-object}}) message headers of the requested track. `Full Track Name Alias` is generally shorter than Full Track Names and thus reduce the overhead in OBJECT messages.
 
 * Expires: Time in milliseconds after which the subscription is no
 longer valid. A value of 0 indicates that the subscription stays active

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -983,12 +983,12 @@ SUBSCRIBE Message {
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
-* Subscribe ID: Session unique identifier for the subscription. `Subscribe ID`
-is monotonically increasing variable length integer and it MUST uniquely
-identify a subscription within a session. `Subscribe ID` is used by
-subscribers and the publishers to identify a given subscription. Subscribers
-specify the `Subscribe ID` and it is included in the corresponding SUBSCRIBE_OK
-or SUBSCRIBE_ERROR.
+* Subscribe ID: The subscription identifier that is unique within the session.
+`Subscribe ID` is a monotonically increasing variable length integer which
+MUST not be reused within a session. `Subscribe ID` is used by subscribers and
+the publishers to identify a given subscription. Subscribers specify the
+`Subscribe ID` and it is included in the corresponding SUBSCRIBE_OK or
+SUBSCRIBE_ERROR messages.
 
 * StartGroup: The Location of the requested group.  StartGroup's Mode MUST NOT be
 None.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -622,8 +622,8 @@ providing the result of announcement. The entity receiving the
 ANNOUNCE MUST send only a single response to a given ANNOUNCE of
 either ANNOUNCE_OK or ANNOUNCE_ERROR.
 
-OBJECT message header carry short hop-by-hop `Track Alias` that maps to the
-Full Track Name. Relays use the `Track Alias`
+OBJECT message header carry short hop-by-hop `Track ID` that maps to the
+Full Track Name. Relays use the `Track ID`
 of an incoming OBJECT message to identify its track and find the active
 subscribers for that track. Relays MUST NOT depend on OBJECT payload
 content for making forwarding decisions and MUST only depend on the
@@ -888,7 +888,7 @@ The format of the OBJECT message is as follows:
 
 ~~~
 OBJECT Message {
-  Track Alias (i),
+  Track ID (i),
   Group Sequence (i),
   Object Sequence (i),
   Object Send Order (i),
@@ -898,7 +898,8 @@ OBJECT Message {
 ~~~
 {: #moq-transport-object-format title="MOQT OBJECT Message"}
 
-* Track Alias : The compressed full track name obtained as part of subscription and/or publish control message exchanges.
+* Track ID : The compressed full track name obtained as part of subscription
+and/or publish control message exchanges.
 
 * Group Sequence : The object is a member of the indicated group
 {{model-group}} within the track.
@@ -982,7 +983,12 @@ SUBSCRIBE Message {
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
-* Subscribe ID: Session unique identifier for the subscription. `Subscribe ID` is monotonically increasing variable length integer and it MUST uniquely identify a subscription within a session. `Subscribe ID` is used by subscribers and the publishers to identify a given subscription. Subscribers generate the `Subscribe ID` and it MUST be copied by the publisher when responding to the subscription requests.
+* Subscribe ID: Session unique identifier for the subscription. `Subscribe ID`
+is monotonically increasing variable length integer and it MUST uniquely
+identify a subscription within a session. `Subscribe ID` is used by
+subscribers and the publishers to identify a given subscription. Subscribers
+generate the `Subscribe ID` and it MUST be copied by the publisher when
+responding to the subscription requests.
 
 * StartGroup: The Location of the requested group.  StartGroup's Mode MUST NOT be
 None.
@@ -1008,7 +1014,8 @@ If a publisher cannot satisfy the requested start or end for the subscription it
 MAY send a SUBSCRIBE_ERROR with code TBD. A publisher MUST NOT send objects
 from outside the requested start and end.
 
-TODO: Define the flow where subscribe request matches an existing subscribe id (subscription updates.)
+TODO: Define the flow where subscribe request matches an existing subscribe id
+(subscription updates.)
 
 ### Examples
 
@@ -1049,7 +1056,6 @@ Start Group: Mode=RelativeNext, Value=0
 Start Object: Mode=Absolute, Value=0
 End Group: Mode=None
 End Object: Mode=None
-
 StartGroup=Largest Group + 1
 StartObject=0
 
@@ -1072,13 +1078,27 @@ A SUBSCRIBE_OK control message is sent for successful subscriptions.
 ~~~
 SUBSCRIBE_OK
 {
+  Track Namespace (b),
+  Track Name (b),
+  Track ID (i),
   Subscribe ID (i),
   Expires (i)
 }
 ~~~
 {: #moq-transport-subscribe-ok format title="MOQT SUBSCRIBE_OK Message"}
 
-* SubscribeID: Subscription Identifer from the incoming subscription request for which this message is the response.
+* Track Namespace: Identifies the namespace of the track as defined in
+({{track-name}}).
+
+* Track Name: Identifies the track name as defined in ({{track-name}}).
+
+* Track ID: Session specific identifier that is used as an alias for the
+Full Track Name in the Track ID field of the OBJECT ({{message-object}})
+message headers of the requested track. Track IDs are generally shorter than
+Full Track Names and thus reduce the overhead in OBJECT messages
+
+* Subscribe ID: Subscription Identifer from the incoming subscription request
+for which this message is the response.
 
 * Expires: Time in milliseconds after which the subscription is no
 longer valid. A value of 0 indicates that the subscription stays active

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1006,7 +1006,6 @@ NOT be None if EndGroup's Mode is not None.
 * Track Request Parameters: The parameters are defined in
 {{version-specific-params}}
 
-
 On successful subscription, the publisher SHOULD start delivering
 objects from the group sequence and object sequence described above.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1077,7 +1077,6 @@ A SUBSCRIBE_OK control message is sent for successful subscriptions.
 SUBSCRIBE_OK
 {
   SubscribeID (i),
-  Track Name (b),
   Track Alias (i),
   Expires (i)
 }


### PR DESCRIPTION
This PR is expected to be base PR to support multi-subscribe like flows that will follow up.

It adds support for SubscribeID and also renames the trackId to `Full Track Name Alias` to avoid the confusion and make the scope clear.

