### PR TITLE
Clarify what ROLE means

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -879,7 +879,7 @@ which are of type varint:
 
 0x01:
 
-: The endpoint process subscriptions and can send objects, but not subscribe.
+: The endpoint can process subscriptions and send objects, but not subscribe.
   The endpoint MUST NOT send a SUBSCRIBE message and an ANNOUNCE MUST NOT be
   sent to it.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -885,7 +885,7 @@ which are of type varint:
 
 0x02:
 
-: The endpoing can send subscriptions and receive objects, but not publish.
+: The endpoint can send subscriptions and receive objects, but not publish.
   The endpoint MUST NOT send an ANNOUNCE message and a SUBSCRIBE MUST NOT be
   sent to it.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -881,19 +881,19 @@ The ROLE parameter (key 0x00) allows each endpoint to independently specify what
 funnctionality they support for the session. It has three possible values,
 which are of type varint:
 
-0x01:
+0x01: Publisher
 
 : The endpoint can process subscriptions and send objects, but not subscribe.
   The endpoint MUST NOT send a SUBSCRIBE message and an ANNOUNCE MUST NOT be
   sent to it.
 
-0x02:
+0x02: Subscriber
 
 : The endpoint can send subscriptions and receive objects, but not publish.
   The endpoint MUST NOT send an ANNOUNCE message and a SUBSCRIBE MUST NOT be
   sent to it.
 
-0x03:
+0x03: PubSub
 
 : The endpoint can act as a publisher or subscriber, and can send or process
   any message type.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -873,28 +873,30 @@ identified as 0xff00000D.
 
 #### ROLE parameter {#role}
 
-The ROLE parameter (key 0x00) allows the client to specify what roles it
-expects the parties to have in the MOQT connection. It has three
-possible values, which are of type varint:
+The ROLE parameter (key 0x00) allows each endpoint to independently specify what
+funnctionality they support for the session. It has three possible values,
+which are of type varint:
 
 0x01:
 
-: Only the client is expected to send objects on the connection. This is
-  commonly referred to as the ingestion case.
+: The endpoint process subscriptions and can send objects, but not subscribe.
+  The endpoint MUST NOT send a SUBSCRIBE message and an ANNOUNCE MUST NOT be
+  sent to it.
 
 0x02:
 
-: Only the server is expected to send objects on the connection. This is
-  commonly referred to as the delivery case.
+: The endpoing can send subscriptions and receive objects, but not publish.
+  The endpoint MUST NOT send an ANNOUNCE message and a SUBSCRIBE MUST NOT be
+  sent to it.
 
 0x03:
 
-: Both the client and the server are expected to send objects.
+: The endpoint can act as a publisher or subscriber, and can send or process
+  any message type.
 
-The client MUST send a ROLE parameter with one of the three values
-specified above. The server MUST close the session if the ROLE
-parameter is missing, is not one of the three above-specified values, or
-it is different from what the server expects based on the application.
+Both endpoints MUST send a ROLE parameter with one of the three values
+specified above. Both endpoints MUST close the session if the ROLE
+parameter is missing, is not one of the three above-specified values.
 
 #### PATH parameter {#path}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -896,7 +896,7 @@ which are of type varint:
 
 Both endpoints MUST send a ROLE parameter with one of the three values
 specified above. Both endpoints MUST close the session if the ROLE
-parameter is missing, is not one of the three above-specified values.
+parameter is missing or is not one of the three above-specified values.
 
 #### PATH parameter {#path}
 


### PR DESCRIPTION
Add some normative text and requires both client and server to send their role.

I can also see the argument for removing this entirely, but it's in the current draft, so if we're going to keep it, I'd like to define it better.

Fixes #151, Fixes #250