### PR TITLE
Add ANNOUNCE_CANCEL

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -670,10 +670,10 @@ Relays MUST ensure that publishers are authorized by:
 Relays respond with an ANNOUNCE_OK or ANNOUNCE_ERROR control message
 providing the result of announcement. The entity receiving the
 ANNOUNCE MUST send only a single response to a given ANNOUNCE of
-either ANNOUNCE_OK or ANNOUNCE_ERROR.  When a publisher wants to stop new
-subscriptions for an announced namespace it uses UNANNOUNCE. When a
-subscriber wants to indicate it will no longer route subscriptions for a
-namespace it previously responded ANNOUNCE_OK to, it sends an
+either ANNOUNCE_OK or ANNOUNCE_ERROR.  When a publisher wants to stop
+new subscriptions for an announced namespace it sends an UNANNOUNCE.
+A subscriber indicates it will no longer route subscriptions for a
+namespace it previously responded ANNOUNCE_OK to by sending an
 ANNOUNCE_CANCEL.
 
 OBJECT message headers carry a short hop-by-hop `Track Alias` that maps to

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -673,7 +673,7 @@ ANNOUNCE MUST send only a single response to a given ANNOUNCE of
 either ANNOUNCE_OK or ANNOUNCE_ERROR.  When a publisher wants to stop new
 subscriptions for an announced namespace it uses UNANNOUNCE. When a
 subscriber wants to indicate it will no longer route subscriptions for a
-namespace it previously responded ANNOUNCE_OK to, it send an
+namespace it previously responded ANNOUNCE_OK to, it sends an
 ANNOUNCE_CANCEL.
 
 OBJECT message headers carry a short hop-by-hop `Track Alias` that maps to

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -670,7 +670,11 @@ Relays MUST ensure that publishers are authorized by:
 Relays respond with an ANNOUNCE_OK or ANNOUNCE_ERROR control message
 providing the result of announcement. The entity receiving the
 ANNOUNCE MUST send only a single response to a given ANNOUNCE of
-either ANNOUNCE_OK or ANNOUNCE_ERROR.
+either ANNOUNCE_OK or ANNOUNCE_ERROR.  When a publisher wants to stop new
+subscriptions for an announced namespace it uses UNANNOUNCE. When a
+subscriber wants to indicate it will no longer route subscriptions for a
+namespace it previously responded ANNOUNCE_OK to, it send an
+ANNOUNCE_CANCEL.
 
 OBJECT message headers carry a short hop-by-hop `Track Alias` that maps to
 the Full Track Name (see {{message-subscribe-ok}}). Relays use the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1529,6 +1529,10 @@ The subscriber sends an `ANNOUNCE_CANCEL` control message to
 indicate it will stop sending new subscriptions for tracks
 within the provided Track Namespace.
 
+If a publisher recieves new subscriptions for that namespace after
+receiving an ANNOUNCE_CANCEL, it SHOULD close the session as a
+'Protocol Violation'.
+
 ~~~
 ANNOUNCE_CANCEL Message {
   Track Namespace (b),

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1519,6 +1519,21 @@ UNANNOUNCE Message {
 * Track Namespace: Identifies a track's namespace as defined in
 ({{track-name}}).
 
+## ANNOUNCE_CANCEL {#message-announce-cancel}
+
+The subscriber sends an `ANNOUNCE_CANCEL` control message to
+indicate it will stop sending new subscriptions for tracks
+within the provided Track Namespace.
+
+~~~
+ANNOUNCE_CANCEL Message {
+  Track Namespace (b),
+}
+~~~
+{: #moq-transport-announce-cancel-format title="MOQT ANNOUNCE_CANCEL Message"}
+
+* Track Namespace: Identifies a track's namespace as defined in
+({{track-name}}).
 
 ## GOAWAY {#message-goaway}
 The server sends a `GOAWAY` message to initiate session migration


### PR DESCRIPTION
To allow subscribers to indicate that no new subscriptions will be routed to the publisher for a given namespace.

Happy to bikeshed on the name and whether we really need another frame for this.

Fixes #319