### PR TITLE
Add object status used to indicate lost or nonexistent objects

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1023,7 +1023,7 @@ session with a Protocol Violation ({{session-termination}}).
 
 There are times where some of the status information is redundant with
 information learned at the lower layer. For example, when using stream
-per object, the end of Group is redundant.
+per group, the end of Group is redundant.
 
 In most cases messages with a non zero status code are sent on the same
 stream that an object with that GroupID would have been sent on. The

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -985,7 +985,7 @@ be sent according to its `Object Forwarding Preference`, described below.
 * Object Payload: An opaque payload intended for the consumer and SHOULD
 NOT be processed by a relay.
 
-* Object Status: As enumeration used to indicated missing
+* Object Status: As enumeration used to indicate missing
   objects and as an marker of the end of group or track.
 
 The Object Status lets subscribers understand what objects will not be received

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1030,15 +1030,13 @@ status could no longer optional and only occur when the payload length
 was zero as it would be needed in non zero length packets. It would also
 have the issue that when a P frame is produced, the software getting
 data from the decoder often does not know if it is the last P frame
-until the next frame is encoded and the sotware gets an I frame. We do
-not want a situttion where we add a whole frame of latency on the
-encoder waiting for next frame so it can set the end of group field on
-the last last object in the group.
-
+until the next frame is encoded and the software gets an I frame. We do
+not want a solution where we add a whole frame of latency on the encoder
+waiting for next frame so it can set the end of group field on the last
+last object in the group.
 
 Any other value SHOULD be treated as a protocol error and terminate the
 session with a Protocol Violation ({{session-termination}}).
-
 
 ### Object Message Formats
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1020,6 +1020,7 @@ Every object has an associated
 
 Any other value SHOULD be treated as a protocol error and terminate the
 session with a Protocol Violation ({{session-termination}}).
+Any object with a status code other than zero will have an empty payload.
 
 There are times where some of the status information is redundant with
 information learned at the lower layer. For example, when using stream

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -982,19 +982,17 @@ group.
 object. The preferences are Track, Group, Object and Datagram.  An Object MUST
 be sent according to its `Object Forwarding Preference`, described below.
 
-* Object Status: As enumeration used to indicated missing
-  objects and as an marker of the end of group or track.
-
 * Object Payload: An opaque payload intended for the consumer and SHOULD
 NOT be processed by a relay.
 
-There is also a status field which helps subscribers understand what
-objects it will not receive due to then being dropped, lost, or never be
-produced including the case where they will not be produced because they
-are beyond the end of a group or track.
-The status code can also be used to indicated the end of a group or
-track.
-Every object has an associated
+* Object Status: As enumeration used to indicated missing
+  objects and as an marker of the end of group or track.
+
+The Object Status lets subscribers understand what objects will not be received
+because they were never produced, are no longer available, or because they
+are beyond the end of a group or track. The status code can also be used to
+indicate the end of a group or track.
+
 `Status` that can have following values:
 
 * 0x0 := Normal object. The payload is array of bytes and can by empty.
@@ -1026,7 +1024,7 @@ There are times where some of the status information is redundant with
 information learned at the lower layer. For example, when using stream
 per group, the end of Group is redundant.
 
-In most cases messages with a non zero status code are sent on the same
+In most cases, messages with a non zero status code are sent on the same
 stream that an object with that GroupID would have been sent on. The
 exception to this is when that stream has been reset; in that case they
 are sent on a new stream. This is to avoid the status message being lost

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1038,6 +1038,10 @@ last object in the group.
 Any other value SHOULD be treated as a protocol error and terminate the
 session with a Protocol Violation ({{session-termination}}).
 
+There are times where some of the status information is redundant with
+information learned at the lower layer. For example, when using stream
+per object, the end of Group is redundant.
+
 ### Object Message Formats
 
 Every Track has a single 'Object Forwarding Preference' and publishers

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1015,15 +1015,6 @@ are beyond the end of a group or track. Every object has an associated
          group. This is sent right after the last object in the
          track. This SHOULD be cached.
 
-* 0x5 := Indicates Object was dropped at a relay. Sent by a relay
-         indicating the object identified by the ObjectId was
-         dropped. This SHOULD NOT be cached.
-
-* 0x6 := Indicates Group was dropped at a relay. Sent by a relay
-         indicating some of the objects in the group identified by the
-         GroupId were dropped. The Object ID is one greater than last
-         object sent and MAY be zero. This SHOULD NOT be cached.
-
 Open Issue: We could make end of track and end of group just be a status
 set on the last object sent on the group or track. This would mean the
 status could no longer optional and only occur when the payload length

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -988,7 +988,7 @@ NOT be processed by a relay.
 * Object Status: As enumeration used to indicate missing
   objects or mark the end of a group or track.
 
