### PR TITLE
Clarify allowed messages during SETUP

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -390,8 +390,6 @@ This draft only specifies a single use of bidirectional streams. Objects are
 sent on unidirectional streams.  Because there are no other uses of
 bidirectional streams, a peer MAY currently close the session as a
 'Protocol Violation' if it receives a second bidirectional stream.
-An endpoint MUST NOT open a unidirectional stream until after it has completed
-the exchange of SETUP messages is complete.
 
 The control stream MUST NOT be abruptly closed at the underlying transport
 layer.  Doing so results in the session being closed as a 'Protocol Violation'.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -377,19 +377,21 @@ separate SETUP parameters for that information in each version.
 
 ## Session initialization {#session-init}
 
-The first stream opened is a client-initiated bidirectional control stream
-where the peers exchange SETUP messages ({{message-setup}}).  All messages
-defined in this draft are sent on the control stream after the SETUP message.
-Control messages MUST NOT be sent on any other stream, and a peer receiving
-a control message on a different stream closes the session as a
-'Protocol Violation'. Objects MUST NOT be sent on the control stream, and a
-peer receiving an Object on the control stream closes the session as a
-'Protocol Violation'.
+The first stream opened is a client-initiated bidirectional control stream where
+the peers exchange SETUP messages ({{message-setup}}).  All messages defined in
+this draft except OBJECT and OBJECT_WITH_LENGTH are sent on the control stream
+after the SETUP message. Control messages MUST NOT be sent on any other stream,
+and a peer receiving a control message on a different stream closes the session
+as a 'Protocol Violation'. Objects MUST NOT be sent on the control stream, and a
+peer receiving an Object on the control stream closes the session as a 'Protocol
+Violation'.
 
 This draft only specifies a single use of bidirectional streams. Objects are
 sent on unidirectional streams.  Because there are no other uses of
 bidirectional streams, a peer MAY currently close the session as a
 'Protocol Violation' if it receives a second bidirectional stream.
+An endpoint MUST NOT open a unidirectional stream until after it has completed
+the exchange of SETUP messages is complete.
 
 The control stream MUST NOT be abruptly closed at the underlying transport
 layer.  Doing so results in the session being closed as a 'Protocol Violation'.


### PR DESCRIPTION
I think the intent of the draft was clear but this makes it explicit not to open a uni stream before setup exchange is done.

Fixes: #136