### PR TITLE
Merge SUBSCRIBE_RESET and SUBSCRIBE_FIN 

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -629,8 +629,8 @@ subscribers for each track. Each new OBJECT belonging to the
 track within the subscription range is forwarded to each active
 subscriber, dependent on the congestion response. A subscription
 remains active until it expires, until the publisher of the track
-terminates the track with a SUBSCRIBE_CLOSED
-(see {{message-subscribe-closed}}).
+terminates the track with a SUBSCRIBE_DONE
+(see {{message-subscribe-done}}).
 
 Objects MUST NOT be sent for unsuccessful subscriptions, and if a subscriber
 receives a SUBSCRIBE_ERROR after receiving objects, it MUST close the session
@@ -659,7 +659,7 @@ as defined below:
 |------|---------------------------|
 
 The applicaiton SHOULD use a relevant status code in
-SUBSCRIBE_CLOSE, as defined below:
+SUBSCRIBE_DONE, as defined below:
 
 |------|---------------------------|
 | Code | Reason                    |
@@ -781,7 +781,7 @@ MOQT Message {
 |-------|-----------------------------------------------------|
 | 0xA   | UNSUBSCRIBE ({{message-unsubscribe}})               |
 |-------|-----------------------------------------------------|
-| 0xB   | SUBSCRIBE_CLOSED ({{message-subscribe-closed}})     |
+| 0xB   | SUBSCRIBE_DONE ({{message-subscribe-done}})         |
 |-------|-----------------------------------------------------|
 | 0x10  | GOAWAY ({{message-goaway}})                         |
 |-------|-----------------------------------------------------|
@@ -1408,7 +1408,7 @@ SUBSCRIBE_ERROR
 A subscriber issues a `UNSUBSCRIBE` message to a publisher indicating it is no
 longer interested in receiving media for the specified track and Objects
 should stop being sent as soon as possible.  The publisher sends a
-SUBSCRIBE_CLOSED to acknowledge the unsubscribe was successful and indicate
+SUBSCRIBE_DONE to acknowledge the unsubscribe was successful and indicate
 the final Object.
 
 The format of `UNSUBSCRIBE` is as follows:
@@ -1422,16 +1422,16 @@ UNSUBSCRIBE Message {
 
 * Subscribe ID: Subscription Identifer as defined in {{message-subscribe-req}}.
 
-## SUBSCRIBE_CLOSED {#message-subscribe-closed}
+## SUBSCRIBE_DONE {#message-subscribe-done}
 
-A publisher issues a `SUBSCRIBE_CLOSED` message to indicate it
+A publisher issues a `SUBSCRIBE_DONE` message to indicate it
 is done publishing Objects for that subscription.  The Status Code indicates why
 the subscription ended, and whether it was an error.
 
-The format of `SUBSCRIBE_CLOSED` is as follows:
+The format of `SUBSCRIBE_DONE` is as follows:
 
 ~~~
-SUBSCRIBE_CLOSED Message {
+SUBSCRIBE_DONE Message {
   Subscribe ID (i),
   Status Code (i),
   Reason Phrase (b),
@@ -1440,7 +1440,7 @@ SUBSCRIBE_CLOSED Message {
   [Final Object (i)],
 }
 ~~~
-{: #moq-transport-subscribe-fin-format title="MOQT SUBSCRIBE_CLOSED Message"}
+{: #moq-transport-subscribe-fin-format title="MOQT SUBSCRIBE_DONE Message"}
 
 * Subscribe ID: Subscription identifier as defined in {{message-subscribe-req}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1436,7 +1436,6 @@ message in this track.
 * Final Object: The largest Object ID sent by the publisher in an OBJECT
 message in the `Final Group` for this track.
 
-
 ## ANNOUNCE {#message-announce}
 
 The publisher sends the ANNOUNCE control message to advertise where the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1384,19 +1384,19 @@ SUBSCRIBE_ERROR
   the receiver MUST close the connection with a Duplicate Track Alias error
   ({{session-termination}}).
 
-## UNSUBSCRIBE {#message-unsubscribe}
+## SUBSCRIBE_CANCEL {#message-subscribe-cancel}
 
-A subscriber issues a `UNSUBSCRIBE` message to a publisher indicating it is no
+A subscriber issues a `SUBSCRIBE_CANCEL` message to a publisher indicating it is no
 longer interested in receiving media for the specified track.
 
-The format of `UNSUBSCRIBE` is as follows:
+The format of `SUBSCRIBE_CANCEL` is as follows:
 
 ~~~
-UNSUBSCRIBE Message {
+SUBSCRIBE_CANCEL Message {
   Subscribe ID (i)
 }
 ~~~
-{: #moq-transport-unsubscribe-format title="MOQT UNSUBSCRIBE Message"}
+{: #moq-transport-subscribe-cancel-format title="MOQT SUBSCRIBE_CANCEL Message"}
 
 * Subscribe ID: Subscription Identifer as defined in {{message-subscribe-req}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -490,10 +490,10 @@ SHOULD terminate the session with 'GOAWAY Timeout' after a sufficient timeout if
 there are still open subscriptions on a connection.
 
 The GOAWAY message does not immediately impact subscription state. A subscriber
-SHOULD individually unsubscribe for each existing subscription using
-SUBSCRIBE_CANCEL.  A publisher MAY reject new SUBSCRIBEs while in the draining
-state. When the server is a subscriber, it SHOULD send a GOAWAY message prior to
-any SUBSCRIBE_CANCEL messages.
+SHOULD individually UNSUBSCRIBE for each existing subscription, while a
+publisher MAY reject new SUBSCRIBEs while in the draining state. When the server
+is a subscriber, it SHOULD send a GOAWAY message prior to any UNSUBSCRIBE
+messages.
 
 After the client receives a GOAWAY, it's RECOMMENDED that the client waits until
 there are no more active subscriptions before closing the session with NO_ERROR.
@@ -758,9 +758,9 @@ MOQT Message {
 |-------|-----------------------------------------------------|
 | 0x8   | ANNOUNCE_ERROR ({{message-announce-error}})         |
 |-------|-----------------------------------------------------|
-| 0x9   | ANNOUNCE_CLOSED  ({{message-announce-closed}})      |
+| 0x9   | UNANNOUNCE  ({{message-unannounce}})                |
 |-------|-----------------------------------------------------|
-| 0xA   | SUBSCRIBE_CANCEL ({{message-subscribe-cancel}})     |
+| 0xA   | UNSUBSCRIBE ({{message-unsubscribe}})               |
 |-------|-----------------------------------------------------|
 | 0xB   | SUBSCRIBE_CLOSED ({{message-subscribe-closed}})     |
 |-------|-----------------------------------------------------|
@@ -1384,26 +1384,27 @@ SUBSCRIBE_ERROR
   the receiver MUST close the connection with a Duplicate Track Alias error
   ({{session-termination}}).
 
-## SUBSCRIBE_CANCEL {#message-subscribe-cancel}
+## UNSUBSCRIBE {#message-unsubscribe}
 
-A subscriber issues a `SUBSCRIBE_CANCEL` message to a publisher indicating it is no
-longer interested in receiving media for the specified track.
+A subscriber issues a `UNSUBSCRIBE` message to a publisher indicating it is no
+longer interested in receiving media for the specified track and Objects
+should stop being sent as soon as possible.
 
-The format of `SUBSCRIBE_CANCEL` is as follows:
+The format of `UNSUBSCRIBE` is as follows:
 
 ~~~
 SUBSCRIBE_CANCEL Message {
   Subscribe ID (i)
 }
 ~~~
-{: #moq-transport-subscribe-cancel-format title="MOQT SUBSCRIBE_CANCEL Message"}
+{: #moq-transport-subscribe-cancel-format title="MOQT UNSUBSCRIBE Message"}
 
 * Subscribe ID: Subscription Identifer as defined in {{message-subscribe-req}}.
 
 ## SUBSCRIBE_CLOSED {#message-subscribe-closed}
 
-A publisher issues a `SUBSCRIBE_CLOSED` message to all subscribers indicating it
-is done publishing objects for that subscription.  The Error Code indicates why
+A publisher issues a `SUBSCRIBE_CLOSED` message to indicate it
+is done publishing Objects for that subscription.  The Status Code indicates why
 the subscription ended, and whether it was an error.
 
 The format of `SUBSCRIBE_CLOSED` is as follows:
@@ -1411,7 +1412,7 @@ The format of `SUBSCRIBE_CLOSED` is as follows:
 ~~~
 SUBSCRIBE_CLOSED Message {
   Subscribe ID (i),
-  Error Code (i),
+  Status Code (i),
   Reason Phrase (b),
   ContentExists (1),
   [Final Group (i)],
@@ -1422,7 +1423,7 @@ SUBSCRIBE_CLOSED Message {
 
 * Subscribe ID: Subscription identifier as defined in {{message-subscribe-req}}.
 
-* Error Code: Identifies an integer error code for subscription end.
+* Status Code: An integer status code indicating why the subscription ended.
 
 * Reason Phrase: Provides the reason for subscription error.
 
@@ -1496,18 +1497,18 @@ message for which this response is provided.
 * Reason Phrase: Provides the reason for announcement error.
 
 
-## ANNOUNCE_CLOSED {#message-announce-closed}
+## UNANNOUNCE {#message-unannounce}
 
-The publisher sends the `ANNOUNCE_CLOSED` control message to indicate
+The publisher sends the `UNANNOUNCE` control message to indicate
 its intent to stop serving new subscriptions for tracks
 within the provided Track Namespace.
 
 ~~~
-ANNOUNCE_CLOSED Message {
+UNANNOUNCE Message {
   Track Namespace (b),
 }
 ~~~
-{: #moq-transport-announce-closed-format title="MOQT ANNOUNCE_CLOSED Message"}
+{: #moq-transport-unannounce-format title="MOQT UNANNOUNCE Message"}
 
 * Track Namespace: Identifies a track's namespace as defined in
 ({{track-name}}).

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -677,7 +677,7 @@ Relays respond with an ANNOUNCE_OK or ANNOUNCE_ERROR control message
 providing the result of announcement. The entity receiving the
 ANNOUNCE MUST send only a single response to a given ANNOUNCE of
 either ANNOUNCE_OK or ANNOUNCE_ERROR.  When a publisher wants to stop
-new subscriptions for an announced namespace it sends an ANNOUNCE_CLOSED.
+new subscriptions for an announced namespace it sends an UNANNOUNCE.
 A subscriber indicates it will no longer route subscriptions for a
 namespace it previously responded ANNOUNCE_OK to by sending an
 ANNOUNCE_CANCEL.
@@ -1393,7 +1393,7 @@ should stop being sent as soon as possible.
 The format of `UNSUBSCRIBE` is as follows:
 
 ~~~
-SUBSCRIBE_CANCEL Message {
+UNSUBSCRIBE Message {
   Subscribe ID (i)
 }
 ~~~

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1418,7 +1418,7 @@ UNSUBSCRIBE Message {
   Subscribe ID (i)
 }
 ~~~
-{: #moq-transport-subscribe-cancel-format title="MOQT UNSUBSCRIBE Message"}
+{: #moq-transport-unsubscribe-format title="MOQT UNSUBSCRIBE Message"}
 
 * Subscribe ID: Subscription Identifer as defined in {{message-subscribe-req}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -658,6 +658,25 @@ as defined below:
 | 0x2  | Retry Track Alias         |
 |------|---------------------------|
 
+The applicaiton SHOULD use a relevant status code in
+SUBSCRIBE_CLOSE, as defined below:
+
+|------|---------------------------|
+| Code | Reason                    |
+|-----:|:--------------------------|
+| 0x0  | Unsubscribed              |
+|------|---------------------------|
+| 0x1  | Internal Error            |
+|------|---------------------------|
+| 0x2  | Unauthorized              |
+|------|---------------------------|
+| 0x3  | Track Ended               |
+|------|---------------------------|
+| 0x4  | Subscription Ended        |
+|------|---------------------------|
+| 0x5  | Going Away                |
+|------|---------------------------|
+
 
 ## Publisher Interactions
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1388,7 +1388,9 @@ SUBSCRIBE_ERROR
 
 A subscriber issues a `UNSUBSCRIBE` message to a publisher indicating it is no
 longer interested in receiving media for the specified track and Objects
-should stop being sent as soon as possible.
+should stop being sent as soon as possible.  The publisher sends a
+SUBSCRIBE_CLOSED to acknowledge the unsubscribe was successful and indicate
+the final Object.
 
 The format of `UNSUBSCRIBE` is as follows:
 


### PR DESCRIPTION
Into SUBSCRIBE_DONE.

I didn't remove the SUBSCRIBE_ERROR message in favor of SUBSCRIBE_CLOSED as @kixelated suggested in this PR.

Fixes #398 
Fixes #356
Addresses some comments in #310, but possibly not all