### PR TITLE
Object Model to Transport Mapping

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -593,7 +593,7 @@ terminates the track with a SUBSCRIBE_FIN
 (see {{message-subscribe-rst}}).
 
 A relay MUST not reorder or drop objects received on a multi-object stream when
-forwarding to subscribers.
+forwarding to subscribers, unless it has application specific information.
 
 Relays MAY aggregate authorized subscriptions for a given track when
 multiple subscribers request the same track. Subscription aggregation
@@ -932,7 +932,8 @@ TODO: figure out how a relay closes these streams
 
 When a stream begins with `STREAM_HEADER_TRACK`, all objects on the stream
 belong to the track requested in the Subscribe message identified by `Subscribe
-ID`.  All objects on the stream have the same `Object Send Order`.
+ID`.  All objects on the stream have the `Object Send Order` specified in the
+stream header.
 
 
 ~~~
@@ -964,7 +965,7 @@ stream that is associated with the subscription, or open a new one and send the
 When a stream begins with `STREAM_HEADER_GROUP`, all objects on the stream
 belong to the track requested in the Subscribe message identified by `Subscribe
 ID` and the group indicated by `Group ID`.  All objects on the stream
-have the same `Object Send Order`.
+have the `Object Send Order` specified in the stream header.
 
 ~~~
 STREAM_HEADER_GROUP Message {

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -897,38 +897,44 @@ NOT be processed by a relay.
 
 The publisher specifies its preference for mapping the elements of the
 object model - Tracks, Groups and Objects, to the underlying transport
-mechanisms such as QUIC Streams and QUIC Datagrams. A publisher chooses it preference driven by the application needs.
+mechanisms such as QUIC Streams and QUIC Datagrams. A publisher chooses it
+preference driven by the application needs.
 
 #### Proposal 1 - Stream Placement Indicator (Victor's Proposal and Text)
 
-`Stream Placement Indicator` specifies as variable length integer indicating
-the publisher's intention when choosing the QUIC stream to transport a given
-object. The details of the same is provided below:
+`Stream Placement Indicator` specifies as variable length integer informing
+the stream to choose for sending a given object.
+
+Each publisher follows the procedure defined below :
 
 Let `N` be the object sequence of the current object and `D` be the
-stream placement indicator, and `S`` be a stack of stream that is initially
+stream placement indicator, and `S` be a stack of streams that is initially
 empty.
 
-For every object to be transported:
+For each object to be sent:
 
-1. If `D` is zero, open a new stream, push it at the top of the stack.
+1. If `D` is zero, open a new stream and push it at the top of the stack.
 Send the object on the stream at the top of the stack.
 
 2. If `D` is non-zero, check if the object sequence of the most recent object
-that sent on the stream at the top of the stack has a value of  `N - D`.
+that was sent on the stream at the top of the stack has a value of  `N - D`.
 
-  2.1 If it is,  continue sending the object on the stream at the top of the
-      stack.
+  -  If it is, continue sending the current object on the stream at the top
+     of the stack.
 
-  2.2 If it is not, close the stream at the top of the stack, pop the stream
-     off the stack and repeat the Step 2. If the stack is empty, close
+
+  - If it is not, close the stream at the top of the stack, pop the stream
+     off the stack and repeat from the Step 2. If the stack is empty, close
      the connection with appropriate error code.
 
+TODO: More details are needed to determine when the stream can be closed.
+      Refer to disucssions on issue 318 on explicit markers for signaling
+      stream completion.
 
 #### Proposal 2 - Object Placement Mode
 
 `Object Placement Mode` is a enumeration of possible mappings of the object
-model to the underlying transport mechanism for delivering media.
+model to the underlying transport mechanisms.
 
 
 ##### Mode: StreamPerGroup
@@ -944,7 +950,7 @@ over a single QUIC stream. `StreamPerObject` has a value of 0x1.
 ##### Mode: StreamPerTrack
 
 The mode `StreamPerTrack` specifies that all the groups and objects for a