-The Object Status lets subscribers understand what objects will not be received
+The Object Status informs subscribers what objects will not be received
 because they were never produced, are no longer available, or because they
 are beyond the end of a group or track.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -975,6 +975,8 @@ A canonical MoQ Object has the following information:
 IDs starts at 0, increasing sequentially for each object within the
 group.
 
+* Object Send Order: An integer indicating the object send order
+{{send-order}} or priority {{ordering-by-priorities}} value.
 
 * Object Forwarding Preference: An enumeration indicating how a sender sends an
 object. The preferences are Track, Group, Object and Datagram.  An Object MUST

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -994,7 +994,7 @@ are beyond the end of a group or track.
 
 `Status` that can have following values:
 
-* 0x0 := Normal object. The payload is array of bytes and can by empty.
+* 0x0 := Normal object. The payload is array of bytes and can be empty.
 
 * 0x1 := Indicates Object does not exist. Indicates that this object
          does not exist at any publisher and it will not be published in
@@ -1017,11 +1017,10 @@ are beyond the end of a group or track.
 
 Any other value SHOULD be treated as a protocol error and terminate the
 session with a Protocol Violation ({{session-termination}}).
-Any object with a status code other than zero will have an empty payload.
+Any object with a status code other than zero MUST have an empty payload.
 
-There are times where some of the status information is redundant with
-information learned at the lower layer. For example, when using stream
-per group, the end of Group is redundant.
+Though some status information could be inferred from QUIC stream state,
+that information is not reliable and cacheable.
 
 In most cases, messages with a non zero status code are sent on the same
 stream that an object with that GroupID would have been sent on. The

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1028,7 +1028,9 @@ are beyond the end of a group or track. Every object has an associated
          stream. If the group is dropped there will only one message
          with this status for the group.
 
-Any other value SHOULD be treated as a protcol error.
+Any other value SHOULD be treated as a protcol error and terminate the
+session with a Protocol Violation ({{session-termination}}).
+
 
 ### Object Message Formats
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -986,7 +986,7 @@ be sent according to its `Object Forwarding Preference`, described below.
 NOT be processed by a relay.
 
 * Object Status: As enumeration used to indicate missing
-  objects and as an marker of the end of group or track.
+  objects or mark the end of a group or track.
 
 The Object Status lets subscribers understand what objects will not be received
 because they were never produced, are no longer available, or because they

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1042,6 +1042,13 @@ There are times where some of the status information is redundant with
 information learned at the lower layer. For example, when using stream
 per object, the end of Group is redundant.
 
+In most cases messages with a non zero status code are sent on the same
+stream that an object with that GroupID would have been sent on. The
+exception to this is when that stream has been reset; in that case they
+are sent on a new stream. This is to avoid the status message being lost
+in cases such as a relay dropping a group and reseting the stream the
+group is being sent on.
+
 ### Object Message Formats
 
 Every Track has a single 'Object Forwarding Preference' and publishers

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -982,16 +982,19 @@ group.
 object. The preferences are Track, Group, Object and Datagram.  An Object MUST
 be sent according to its `Object Forwarding Preference`, described below.
 
-* Object Status: As enumeration used for missing or dropped objects that
-  indicates why data is missing.
+* Object Status: As enumeration used to indicated missing or dropped
+  objects and as an marker of the end of group or track.
 
 * Object Payload: An opaque payload intended for the consumer and SHOULD
 NOT be processed by a relay.
 
-There is also a status field which help subscribers understand what
+There is also a status field which helps subscribers understand what
 objects it will not receive due to then being dropped, lost, or never be
 produced including the case where they will not be produced because they
-are beyond the end of a group or track. Every object has an associated
+are beyond the end of a group or track.
+The status code can also be used to indicated the end of a group or
+track.
+Every object has an associated
 `Status` that can have following values:
 
 * 0x0 := Normal object. The payload is array of bytes and can by empty.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1028,6 +1028,7 @@ are beyond the end of a group or track. Every object has an associated
          stream. If the group is dropped there will only one message
          with this status for the group.
 
