### PR TITLE
Split SUBSCRIBE into SUBSCRIBE and FETCH

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1114,7 +1114,7 @@ ID` and the group indicated by `Group ID`.  All objects on the stream
 have the `Object Send Order` specified in the stream header.
 
 ~~~
-STREAM_HEADER_GROUP Message {
+STREAM_SUBSCRIBE_GROUP/STREAM_FETCH_GROUP Message {
   ID (i),
   Group ID (i)
   Object Send Order (i)

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1071,26 +1071,26 @@ TODO: figure out how a relay closes these streams
 
 **Stream Header Track**
 
-When a stream begins with `STREAM_HEADER_TRACK`, all objects on the stream
-belong to the track requested in the Subscribe message identified by `Subscribe
-ID`.  All objects on the stream have the `Object Send Order` specified in the
-stream header.
+When a stream begins with `STREAM_SUBSCRIBE_TRACK` or 'STREAM_FETCH_TRACK', all
+objects on the stream belong to the track requested in the corresponding
+subscription or fetch as identified by the `Track Alias' or 'Fetch ID'.  All
+objects on the stream have the `Object Send Order` specified in the stream header.
 
 
 ~~~
-STREAM_HEADER_TRACK Message {
+STREAM_SUBSCRIBE_TRACK/STREAM_FETCH_TRACK Message {
   ID (i),
   Object Send Order (i),
 }
 ~~~
-{: #stream-header-track-format title="MOQT STREAM_HEADER_TRACK Message"}
+{: #stream-header-track-format title="MOQT STREAM_TRACK Message"}
 
-All Objects received on a stream opened with STREAM_HEADER_TRACK have an `Object
-Forwarding Preference` = `Track`.
+All Objects received on a stream opened with STREAM_SUBSCRIBE_TRACK or
+STREAM_FETCH_TRACK have an `Object Forwarding Preference` = `Track`.
 
 To send an Object with `Object Forwarding Preference` = `Track`, find the open
 stream that is associated with the subscription, or open a new one and send the
-`STREAM_HEADER_TRACK` if needed, then serialize the the following object fields.
+header, then serialize the the following object fields.
 
 ~~~
 {

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1007,7 +1007,7 @@ serialize object fields below, and terminate the stream.
 
 ~~~
 OBJECT_STREAM Message {
-  Track Alias (i),
+  ID (i),
   Group ID (i),
   Object ID (i),
   Object Send Order (i),
@@ -1016,10 +1016,7 @@ OBJECT_STREAM Message {
 ~~~
 {: #moq-transport-object-stream-format title="MOQT OBJECT_STREAM Message"}
 
-* Subscribe ID: Subscription Identifer as defined in {{message-subscribe-req}}.
-
-* Track Alias: Identifies the Track Namespace and Track Name as defined in
-{{message-subscribe-req}}.
+* ID: The Track Alias for subscriptions or the Fetch ID for Fetches.
 
 If the Track Namespace and Track Name identified by the Track Alias are
 different from those specified in the subscription identified by Subscribe ID,
@@ -1042,7 +1039,7 @@ will be dropped.
 
 ~~~
 OBJECT_DATAGRAM Message {
-  Track Alias (i),
+  ID (i),
   Group ID (i),
   Object ID (i),
   Object Send Order (i),
@@ -1074,7 +1071,7 @@ stream header.
 
 ~~~
 STREAM_HEADER_TRACK Message {
-  Track Alias (i),
+  ID (i),
   Object Send Order (i),
 }
 ~~~
@@ -1110,7 +1107,7 @@ have the `Object Send Order` specified in the stream header.
 
 ~~~
 STREAM_HEADER_GROUP Message {
-  Track Alias (i),
+  ID (i),
   Group ID (i)
   Object Send Order (i)
 }
@@ -1440,6 +1437,23 @@ EndObject's Mode MUST be None if EndGroup's Mode is None.
 
 * Track Request Parameters: The parameters are defined in
 {{version-specific-params}}
+
+## FETCH_CANCEL {#message-fetch-cancel}
+
+A subscriber issues a `FETCH_CANCEL` message to a publisher indicating it
+is no longer interested in receiving Objects for the specified track and
+Objects should stop being sent as soon as possible.
+
+The format of `FETCH_CANCEL` is as follows:
+
+~~~
+FETCH_CANCEL Message {
+  Fetch ID (i)
+}
+~~~
+{: #moq-transport-unsubscribe-format title="MOQT UNSUBSCRIBE Message"}
+
+* Fetch ID: Fetch Identifer as defined in {{message-fetch-req}}.
 
 
 ## ANNOUNCE {#message-announce}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -804,9 +804,17 @@ MOQT Message {
 |-------|-----------------------------------------------------|
 | 0x41  | SERVER_SETUP ({{message-setup}})                    |
 |-------|-----------------------------------------------------|
-| 0x50  | STREAM_HEADER_TRACK ({{multi-object-streams}})      |
+| 0x48  | OBJECT_FETCH_STREAM ({{object-message-formats}})    |
 |-------|-----------------------------------------------------|
-| 0x51  | STREAM_HEADER_GROUP ({{multi-object-streams}})      |
+| 0x49  | OBJECT_FETCH_DATAGRAM ({{object-message-formats}})  |
+|-------|-----------------------------------------------------|
+| 0x50  | STREAM_SUBSCRIBE_TRACK ({{multi-object-streams}})   |
+|-------|-----------------------------------------------------|
+| 0x51  | STREAM_SUBSCRIBE_GROUP ({{multi-object-streams}})   |
+|-------|-----------------------------------------------------|
+| 0x52  | STREAM_FETCH_TRACK ({{multi-object-streams}})       |
+|-------|-----------------------------------------------------|
+| 0x53  | STREAM_FETCH_GROUP ({{multi-object-streams}})       |
 |-------|-----------------------------------------------------|
 
 ## Parameters {#params}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1414,7 +1414,7 @@ FETCH Message {
   Track Request Parameters (..) ...
 }
 ~~~
-{: #moq-transport-subscribe-format title="MOQT FETCH Message"}
+{: #moq-transport-fetch-format title="MOQT FETCH Message"}
 
 * Fetch ID: Identifier of the Fetch that is unique within the session.
 `Fetch ID` is a monotonically increasing variable length integer which

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1295,7 +1295,7 @@ end prior to the expiry time or last longer.
 If 0, then the Largest Group ID and Largest Object ID fields will not be
 present.
 
-TODO: Should these be the first Group being delivered?  If the previous group
+TODO: Should these be the first Group being delivered?  If the last group
 isn't cached, but was requested, should that be indicated?
 ie: by making ContentExists an enum?
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1217,7 +1217,7 @@ begin at the first group.
 Current Group (0x1): Start at the first Object from the largest received
 group.
 
-Next Group (0x2): Start at the first Object from from the next group.
+Next Group (0x2): Start at the first Object from the next group.
 
 
 The format of SUBSCRIBE is as follows:


### PR DESCRIPTION
A PR corresponding to: https://datatracker.ietf.org/meeting/119/materials/slides-119-moq-subscribe-and-fetch

Fixes #269 
Fixes #296
Fixes #350 
Fixes #326
Fixes #377

Also relevant to #396, #326

Some open questions:
 - Do we want OBJECT_FETCH_DATAGRAM to be transmitted over datagrams only?