### PR TITLE
Remove 'Generic Error'

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -405,8 +405,6 @@ code, as defined below:
 |-----:|:--------------------------|
 | 0x0  | No Error                  |
 |------|---------------------------|
-| 0x1  | Generic Error             |
-|------|---------------------------|
 | 0x2  | Unauthorized              |
 |------|---------------------------|
 | 0x3  | Protocol Violation        |
@@ -419,8 +417,6 @@ code, as defined below:
 |------|---------------------------|
 
 * No Error: The session is being terminated without an error.
-
-* Generic Error: An unclassified error occurred.
 
 * Unauthorized: The endpoint breached an agreement, which MAY have been
  pre-negotiated by the application.
@@ -607,8 +603,6 @@ as defined below:
 |------|---------------------------|
 | Code | Reason                    |
 |-----:|:--------------------------|
-| 0x0  | Generic Error             |
-|------|---------------------------|
 | 0x1  | Invalid Range             |
 |------|---------------------------|
 | 0x2  | Retry Track Alias         |


### PR DESCRIPTION
'Generic Error' is never used in the draft and given "Protocol Violation" is also available, I don't think it's useful.

I didn't renumber the error codes, but I could.