### PR TITLE
Describe how to use datagrams

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -313,7 +313,7 @@ over a QUIC connection directly [QUIC], and over WebTransport
 semantics (see {{?I-D.ietf-webtrans-overview, Section 4}}); thus, the
 main difference lies in how the servers are identified and how the
 connection is established.  There is no definition of the protocol
-over other transports, such as TCP, and applicaitons using MoQ might
+over other transports, such as TCP, and applications using MoQ might
 need to fallback to another protocol when QUIC or WebTransport aren't
 available.
 
@@ -669,9 +669,6 @@ limits.  See section 2.2 in {{QUIC}}.
 
 # Messages {#message}
 
-Both unidirectional and bidirectional streams contain sequences of
-length-delimited messages.
-
 An endpoint that receives an unknown message type MUST close the session.
 
 ~~~
@@ -868,6 +865,14 @@ specified track, as well as associated metadata required to deliver,
 cache, and forward it. There are two subtypes of this message. When the
 message type is 0x00, the optional Object Payload Length field is
 present. When the message type ix 0x02, the field is not present.
+
+OBJECT messages are transmitted over unidirectional streams and can
+also be transmitted over datagrams if the object or objects fit into
+a single datagram.  For larger objects, a stream needs to be used.
+Streams are by default reliable and datagrams are by default unreliable,
+but implementations can provide equivalent levels of reliability,
+including the support of a time-to-live parameter that indicates
+when to stop retransmitting lost data from the stream or datagram.
 
 The format of the OBJECT message is as follows:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -874,7 +874,8 @@ but implementations can provide equivalent levels of reliability,
 including the support of a time-to-live parameter that indicates
 when to stop retransmitting lost data from the stream or datagram.
 The choice of whether to use a datagram or stream is a hop-by-hop
-decision, because MTUs may differ.
+decision, because MTUs may differ.  Datagrams do not have flow control
+limits, but streams do, which may affect the decision of which to use.
 
 The format of the OBJECT message is as follows:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -873,6 +873,8 @@ Streams are by default reliable and datagrams are by default unreliable,
 but implementations can provide equivalent levels of reliability,
 including the support of a time-to-live parameter that indicates
 when to stop retransmitting lost data from the stream or datagram.
+The choice of whether to use a datagram or stream is a hop-by-hop
+decision, because MTUs may differ.
 
 The format of the OBJECT message is as follows:
 


### PR DESCRIPTION
Fixes #35

Also fixes #38 because there is existing text about streams:
```
"A relay that reads from a stream and writes to stream in order will
introduce head-of-line blocking.  Packet loss will cause stream data to
be buffered in the library, awaiting in order delivery, which will
increase latency over additional hops.  To mitigate this, a relay SHOULD
read and write stream data out of order subject to flow control
limits.  See section 2.2 in {{QUIC}}."
```
