### PR TITLE
One forwarding preference per track

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1255,7 +1255,10 @@ exactly one stream.
 WebTransport datagram, if possible. If not possible, it is delivered on exactly
 one stream.
 
-Any other value terminates the session with error PROTOCOL_VIOLATION.
+Any other value terminates the session with error PROTOCOL_VIOLATION. Senders
+MUST NOT send SUBSCRIBE_OKs with different forwarding preferences for the same
+track. Receivers SHOULD terminate the session with error PROTOCOL_VIOLATION if
+they can detect this condition.
 
 * Expires: Time in milliseconds after which the subscription is no
 longer valid. A value of 0 indicates that the subscription stays active

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -886,19 +886,19 @@ group.
 * Object Payload: An opaque payload intended for the consumer and SHOULD
 NOT be processed by a relay.
 
-### Object Message Formats
+### Object Header Formats
 
 Objects are delivered in unidirectional streams. Each object is preceded by a
 header that contains metadata about the object. The format of this header
-depednds on the forwarding preference for the track, as communicated by the
-SUBSCRIBE_OK message {{message-subscribe-ok}}.
+depends on the forwarding preference for the track, as communicated by the
+SUBSCRIBE_OK message ({{message-subscribe-ok}}).
 
 The first bytes of every unidirectional stream encode the subscribe ID, which
-refers to a SUBSCRIBE_OK that contains parsing instructions. Note that if
-a streams arrives for a subscribe_id for which a SUBSCRIBE_OK has not arrived,
-the receiver ought to buffer objects for that stream until it receives the
-SUBSCRIBE_OK. Due to resource constraints, the receiver could opt to send
-STOP_SENDING for the stream instead.
+refers to a SUBSCRIBE_OK that contains parsing instructions. If a stream arrives
+for a subscribe_id for which a SUBSCRIBE_OK has not arrived, the receiver SHOULD
+buffer objects for that stream until it receives the SUBSCRIBE_OK. Due to
+resource constraints, the receiver could opt to send STOP_SENDING for the stream
+instead.
 
 **Object or Prefer Datagram Forwarding Preference**
 
@@ -966,8 +966,8 @@ their corresponding object payloads.
 If a stream ends gracefully in the middle of a serialized Object, terminate the
 session with a Protocol Violation.
 
-A sender MUST NOT open more than stream for a given group and the same
-subscription.
+A sender MUST NOT open more than one stream for a given tuple of subscribe_id,
+track_alias, and group_id.
 
 TODO: figure out how a relay closes these streams
 
@@ -1000,8 +1000,8 @@ This is followed one or more object headers and their corresponding object paylo
 If a stream ends gracefully in the middle of a serialized Object, terminate the
 session with a Protocol Violation.
 
-A sender MUST NOT open more than stream for a given track and the same
-subscription.
+A sender MUST NOT open more than one stream for a given tuple of subscribe_id
+and track_alias.
 
 ### Examples:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -900,7 +900,7 @@ buffer objects for that stream until it receives the SUBSCRIBE_OK. Due to
 resource constraints, the receiver could opt to send STOP_SENDING for the stream
 instead.
 
-**Object or Prefer Datagram Forwarding Preference**
+**Object or Datagram Forwarding Preference**
 
 The format of an Object header delivered for the Object or Datagram forwarding
 preference is identical, although the latter is usually delivered via a QUIC or


### PR DESCRIPTION
Fixes #351.

There could stand to be (1) a section on a subscriptions, and (2) rearranging the sections here to pull objects out of the message section. But I think it would be easier to review if cut-and-paste happens in a separate PR.

There are other issues (e.g. explicit payload length all the time) that are not addressed in this PR.