### PR TITLE
Add a way to get the current group ID

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1615,8 +1615,7 @@ value is a malformed message.
 contain the highest Group and object ID known.
 
 0x04: The sender is a relay that cannot obtain the current track status from
-upstream. Subsequent fields contain the largest group and object ID known to
-the sender.
+upstream. Subsequent fields contain the largest group and object ID known.
 
 Any other value in the Status Code field is a malformed message.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -794,6 +794,10 @@ MOQT Message {
 |-------|-----------------------------------------------------|
 | 0xC   | ANNOUNCE_CANCEL ({{message-announce-cancel}})       |
 |-------|-----------------------------------------------------|
+| 0xD   | GET_CURRENT_GROUP ({{message-get-current-group}})   |
+|-------|-----------------------------------------------------|
+| 0xE   | CURRENT_GROUP ({{message-current-group}})           |
+|-------|-----------------------------------------------------|
 | 0x10  | GOAWAY ({{message-goaway}})                         |
 |-------|-----------------------------------------------------|
 | 0x40  | CLIENT_SETUP ({{message-setup}})                    |
@@ -1564,6 +1568,38 @@ ANNOUNCE_CANCEL Message {
 
 * Track Namespace: Identifies a track's namespace as defined in
 ({{track-name}}).
+
+## GET_CURRENT_GROUP (#message-get-current-group}
+
+A potential subscriber sends a 'GET_CURRENT_GROUP' message on the control
+ stream to obtain the current group ID for a given track.
+
+~~~
+GET_CURRENT_GROUP Message {
+  Track Namespace (b),
+  Track Name (b),
+}
+~~~
+{: #moq-get-current-group-format title="MOQT GET_CURRENT_GROUP Message"}
+
+## CURRENT_GROUP (#message-current-group}
+
+An endpoint sends a 'CURRENT_GROUP' message on the control stream in response
+to a GET_CURRENT_GROUP message.
+
+~~~
+CURRENT_GROUP Message {
+  Track Namespace (b),
+  Track Name (b),
+  Current Group ID (i),
+}
+~~~
+{: #moq-current-group-format title="MOQT CURRENT_GROUP Message"}
+
+The 'Current Group ID field' contains the highest group ID the sender has
+observed. If the sender is a relay that does not have an active subscription to
+the track, it SHOULD send a GET_CURRENT_GROUP message upstream to obtain up-to-
+date information before sending a CURRENT_GROUP.
 
 ## GOAWAY {#message-goaway}
 The server sends a `GOAWAY` message to initiate session migration

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1622,9 +1622,9 @@ upstream. Subsequent fields contain the largest group and object ID known.
 Any other value in the Status Code field is a malformed message.
 
 When a relay is subscribed to a track, it can simply return the highest group
-and object ID it has observed, whether or not that object was cached. If not
-subscribed, a relay SHOULD send a TRACK_STATUS_REQUEST upstream to obtain
-updated information.
+and object ID it has observed, whether or not that object was cached or
+completely delivered. If not subscribed, a relay SHOULD send a
+TRACK_STATUS_REQUEST upstream to obtain updated information.
 
 Alternatively, the relay MAY subscribe to the track to obtain the same
 information.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1569,7 +1569,7 @@ ANNOUNCE_CANCEL Message {
 * Track Namespace: Identifies a track's namespace as defined in
 ({{track-name}}).
 
-## GET_CURRENT_GROUP (#message-get-current-group}
+## GET_CURRENT_GROUP {#message-get-current-group}
 
 A potential subscriber sends a 'GET_CURRENT_GROUP' message on the control
  stream to obtain the current group ID for a given track.
@@ -1582,7 +1582,7 @@ GET_CURRENT_GROUP Message {
 ~~~
 {: #moq-get-current-group-format title="MOQT GET_CURRENT_GROUP Message"}
 
-## CURRENT_GROUP (#message-current-group}
+## CURRENT_GROUP {#message-current-group}
 
 An endpoint sends a 'CURRENT_GROUP' message on the control stream in response
 to a GET_CURRENT_GROUP message.
@@ -1591,15 +1591,41 @@ to a GET_CURRENT_GROUP message.
 CURRENT_GROUP Message {
   Track Namespace (b),
   Track Name (b),
+  Status Code (i),
   Current Group ID (i),
 }
 ~~~
 {: #moq-current-group-format title="MOQT CURRENT_GROUP Message"}
 
-The 'Current Group ID field' contains the highest group ID the sender has
+The 'Status Code' field provides additional information about the status of the
+track. It MUST hold one of the following values. Any other value is a malformed
+message.
+
+0x00: The track is in progress, and the 'Current Group ID' field contains the
+highest group ID known to the sender for that track.
+
+0x01: The track does not exist. The 'Current Group ID' field MUST be zero, and
+any other value is a malformed message.
+
+0x02: The track has not yet begun. The 'Current Group ID' field MUST be zero in
+this case. Any other value is a malformed message.
+
+0x03: The track has finished, so there is no "live edge." The 'Current Group ID'
+field represents the highest Group ID known to the sender.
+
+0x04: The sender is a relay that cannot obtain the current group ID from the
+publisher. The 'Current Group ID' field contains the largest group ID known to
+the sender.
+
+Any other value in the Status Code field is a malformed message.
+
+The 'Current Group ID field' usually contains the highest group ID the sender has
 observed. If the sender is a relay that does not have an active subscription to
 the track, it SHOULD send a GET_CURRENT_GROUP message upstream to obtain up-to-
 date information before sending a CURRENT_GROUP.
+
+The receiver of multiple CURRENT_GROUP messages for the same track should use
+the highest Current Group ID that it observes.
 
 ## GOAWAY {#message-goaway}
 The server sends a `GOAWAY` message to initiate session migration

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1612,7 +1612,7 @@ value is a malformed message.
 value is a malformed message.
 
 0x03: The track has finished, so there is no "live edge." Subsequent fields
-contain the highest Group and object ID known to the sender.
+contain the highest Group and object ID known.
 
 0x04: The sender is a relay that cannot obtain the current track status from
 upstream. Subsequent fields contain the largest group and object ID known to

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1571,8 +1571,8 @@ ANNOUNCE_CANCEL Message {
 
 ## TRACK_STATUS_REQUEST {#message-track-status-req}
 
-A potential subscriber sends a 'TRACK_INFO_REQUEST' message on the control
- stream to obtain the current group ID for a given track.
+A potential subscriber sends a 'TRACK_STATUS_REQUEST' message on the control
+ stream to obtain information about the current status of a given track.
 
 ~~~
 TRACK_STATUS_REQUEST Message {

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1603,7 +1603,7 @@ track. It MUST hold one of the following values. Any other value is a malformed
 message.
 
 0x00: The track is in progress, and subsequent fields contain the highest group
-and object ID known to the sender for that track.
+and object ID for that track.
 
 0x01: The track does not exist. Subsequent fields MUST be zero, and any other
 value is a malformed message.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1574,6 +1574,8 @@ ANNOUNCE_CANCEL Message {
 A potential subscriber sends a 'TRACK_STATUS_REQUEST' message on the control
  stream to obtain information about the current status of a given track.
 
+A TRACK_STATUS message MUST be sent in response to each TRACK_STATUS_REQUEST.
+
 ~~~
 TRACK_STATUS_REQUEST Message {
   Track Namespace (b),


### PR DESCRIPTION
There is a bit of angst about using SUBSCRIBE to obtain the current Group ID. This PR is a straw man to provide an explicit means of obtaining the group ID.

I would be surprised if this ended up in the final RFC, but it might be useful to keep in the draft as a primitive while the other SUBSCRIBE/FETCH stuff moves around.