### PR TITLE
Simplify/Clarify Subscribe by adding 4 modes

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1276,7 +1276,8 @@ See ({{sub-filter}}).
 
 * EndGroup: The end Group ID. Only present for the "AbsoluteRange" filter type.
 
-* EndObject: The end Object ID. Only present for the "AbsoluteRange" filter type.
+* EndObject: The end Object ID, plus 1. A value of 0 means the entire group is
+requested. Only present for the "AbsoluteRange" filter type.
 
 * Track Request Parameters: The parameters are defined in
 {{version-specific-params}}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1203,21 +1203,24 @@ OBJECT_STREAM {
 
 ### Subscribe Location Filter {#sub-filter}
 
-The receiver specifies a filter value that allows publisher
-to identify the range of groups and objects that needs to be delivered, wherever applicable.
+The subscriber specifies a filter on the subscription to allow
+the publisher to identify which objects need to be delivered.
 
-There are 4 filter values:
+There are 4 types of filters:
 
-Current (0x1) : A filter value of "Current" specifies an open-ended subscription with objects from the beginning of the current group.
+Lastest Group (0x1) : Specifies an open-ended subscription with objects
+from the beginning of the current group.
 
-Latest (0x2): A filter value of "Latest" specifies an open-ended subscription beginning from the current object of the current group.
+Latest Object (0x2): Specifies an open-ended subscription beginning from
+the current object of the current group.
 
-AbsoluteStart (0x3):  A filter value of "AbsoluteStart" specifies an open-ended subscription with objects beginning from group/object identified in the StartGroup and StartObject fields.
+AbsoluteStart (0x3):  Specifies an open-ended subscription with objects
+beginning from the object identified in the StartGroup and StartObject fields.
 
-AbsoluteRange (0x4):  A filter value of "AbsoluteRange" specifies a closed subscription. The group information is obtained from the StartGroup and EndGroup fields, the object information is obtained from the StartObject and the EndObject fields.
+AbsoluteRange (0x4):  Specifies a closed subscription starting at StartObject
+in the StartGroup and ending at EndObject in EndGroup.
 
-
-A filter value other than the above MUST be treated as error.
+A filter type other than the above MUST be treated as error.
 
 
 ### SUBSCRIBE Format
@@ -1231,13 +1234,13 @@ SUBSCRIBE Message {
   Track Alias (i),
   Track Namespace (b),
   Track Name (b),
+  Filter Type (i),
+  [StartGroup (i),
+   StartObject (i)],
+  [EndGroup (i),
+   EndObject (i)],
   Number of Parameters (i),
   Track Request Parameters (..) ...,
-  Location Filter (i),
-  [StartGroup (i)],
-  [StartObject (i)],
-  [EndGroup (i)],
-  [EndObject (i)],
 }
 ~~~
 {: #moq-transport-subscribe-format title="MOQT SUBSCRIBE Message"}
@@ -1260,28 +1263,21 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
+* Location Filter: Identifies acceptable values for start and end group(s)/object(s)
+  to be delivered. See ({{sub-filter}}).
+
+* StartGroup: The start Group ID. Only present for "AbsoluteStart" and
+  "AbsoluteRange" filter types.
+
+* StartObject: The start Object ID within the StartGroup. Only present for
+  "AbsoluteStart" and "AbsoluteRange" filter types.
+
+* EndGroup: The end Group ID. Only present for the "AbsoluteRange" filter type.
+
+* EndObject: The end Object ID. Only present for the "AbsoluteRange" filter type.
+
 * Track Request Parameters: The parameters are defined in
 {{version-specific-params}}
-
-* Location Filter: Identifies acceptable values for start and end group(s)/object(s) to be delivered. See ({{sub-filter}}).
-
-For filter value of "AbsoluteStart", the following interpretation holds:
-
-* StartGroup: The start Group ID. This field MUST be present.
-
-* StartObject: The start Object ID within the group corresponding to the StartGroup. Omitting this field implies objects from the beginning of the group.
-
-The fields EndGroup and EndObject MUST NOT be present.
-
-For filter value of "AbsoluteRange", the following interpretation holds:
-
-* StartGroup: The start Group ID. This field MUST be present.
-
-* StartObject: The start Object ID within the group corresponding to the StartGroup. This field MUST be present.
-
-* EndGroup: The end Group ID. This field MUST be present.
-
-* EndObject: The end Object ID. Omitting this field implies until the end of group specified in EndGroup.
 
 
 On successful subscription, the publisher MUST reply with a SUBSCRIBE_OK,

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1201,7 +1201,7 @@ OBJECT_STREAM {
 
 ## SUBSCRIBE {#message-subscribe-req}
 
-### Subscribe Location Filter {#sub-filter}
+### Filter Types {#sub-filter}
 
 The subscriber specifies a filter on the subscription to allow
 the publisher to identify which objects need to be delivered.
@@ -1263,14 +1263,15 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
-* Location Filter: Identifies acceptable values for start and end group(s)/object(s)
-  to be delivered. See ({{sub-filter}}).
+* Filter Type: Identifies the type of filter, which also indicates whether
+the StartGroup/StartObject and EndGroup/EndObject fields will be present.
+See ({{sub-filter}}).
 
 * StartGroup: The start Group ID. Only present for "AbsoluteStart" and
-  "AbsoluteRange" filter types.
+"AbsoluteRange" filter types.
 
 * StartObject: The start Object ID within the StartGroup. Only present for
-  "AbsoluteStart" and "AbsoluteRange" filter types.
+"AbsoluteStart" and "AbsoluteRange" filter types.
 
 * EndGroup: The end Group ID. Only present for the "AbsoluteRange" filter type.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1277,7 +1277,7 @@ For filter value of "AbsoluteRange", the following interpretation holds:
 
 * StartGroup: The start Group ID. This field MUST be present.
 
-* StartObject: The start Object ID within the group corresponding to the StartGroup. Omitting this field implies objects from the beginning of the group.
+* StartObject: The start Object ID within the group corresponding to the StartGroup. This field MUST be present.
 
 * EndGroup: The end Group ID. This field MUST be present.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1211,10 +1211,11 @@ SUBSCRIBE Message {
   Track Alias (i),
   Track Namespace (b),
   Track Name (b),
+  Location Filter (i),
   StartGroup (i),
-  [ StartObject (i), ]
-  EndGroup (i),
-  [ EndObject (i), ]
+  StartObject (i),
+  [EndGroup (i)],
+  [ EndObject (i)],
   Number of Parameters (i),
   Track Request Parameters (..) ...
 }
@@ -1239,19 +1240,19 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
-* StartGroup: The start Group ID, plus 1. A value of 0 means the latest group.
+* Subscribe Filter: Identifies acceptable values for start and end group(s)/object(s) to be delivered. See ({{sub-filter}}).
 
-* StartObject: The start Object ID, plus 1. A value of 0 means the latest object.
-This field is not present when Start Group is 0.
+* StartGroup: The start Group ID.
 
-* EndGroup: The end Group ID, plus 1. A value of 0 means the subscription is
-open-ended and continues to the end of the track.
+* StartObject: The start Object ID within the group corresponding to the StartGroup.
 
-* EndObject: The end Object ID, plus 1. A value of 0 means the entire group is
-requested. This field is not present when End Group is 0.
+* EndGroup: The end Group ID. If omitted means, subscription is open-ended and continues to the end of the track.
+
+* EndObject: The end Object ID. This field MUST NOT be present if the EndGroup is omitted.
 
 * Track Request Parameters: The parameters are defined in
 {{version-specific-params}}
+
 
 On successful subscription, the publisher MUST reply with a SUBSCRIBE_OK,
 allowing the subscriber to determine the start group/object when not explicitly
@@ -1264,6 +1265,24 @@ objects from outside the requested start and end.
 TODO: Define the flow where subscribe request matches an existing subscribe id
 (subscription updates.)
 
+### Subscribe Filter {#sub-filter}
+
+The receiver specifies a filter value that allows publisher
+to identify the range of groups and objects that needs to be delivered, wherever applicable.
+
+There are 3 filter values:
+
+Current (0x1) : A filter value of "Current" implies objects from the beginning of the current group.
+
+Latest (0x2): A filter value of "Latest" implies beginning from the current object of the current group.
+
+Absolute (0x3):  For filter value of "Absolute", the group information is obtained from the StartGroup and EndGroup fields,
+the object information is obtained from the StartObject and the
+EndObject fields.
+
+A filter value other than the above MUST be treated as error.
+
+The fields `StartGroup`, `StartObject`, `EndGroup` and `EndObject` MUST be only present if the filer value is `Absolute`, else the subscription MUST be treated as error.
 
 ## SUBSCRIBE_OK {#message-subscribe-ok}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1241,7 +1241,7 @@ SUBSCRIBE Message {
   [EndGroup (i),
    EndObject (i)],
   Number of Parameters (i),
-  Track Request Parameters (..) ...,
+  Track Request Parameters (..) ...
 }
 ~~~
 {: #moq-transport-subscribe-format title="MOQT SUBSCRIBE Message"}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1208,7 +1208,7 @@ the publisher to identify which objects need to be delivered.
 
 There are 4 types of filters:
 
-Lastest Group (0x1) : Specifies an open-ended subscription with objects
+Latest Group (0x1) : Specifies an open-ended subscription with objects
 from the beginning of the current group.
 
 Latest Object (0x2): Specifies an open-ended subscription beginning from

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1214,8 +1214,8 @@ from the beginning of the current group.
 Latest Object (0x2): Specifies an open-ended subscription beginning from
 the current object of the current group.
 
-AbsoluteStart (0x3):  Specifies an open-ended subscription with objects
-beginning from the object identified in the StartGroup and StartObject fields.
+AbsoluteStart (0x3):  Specifies an open-ended subscription beginning
+from the object identified in the StartGroup and StartObject fields.
 
 AbsoluteRange (0x4):  Specifies a closed subscription starting at StartObject
 in StartGroup and ending at EndObject in EndGroup.  The start and end of the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1218,7 +1218,8 @@ AbsoluteStart (0x3):  Specifies an open-ended subscription with objects
 beginning from the object identified in the StartGroup and StartObject fields.
 
 AbsoluteRange (0x4):  Specifies a closed subscription starting at StartObject
-in the StartGroup and ending at EndObject in EndGroup.
+in StartGroup and ending at EndObject in EndGroup.  The start and end of the
+range are inclusive.
 
 A filter type other than the above MUST be treated as error.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1279,7 +1279,6 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 * Track Request Parameters: The parameters are defined in
 {{version-specific-params}}
 
-
 On successful subscription, the publisher MUST reply with a SUBSCRIBE_OK,
 allowing the subscriber to determine the start group/object when not explicitly
 specified and the publisher SHOULD start delivering objects.
@@ -1290,7 +1289,6 @@ objects from outside the requested start and end.
 
 TODO: Define the flow where subscribe request matches an existing subscribe id
 (subscription updates.)
-
 
 
 ## SUBSCRIBE_OK {#message-subscribe-ok}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1271,8 +1271,8 @@ See ({{sub-filter}}).
 * StartGroup: The start Group ID. Only present for "AbsoluteStart" and
 "AbsoluteRange" filter types.
 
-* StartObject: The start Object ID within the StartGroup. Only present for
-"AbsoluteStart" and "AbsoluteRange" filter types.
+* StartObject: The start Object ID, plus 1. A value of 0 means the entire group is
+requested. Only present for "AbsoluteStart" and "AbsoluteRange" filter types.
 
 * EndGroup: The end Group ID. Only present for the "AbsoluteRange" filter type.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1201,6 +1201,25 @@ OBJECT_STREAM {
 
 ## SUBSCRIBE {#message-subscribe-req}
 
+### Subscribe Filter {#sub-filter}
+
+The receiver specifies a filter value that allows publisher
+to identify the range of groups and objects that needs to be delivered, wherever applicable.
+
+There are 3 filter values:
+
+Current (0x1) : A filter value of "Current" implies objects from the beginning of the current group.
+
+Latest (0x2): A filter value of "Latest" implies beginning from the current object of the current group.
+
+Absolute (0x3):  For filter value of "Absolute", the group information is obtained from the StartGroup and EndGroup fields,
+the object information is obtained from the StartObject and the
+EndObject fields.
+
+A filter value other than the above MUST be treated as error.
+
+
+## SUBSCRIBE Format
 A receiver issues a SUBSCRIBE to a publisher to request a track.
 
 The format of SUBSCRIBE is as follows:
@@ -1211,13 +1230,13 @@ SUBSCRIBE Message {
   Track Alias (i),
   Track Namespace (b),
   Track Name (b),
+  Number of Parameters (i),
+  Track Request Parameters (..) ...,
   Location Filter (i),
-  StartGroup (i),
-  StartObject (i),
+  [StartGroup (i)],
+  [StartObject (i)],
   [EndGroup (i)],
   [ EndObject (i)],
-  Number of Parameters (i),
-  Track Request Parameters (..) ...
 }
 ~~~
 {: #moq-transport-subscribe-format title="MOQT SUBSCRIBE Message"}
@@ -1240,18 +1259,21 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
+* Track Request Parameters: The parameters are defined in
+{{version-specific-params}}
+
 * Subscribe Filter: Identifies acceptable values for start and end group(s)/object(s) to be delivered. See ({{sub-filter}}).
 
-* StartGroup: The start Group ID.
+For filter value of "Absolute", the following interpretation holds:
+
+* StartGroup: The start Group ID. This field MUST be present.
 
 * StartObject: The start Object ID within the group corresponding to the StartGroup.
 
-* EndGroup: The end Group ID. If omitted means, subscription is open-ended and continues to the end of the track.
+* EndGroup: The end Group ID. If omitted implies an open-ended subscription and continues to the end of the track.
 
 * EndObject: The end Object ID. This field MUST NOT be present if the EndGroup is omitted.
 
-* Track Request Parameters: The parameters are defined in
-{{version-specific-params}}
 
 
 On successful subscription, the publisher MUST reply with a SUBSCRIBE_OK,
@@ -1265,24 +1287,7 @@ objects from outside the requested start and end.
 TODO: Define the flow where subscribe request matches an existing subscribe id
 (subscription updates.)
 
-### Subscribe Filter {#sub-filter}
 
-The receiver specifies a filter value that allows publisher
-to identify the range of groups and objects that needs to be delivered, wherever applicable.
-
-There are 3 filter values:
-
-Current (0x1) : A filter value of "Current" implies objects from the beginning of the current group.
-
-Latest (0x2): A filter value of "Latest" implies beginning from the current object of the current group.
-
-Absolute (0x3):  For filter value of "Absolute", the group information is obtained from the StartGroup and EndGroup fields,
-the object information is obtained from the StartObject and the
-EndObject fields.
-
-A filter value other than the above MUST be treated as error.
-
-The fields `StartGroup`, `StartObject`, `EndGroup` and `EndObject` MUST be only present if the filer value is `Absolute`, else the subscription MUST be treated as error.
 
 ## SUBSCRIBE_OK {#message-subscribe-ok}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1201,25 +1201,26 @@ OBJECT_STREAM {
 
 ## SUBSCRIBE {#message-subscribe-req}
 
-### Subscribe Filter {#sub-filter}
+### Subscribe Location Filter {#sub-filter}
 
 The receiver specifies a filter value that allows publisher
 to identify the range of groups and objects that needs to be delivered, wherever applicable.
 
-There are 3 filter values:
+There are 4 filter values:
 
-Current (0x1) : A filter value of "Current" implies objects from the beginning of the current group.
+Current (0x1) : A filter value of "Current" specifies an open-ended subscription with objects from the beginning of the current group.
 
-Latest (0x2): A filter value of "Latest" implies beginning from the current object of the current group.
+Latest (0x2): A filter value of "Latest" specifies an open-ended subscription beginning from the current object of the current group.
 
-Absolute (0x3):  For filter value of "Absolute", the group information is obtained from the StartGroup and EndGroup fields,
-the object information is obtained from the StartObject and the
-EndObject fields.
+AbsoluteStart (0x3):  A filter value of "AbsoluteStart" specifies an open-ended subscription with objects beginning from group/object identified in the StartGroup and StartObject fields.
+
+AbsoluteRange (0x4):  A filter value of "AbsoluteRange" specifies a closed subscription. The group information is obtained from the StartGroup and EndGroup fields, the object information is obtained from the StartObject and the EndObject fields.
+
 
 A filter value other than the above MUST be treated as error.
 
 
-## SUBSCRIBE Format
+### SUBSCRIBE Format
 A receiver issues a SUBSCRIBE to a publisher to request a track.
 
 The format of SUBSCRIBE is as follows:
@@ -1236,7 +1237,7 @@ SUBSCRIBE Message {
   [StartGroup (i)],
   [StartObject (i)],
   [EndGroup (i)],
-  [ EndObject (i)],
+  [EndObject (i)],
 }
 ~~~
 {: #moq-transport-subscribe-format title="MOQT SUBSCRIBE Message"}
@@ -1262,18 +1263,25 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 * Track Request Parameters: The parameters are defined in
 {{version-specific-params}}
 
-* Subscribe Filter: Identifies acceptable values for start and end group(s)/object(s) to be delivered. See ({{sub-filter}}).
+* Location Filter: Identifies acceptable values for start and end group(s)/object(s) to be delivered. See ({{sub-filter}}).
 
-For filter value of "Absolute", the following interpretation holds:
+For filter value of "AbsoluteStart", the following interpretation holds:
 
 * StartGroup: The start Group ID. This field MUST be present.
 
-* StartObject: The start Object ID within the group corresponding to the StartGroup.
+* StartObject: The start Object ID within the group corresponding to the StartGroup. Omitting this field implies objects from the beginning of the group.
 
-* EndGroup: The end Group ID. If omitted implies an open-ended subscription and continues to the end of the track.
+The fields EndGroup and EndObject MUST NOT be present.
 
-* EndObject: The end Object ID. This field MUST NOT be present if the EndGroup is omitted.
+For filter value of "AbsoluteRange", the following interpretation holds:
 
+* StartGroup: The start Group ID. This field MUST be present.
+
+* StartObject: The start Object ID within the group corresponding to the StartGroup. Omitting this field implies objects from the beginning of the group.
+
+* EndGroup: The end Group ID. This field MUST be present.
+
+* EndObject: The end Object ID. Omitting this field implies until the end of group specified in EndGroup.
 
 
 On successful subscription, the publisher MUST reply with a SUBSCRIBE_OK,


### PR DESCRIPTION
I took a stab at another rewrite of Subscribe message which attempts to not use special group and object values. Also add support for multiple subscription flows that have been discussed.

As this is a control message, we should be Ok to be elaborate in describing the subscriber needs.

This leaves 0 as a special value for the StartObject and EndObject.