-given track is sent over a single QUIC stream. `StreamPerTrack` has a
+given track are sent over a single QUIC stream. `StreamPerTrack` has a
 value of 0x2.
 
 ##### Mode: StreamPerPriority
@@ -957,6 +963,10 @@ value of 0x3.
 
 The mode `Datagram` specifies that objects are sent using QUIC datagrams and
 has a value of 0x4.
+
+Note: Certain considerations apply when using Datagram. See the
+section on datagram that follows from discussions in the PR316.s
+under the PR 316
 
 ## SUBSCRIBE {#message-subscribe-req}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -865,7 +865,7 @@ OBJECT Message {
   Object Delivery Preference (i),
   Object Send Order (i),
   [Object Payload Length (i)],
-  Object Payload (b),
+  Object Payload (...),
 }
 ~~~
 {: #moq-transport-object-format title="MOQT OBJECT Message"}
@@ -968,6 +968,240 @@ under the PR 316
 TODO: More details are needed to determine when a stream can be closed.
       Refer to disucssions on issue 318 on explicit markers for signaling
       stream completion.
+
+## OBJECT (Proposal 3)
+
+### Canonical Object Fields
+
+A canonical MoQ Object has the following information:
+
+* Track Alias: The track alias obtained as part of subscription and/or
+publish control message exchanges.
+
+* Group Sequence : The object is a member of the indicated group
+{{model-group}} within the track.
+
+* Object Sequence: The order of the object within the group.  The
+sequence starts at 0, increasing sequentially for each object within the
+group.
+
+* Object Send Order: An integer indicating the object send order
+{{send-order}} or priority {{ordering-by-priorities}} value.
+
+* Object Forwarding Preference: An integer indicating how a sender MUST send an
+object. The preferences are Track, Group, Object, Priority and Datagram.  An
+Object MUST be sent according to its `Object Forwarding Preference`, each
+section describes how to do so.
+
+** Implementers Note: the Object Forwarding Preference is never sent directly
+on the wire, but can be represented by storing the frame type.  Since there's no
+frame type for datagram, recommend we reserve a frame type for this purpose.
+
+* Object Payload: An opaque payload intended for the consumer and SHOULD
+NOT be processed by a relay.
+
+### Object Message Formats
+
+There are five ways to represent an Object on the wire: `OBJECT_STREAM`,
+`OBJECT_DATAGRAM`, `SHORT_OBJECT_TRACK`, `SHORT_OBJECT_GROUP` and
+`SHORT_OBJECT_PRIORITY`.
+
+An `OBJECT_STREAM` message carries a single object on a stream.  There is no
+explicit length of the payload; it is terminated by the end of the stream.  An
+`OBJECT_STREAM` message MUST be the first message on a unidirectional stream.
+
+An Object received in an `OBJECT_STREAM` message has an `Object Forwarding
+Preference` = `Object`.
+
+To send an Object with `Object Forwarding Preference` = `Object`, open transport
+stream, serialize object fields below, and terminate the stream.
+
+~~~
+OBJECT_STREAM Message {
+  Track Alias (i),
+  Group Sequence (i),
+  Object Sequence (i),
+  Object Send Order (i),
+  Object Payload (...),
+}
+~~~
+{: #moq-transport-object-stream-format title="MOQT OBJECT_STREAM Message"}
+
+An `OBJECT_DATAGRAM` message carries a single object in a transport
+datagram. There is no serialized message type, all datagrams in MoQT contain
+OBJECT_DATAGRAM messages.  There is no explicit length of the payload; it is
+terminated by the end of the datagram.
+
+An Object received in an `OBJECT_DATAGRAM` message has an `Object Forwarding
+Preference` = `Datagram`.
+
+To send an Object with `Object Forwarding Preference` = `Datagram`, send a
+datagram with the serialized object fields below.
+
+~~~
+OBJECT_DATAGRAM {
+  Track Alias (i),
+  Group Sequence (i),
+  Object Sequence (i),
+  Object Send Order (i),
+  Object Payload (...),
+}
+~~~
+{: #moq-transport-object-datagram-format title="MOQT OBJECT_DATAGRAM"}
+
+### Multi-Object Streams
+
+When multiple objects are sent on a stream, the stream begins with a stream
+header message and is followed by the corresponding type of `SHORT_OBJECT_*`
+messages.  The stream header messages are `STREAM_HEADER_TRACK`,
+`STREAM_HEADER_GROUP`, `STREAM_HEADER_PRIORITY`.  Note that `SHORT_OBJECT_*`
+messages have no type encoded on the wire.
+
+TODO: figure out how a relay closes these streams
+
+When a stream begins with `STREAM_HEADER_TRACK`, all objects on the stream
+belong to track indicated by `Track Alias`.
+
+~~~
+STREAM_HEADER_TRACK Message {
+  Track Alias (i)
+}
+~~~
+{: #moq-transport-stream-header-track-format title="MOQT STREAM_HEADER_TRACK Message"}
+
+An Object received in a `SHORT_OBJECT_TRACK` message has an `Object Forwarding
+Preference` = `Track`.
+
+To send an Object with `Object Forwarding Preference` = `Track`, find the open
+stream that is associated with the `Track Alias`, or open a new one and send the
+`STREAM_HEADER_TRACK` if needed, then serialize the `SHORT_OBJECT_TRACK` fields.
+
+~~~
+SHORT_OBJECT_TRACK {
+  Group Sequence (i),
+  Object Sequence (i),
+  Object Send Order (i),
+  Object Payload Length (i),
+  Object Payload (...),
+}
+~~~
+{: #moq-transport-short-object-track-format title="MOQT SHORT_OBJECT_TRACK"}
+
+When a stream begins with `STREAM_HEADER_GROUP`, all objects on the stream
+belong to the track indicated by the `Track Alias` and the group indicated by
+`Group Sequence`.
+
+~~~
+STREAM_HEADER_GROUP Message {
+  Track Alias (i),
+  Group Sequence (i)
+}
+~~~
+{: #moq-transport-stream-header-group-format title="MOQT STREAM_HEADER_GROUP Message"}
+
+An Object received in a `SHORT_OBJECT_GROUP` message has an `Object Forwarding
+Preference` = `Group`.
+
+To send an Object with `Object Forwarding Preference` = `Group`, find the open
+stream that is associated with the `Track Alias` and `Group Sequence`, or open a
+new one and send the `STREAM_HEADER_GROUP` if needed, then serialize the
+`SHORT_OBJECT_GROUP` fields.
+
+~~~
+SHORT_OBJECT_GROUP {
+  Object Sequence (i),
+  Object Send Order (i),
+  Object Payload Length (i),
+  Object Payload (...),
+}
+~~~
+{: #moq-transport-short-object-group-format title="MOQT SHORT_OBJECT_GROUP"}
+
+When a stream begins with `STREAM_HEADER_PRIORITY`, all objects on the stream
+belong have the same `Object Send Order`.
+
+~~~
+STREAM_HEADER_PRIORITY Message {
+  Object Send Order (i)
+}
+~~~
+{: #moq-transport-stream-header-priority-format title="MOQT STREAM_HEADER_PRIORITY Message"}
+
+An Object received in a `SHORT_OBJECT_PRIORITY` message has an `Object
+Forwarding Preference` = `Priority`.
+
+To send an Object with `Object Forwarding Preference` = `Priority`, find the
+open stream that is associated with the `Object Send Order`, or open a
+new one and send the `STREAM_HEADER_PRIORITY` if needed, then serialize the
+`SHORT_OBJECT_PRIORITY` fields.
+
+~~~
+SHORT_OBJECT_PRIORITY {
+  Track Alias (i),
+  Group Sequence (i),
+  Object Sequence (i),
+  Object Payload Length (i),
+  Object Payload (...),
+}
+~~~
+{: #moq-transport-short-object-priority-format title="MOQT SHORT_OBJECT_PRIORITY"}
+
+### Examples:
+
+Sending a track on one stream:
+
+~~~
+STREAM_HEADER_TRACK {
+  Track Alias = 1
+}
+SHORT_OBJECT_TRACK {
+  Group Sequence = 0
+  Object Sequence = 0
+  Object Send Order = 0
+  Object Payload Length = 4
+  Payload = "abcd"
+}
+SHORT_OBJECT_TRACK {
+  Group Sequence = 1
+  Object Sequence = 0
+  Object Send Order = 1
+  Object Payload Length = 4
+  Payload = "efgh"
+}
+~~~
+
+Sending a group on one stream, with a unordered object in the group appearing
+on its own stream.
+
+~~~
+Stream = 2
+
+STREAM_HEADER_GROUP {
+  Track Alias = 2
+  Group Sequence = 0
+}
+SHORT_OBJECT_GROUP {
+  Object Sequence = 0
+  Object Send Order = 0
+  Object Payload Length = 4
+  Payload = "abcd"
+}
+SHORT_OBJECT_GROUP {
+  Object Sequence = 1
+  Object Send Order = 2
+  Object Payload Length = 4
+  Payload = "efgh"
+}
+
+Stream = 6
+
+OBJECT_STREAM {
+  Track Alias = 2
+  Group Sequence = 0
+  Object Sequence = 1
+  Payload = "moqrocks"
+}
+~~~
 
 ## SUBSCRIBE {#message-subscribe-req}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -652,7 +652,8 @@ congestion response.
 ## Relay Object Handling
 
 MOQT encodes the delivery information for a stream via OBJECT headers
-({{message-object}}).
+({{message-object}}).  A relay MUST NOT modify Object properties when
+forwarding.
 
 A relay MUST treat the object payload as opaque.  A relay MUST NOT
 combine, split, or otherwise modify object payloads.  A relay SHOULD
@@ -975,6 +976,10 @@ stream that is associated with the subscription, or open a new one and send the
 ~~~
 {: #object-track-format title="MOQT Track Stream Object Fields"}
 
+A sender MUST NOT send an Object on a stream if its Group ID is less than a
+previously sent Group ID on that stream, or if its Object ID is less than or
+equal to a previously sent Object ID within a given group on that stream.
+
 When a stream begins with `STREAM_HEADER_GROUP`, all objects on the stream
 belong to the track requested in the Subscribe message identified by `Subscribe
 ID` and the group indicated by `Group ID`.  All objects on the stream
@@ -1006,6 +1011,9 @@ then serialize the following fields.
 }
 ~~~
 {: #object-group-format title="MOQT Group Stream Object Fields"}
+
+A sender MUST NOT send an Object on a stream if its Object ID is less than a
+previously sent Object ID within a given group in that stream.
 
 ### Examples:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -674,11 +674,9 @@ MOQT Message {
 |-------|----------------------------------------------------|
 | ID    | Messages                                           |
 |------:|:---------------------------------------------------|
-| 0x0   | OBJECT with payload length ({{message-object}})    |
+| 0x0   | OBJECT_STREAM ({{object-message-formats}})         |
 |-------|----------------------------------------------------|
-| 0x2   | OBJECT without payload length ({{message-object}}) |
-|-------|----------------------------------------------------|
-| 0x3   | SUBSCRIBE ({{message-subscribe-req}})      |
+| 0x3   | SUBSCRIBE ({{message-subscribe-req}})              |
 |-------|----------------------------------------------------|
 | 0x4   | SUBSCRIBE_OK ({{message-subscribe-ok}})            |
 |-------|----------------------------------------------------|
@@ -703,6 +701,10 @@ MOQT Message {
 | 0x40  | CLIENT_SETUP ({{message-setup}})                   |
 |-------|----------------------------------------------------|
 | 0x41  | SERVER_SETUP ({{message-setup}})                   |
+|-------|----------------------------------------------------|
+| 0x50  | STREAM_HEADER_TRACK ({{multi-object-streams}})     |
+|-------|----------------------------------------------------|
+| 0x51  | STREAM_HEADER_GROUP ({{multi-object-streams}})     |
 |-------|----------------------------------------------------|
 
 ## Parameters {#params}
@@ -910,8 +912,8 @@ OBJECT_STREAM Message {
 {{message-subscribe-req}}.
 
 The Track Namespace and Track Name identified by the Track Alias is different
-from the one identified by Subscribe ID, the receiver MUST close the session
-with a Protocol Violation.
+from the one specified in the subscription identified by Subscribe ID, the
+receiver MUST close the session with a Protocol Violation.
 
 * Other fields: As described in {{canonical-object-fields}}.
 
@@ -936,6 +938,7 @@ ID`.  All objects on the stream have the same `Object Send Order`.
 ~~~
 STREAM_HEADER_TRACK Message {
   Subscribe ID (i)
+  Track Alias (i),
   Object Send Order (i),
 }
 ~~~
@@ -966,6 +969,7 @@ have the same `Object Send Order`.
 ~~~
 STREAM_HEADER_GROUP Message {
   Subscribe ID (i),
+  Track Alias (i),
   Group ID (i)
   Object Send Order (i)
 }
@@ -1006,8 +1010,8 @@ STREAM_HEADER_TRACK {
   Payload = "abcd"
 }
 {
-  Group Sequence = 1
-  Object Sequence = 0
+  Group ID = 1
+  Object ID = 0
   Object Payload Length = 4
   Payload = "efgh"
 }
@@ -1022,16 +1026,16 @@ Stream = 2
 STREAM_HEADER_GROUP {
   Subscribe ID = 2
   Track Alias = 2
-  Group Sequence = 0
+  Group ID = 0
   Object Send Order = 0
 }
 {
-  Object Sequence = 0
+  Object ID = 0
   Object Payload Length = 4
   Payload = "abcd"
 }
 {
-  Object Sequence = 1
+  Object ID = 1
   Object Payload Length = 4
   Payload = "efgh"
 }
@@ -1041,8 +1045,8 @@ Stream = 6
 OBJECT_STREAM {
   Subscribe ID = 2
   Track Alias = 2
-  Group Sequence = 0
-  Object Sequence = 1
+  Group ID = 0
+  Object ID = 1
   Payload = "moqrocks"
 }
 ~~~

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -925,7 +925,7 @@ OBJECT_STREAM Message {
 * Track Alias: Identifies the Track Namespace and Track Name as defined in
 {{message-subscribe-req}}.
 
-The Track Namespace and Track Name identified by the Track Alias is different
+If the Track Namespace and Track Name identified by the Track Alias is different
 from the one specified in the subscription identified by Subscribe ID, the
 receiver MUST close the session with a Protocol Violation.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -925,9 +925,9 @@ OBJECT_STREAM Message {
 * Track Alias: Identifies the Track Namespace and Track Name as defined in
 {{message-subscribe-req}}.
 
-If the Track Namespace and Track Name identified by the Track Alias is different
-from the one specified in the subscription identified by Subscribe ID, the
-receiver MUST close the session with a Protocol Violation.
+If the Track Namespace and Track Name identified by the Track Alias are
+different from those specified in the subscription identified by Subscribe ID,
+the receiver MUST close the session with a Protocol Violation.
 
 * Other fields: As described in {{canonical-object-fields}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -927,9 +927,6 @@ that was sent on the stream at the top of the stack has a value of  `N - D`.
      off the stack and repeat from the Step 2. If the stack is empty, close
      the connection with appropriate error code.
 
-TODO: More details are needed to determine when the stream can be closed.
-      Refer to disucssions on issue 318 on explicit markers for signaling
-      stream completion.
 
 #### Proposal 2 - Object Placement Mode
 
@@ -967,6 +964,10 @@ has a value of 0x4.
 Note: Certain considerations apply when using Datagram. See the
 section on datagram that follows from discussions in the PR316.s
 under the PR 316
+
+TODO: More details are needed to determine when a stream can be closed.
+      Refer to disucssions on issue 318 on explicit markers for signaling
+      stream completion.
 
 ## SUBSCRIBE {#message-subscribe-req}
 


### PR DESCRIPTION
This PR brings in currently active proposals for supporting explicit indicators of mapping object model to quic transport.

Fixes #244 


