### PR TITLE
Delivery Preference for VOD and reliable live (and absolute start/end offsets)

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1199,44 +1199,6 @@ OBJECT_STREAM {
 
 A receiver issues a SUBSCRIBE to a publisher to request a track.
 
-### Subscribe Locations {#subscribe-locations}
-
-The receiver specifies a start and optional end `Location` for the subscription.
-A location value may be an absolute group or object sequence, or it may be a
-delta relative to the largest group or the largest object in a group.
-
-~~~
-Location {
-  Mode (i),
-  [Value (i)],
-}
-~~~
-
-There are 4 modes:
-
-None (0x0): The Location is unspecified, Value is not present
-
-Absolute (0x1): Value is an absolute sequence
-
-RelativePrevious (0x2): Value is a delta from the largest sequence.  0 is the
-largest sequence, 1 is the largest sequence - 1, and so on.
-
-RelativeNext (0x3): Value is a delta from the largest sequence.  0 is the largest
-sequence + 1, 1 is the largest sequence + 2, and so on.
-
-The following table shows an example of how the RelativePrevious and RelativeNext
-values are used to determine the absolute sequence.
-
-~~~
-Sequence:                0    1    2    3    4   [5]  [6] ...
-                                             ^
-                                      Largest Sequence
-RelativePrevious Value:  4    3    2    1    0
-RelativeNext Value:                               0    1  ...
-~~~
-{: title="Relative Indexing"}
-
-
 ### SUBSCRIBE Format
 
 The format of SUBSCRIBE is as follows:
@@ -1247,10 +1209,11 @@ SUBSCRIBE Message {
   Track Alias (i),
   Track Namespace (b),
   Track Name (b),
-  StartGroup (Location),
-  StartObject (Location),
-  EndGroup (Location),
-  EndObject (Location),
+  Start Group (i),
+  [ Start Object (i), ]
+  End Group (i),
+  [ End Object (i), ]
+  Delivery Preference (i),
   Number of Parameters (i),
   Track Request Parameters (..) ...
 }
@@ -1275,24 +1238,24 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
-* StartGroup: The Location of the requested group.  StartGroup's Mode MUST NOT be
-None.
+* Start Group: The start Group ID, plus 1. A value of 0 indicates no start group and the latest group is used instead.
 
-* StartObject: The Location of the requested object.  StartObject's Mode MUST NOT
-be None.
+* Start Object: The start Object ID, plus 1. A value of 0 indicates no start object and the latest object is used instead. This field is not present when Start Group is 0.
 
-* EndGroup: The last Group requested in the subscription, inclusive.  EndGroup's
-Mode is None for an open-ended subscription.
+* End Group: The end Group ID, plus 1. A value of 0 indicates no end group and the subscription is open-ended.
 
-* EndObject: The last Object requested in the subscription, exclusive.
-EndObject's Mode MUST be None if EndGroup's Mode is None.  EndObject's Mode MUST
-NOT be None if EndGroup's Mode is not None.
+* End Object: The end Object ID, plus 1. A value of 0 indicates no end object and the entire group is requested. This field is not present when End Group is 0.
+
+* Delivery Preference: Indicates how objects should be transmitted and dropped.
+The following seciton ({{delivery-preference}}) enumerates the possible values.
 
 * Track Request Parameters: The parameters are defined in
 {{version-specific-params}}
 
 On successful subscription, the publisher SHOULD start delivering
-objects from the group ID and object ID described above.
+objects within the range described above.
+The publisher MUST reply with a SUBSCRIBE_OK to indicate the latest group/object,
+allowing the subscriber to determine the start group/object when not specified.
 
 If a publisher cannot satisfy the requested start or end for the subscription it
 MAY send a SUBSCRIBE_ERROR with code 'Invalid Range'. A publisher MUST NOT send
@@ -1301,58 +1264,31 @@ objects from outside the requested start and end.
 TODO: Define the flow where subscribe request matches an existing subscribe id
 (subscription updates.)
 
-### Examples
+### Delivery Preference
+The publisher will attempt to deliver every object within the requested range.
+However, in many situations this will be impossible.
+Congestion may cause the subscriber to fall behind until eventually the publisher hits resource limits and drops objects.
 
-~~~
-1. Now
+The `Delivery Preference` is a hint from the subscriber indiciating which streams/datagrams should be transmitted first during congestion, and coorespondingly which streams/datagrams should be starved or dropped.
+A publisher OUGHT to respect the delivery prefernce however, especially when multiple subscribers share a cache, this may be on a best effort basis.
+A subscriber MUST NOT expect objects to arrive in the indicated order.
 
-Start Group: Mode=RelativePrevious, Value=0
-Start Object: Mode=RelateiveNext, Value=0
-End Group: Mode=None
-End Object: Mode=None
+Note that objects are placed on QUIC streams according to the Object Forwarding Preference ({{object-message-formats})).
+The Delivery Preference does not change the ordering/reliability that QUIC streams impose.
 
-StartGroup=Largest Group
-StartObject=Largest Object + 1
+|----|---------------|
+| ID | Name          |
+|---:|:--------------|
+| 0  | default       |
+|----|---------------|
+| 1  | prefer-stalls |
+|----|---------------|
+| 2  | prefer-skips  |
+|----|---------------|
 
-2. Current
-
-Start Group: Mode=RelativePrevious, Value=0
-Start Object: Mode=Absolute, Value=0
-End Group: Mode=None
-End Object: Mode=None
-
-StartGroup=Largest Group
-StartObject=0
-
-3. Previous
-
-Start Group: Mode=RelativePrevious, Value=1
-Start Object: Mode=Absolute, Value=0
-End Group: Mode=None
-End Object: Mode=None
-
-StartGroup=Largest Group - 1
-StartObject=0
-
-4. Next
-
-Start Group: Mode=RelativeNext, Value=0
-Start Object: Mode=Absolute, Value=0
-End Group: Mode=None
-End Object: Mode=None
-StartGroup=Largest Group + 1
-StartObject=0
-
-5. Range, All of group 3
-
-Start Group: Mode=Absolute, Value=3
-Start Object: Mode=Absolute, Value=0
-End Group: Mode=Absolute, Value=4
-End Object: Mode=Absolute, Value=0
-
-Start = Group 3, Object 0
-End = Group 3, Object <last>
-~~~
+* `default`: The publisher transmits according to the `priority` field for each stream, as chosen by the broadcaster.
+* `prefer-stalls`: The publisher ignores the `priority` field, transmitting streams in ascending `group_id`, and then ascending `object_id` order.
+* `prefer-skips`: The publisher ignores the `priority` field, transmiting streams in descending `group_id`, and then ascending `object_id` order.
 
 
 ## SUBSCRIBE_OK {#message-subscribe-ok}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1238,13 +1238,13 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
-* Start Group: The start Group ID, plus 1. A value of 0 indicates no start group and the latest group is used instead.
+* Start Group: The start Group ID, plus 1. A value of 0 means the latest group is used instead.
 
-* Start Object: The start Object ID, plus 1. A value of 0 indicates no start object and the latest object is used instead. This field is not present when Start Group is 0.
+* Start Object: The start Object ID, plus 1. A value of 0 means the latest object is used instead. This field is not present when Start Group is 0.
 
-* End Group: The end Group ID, plus 1. A value of 0 indicates no end group and the subscription is open-ended.
+* End Group: The end Group ID, plus 1. A value of 0 means the subscription is open-ended.
 
-* End Object: The end Object ID, plus 1. A value of 0 indicates no end object and the entire group is requested. This field is not present when End Group is 0.
+* End Object: The end Object ID, plus 1. A value of 0 means the entire group is requested. This field is not present when End Group is 0.
 
 * Delivery Preference: Indicates how objects should be transmitted and dropped.
 The following seciton ({{delivery-preference}}) enumerates the possible values.


### PR DESCRIPTION
The default behavior for live streams will be `prefer-skip` as encoded in the priority field. This doesn't work for VOD and reliable live, as they want to receive objects in creation order instead.

This is a counter-proposal to the FETCH keyword which attempts to accomplish something similar, but in a way that won't work for reliable live.

This PR also removes relative start/end offsets because SUBSCRIBE was getting too complex. An application that wants to start N groups back needs to use use #425 or a timeline to learn about the absolute group/object IDs.