+Any other value SHOULD be treated as a protcol error.
 
 ### Object Message Formats
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -982,11 +982,13 @@ group.
 object. The preferences are Track, Group, Object and Datagram.  An Object MUST
 be sent according to its `Object Forwarding Preference`, described below.
 
-* Object Payload: An opaque payload intended for the consumer and SHOULD
-NOT be processed by a relay.
-
 * Object Status: As enumeration used to indicate missing
-  objects or mark the end of a group or track.
+objects or mark the end of a group or track. See {{object-status}} below.
+
+* Object Payload: An opaque payload intended for the consumer and SHOULD
+NOT be processed by a relay. Only present when 'Object Status' is Normal (0x0).
+
+#### Object Status {#object-status}
 
 The Object Status informs subscribers what objects will not be received
 because they were never produced, are no longer available, or because they

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1136,13 +1136,14 @@ Forwarding Preference` = `Track`.
 To send an Object with `Object Forwarding Preference` = `Track`, find the open
 stream that is associated with the subscription, or open a new one and send the
 `STREAM_HEADER_TRACK` if needed, then serialize the following object fields.
+The Object Status field is only sent if the Object Payload Length is zero.
 
 ~~~
 {
   Group ID (i),
   Object ID (i),
-  Object Status (i),
   Object Payload Length (i),
+  [Object Status (i)],
   Object Payload (..),
 }
 ~~~
@@ -1176,12 +1177,13 @@ To send an Object with `Object Forwarding Preference` = `Group`, find the open
 stream that is associated with the subscription, `Group ID` and `Object
 Send Order`, or open a new one and send the `STREAM_HEADER_GROUP` if needed,
 then serialize the following fields.
+The Object Status field is only sent if the Object Payload Length is zero.
 
 ~~~
 {
   Object ID (i),
-  Object Status (i),
   Object Payload Length (i),
+  [Object Status (i)],
   Object Payload (..),
 }
 ~~~

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1015,17 +1015,6 @@ are beyond the end of a group or track. Every object has an associated
          group. This is sent right after the last object in the
          track. This SHOULD be cached.
 
-Open Issue: We could make end of track and end of group just be a status
-set on the last object sent on the group or track. This would mean the
-status could no longer optional and only occur when the payload length
-was zero as it would be needed in non zero length packets. It would also
-have the issue that when a P frame is produced, the software getting
-data from the decoder often does not know if it is the last P frame
-until the next frame is encoded and the software gets an I frame. We do
-not want a solution where we add a whole frame of latency on the encoder
-waiting for next frame so it can set the end of group field on the last
-last object in the group.
-
 Any other value SHOULD be treated as a protocol error and terminate the
 session with a Protocol Violation ({{session-termination}}).
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -982,7 +982,7 @@ group.
 object. The preferences are Track, Group, Object and Datagram.  An Object MUST
 be sent according to its `Object Forwarding Preference`, described below.
 
-* Object Status: As enumeration used to indicated missing or dropped
+* Object Status: As enumeration used to indicated missing
   objects and as an marker of the end of group or track.
 
 * Object Payload: An opaque payload intended for the consumer and SHOULD

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -992,7 +992,7 @@ The Object Status informs subscribers what objects will not be received
 because they were never produced, are no longer available, or because they
 are beyond the end of a group or track.
 
-`Status` that can have following values:
+`Status` can have following values:
 
 * 0x0 := Normal object. The payload is array of bytes and can be empty.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -980,7 +980,7 @@ group.
 object. The preferences are Track, Group, Object and Datagram.  An Object MUST
 be sent according to its `Object Forwarding Preference`, described below.
 
-* Object Status: As enumeration used for missing or dropped ojects that
+* Object Status: As enumeration used for missing or dropped objects that
   indicates why data is missing.
 
 * Object Payload: An opaque payload intended for the consumer and SHOULD

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -990,8 +990,7 @@ NOT be processed by a relay.
 
 The Object Status lets subscribers understand what objects will not be received
 because they were never produced, are no longer available, or because they
-are beyond the end of a group or track. The status code can also be used to
-indicate the end of a group or track.
+are beyond the end of a group or track.
 
 `Status` that can have following values:
 


### PR DESCRIPTION
 This PR adds a status field to the object that allows an relay to indicate an object or group was lost or dropped. 
 
 It also allows a producer to indicate a object or group will not be produced including the cases for end of group and end of track. 
 
 The PR probably needs a bit more text on what what producers and relays do but I think this is close enough to get some initial discussion on this solution. 

Fixes #318
Fixes #427
Fixes most of #423 

Closes #334
Closes #426