### PR TITLE
Add a Max Cache Duration (aka ttl) field to Objects

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -982,6 +982,10 @@ group.
 object. The preferences are Track, Group, Object and Datagram.  An Object MUST
 be sent according to its `Object Forwarding Preference`, described below.
 
+* Cache Duration: The length of time in milliseconds a caching relay SHOULD
+cache an Object for.  The relay SHOULD NOT begin sending the Object if it
+has resided in the cache for longer than that time interval.
+
 * Object Status: As enumeration used to indicate missing
 objects or mark the end of a group or track. See {{object-status}} below.
 
@@ -1058,6 +1062,7 @@ OBJECT_STREAM Message {
   Group ID (i),
   Object ID (i),
   Object Send Order (i),
+  Cache Duration (i),
   Object Status (i),
   Object Payload (..),
 }
@@ -1095,6 +1100,7 @@ OBJECT_DATAGRAM Message {
   Group ID (i),
   Object ID (i),
   Object Send Order (i),
+  Cache Duration (i),
   Object Status (i),
   Object Payload (..),
 }
@@ -1127,6 +1133,7 @@ STREAM_HEADER_TRACK Message {
   Subscribe ID (i)
   Track Alias (i),
   Object Send Order (i),
+  Cache Duration (i),
 }
 ~~~
 {: #stream-header-track-format title="MOQT STREAM_HEADER_TRACK Message"}
@@ -1165,8 +1172,9 @@ have the `Object Send Order` specified in the stream header.
 STREAM_HEADER_GROUP Message {
   Subscribe ID (i),
   Track Alias (i),
-  Group ID (i)
-  Object Send Order (i)
+  Group ID (i),
+  Object Send Order (i),
+  Cache Duration (i),
 }
 ~~~
 {: #stream-header-group-format title="MOQT STREAM_HEADER_GROUP Message"}
@@ -1202,6 +1210,7 @@ STREAM_HEADER_TRACK {
   Subscribe ID = 1
   Track Alias = 1
   Object Send Order = 0
+  Cache Duration = 1000
 }
 {
   Group ID = 0
@@ -1228,6 +1237,7 @@ STREAM_HEADER_GROUP {
   Track Alias = 2
   Group ID = 0
   Object Send Order = 0
+  Cache Duration = 1000
 }
 {
   Object ID = 0
@@ -1247,6 +1257,8 @@ OBJECT_STREAM {
   Track Alias = 2
   Group ID = 0
   Object ID = 1
+  Object Send Order = 0
+  Cache Duration = 1000
   Payload = "moqrocks"
 }
 ~~~

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1253,8 +1253,8 @@ STREAM_HEADER_GROUP {
 Stream = 6
 
 OBJECT_STREAM {
-  Subscribe ID = 2
-  Track Alias = 2
+  Subscribe ID = 3
+  Track Alias = 3
   Group ID = 0
   Object ID = 1
   Object Send Order = 0

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -982,7 +982,7 @@ group.
 object. The preferences are Track, Group, Object and Datagram.  An Object MUST
 be sent according to its `Object Forwarding Preference`, described below.
 
-* Max Cache Duration: The maximum length of time in milliseconds a caching
+* Max Cache Duration: The maximum length of time in seconds a caching
 relay MAY cache an Object for.  A value of 0 indicates the relay should decide
 how long to cache the Object. The relay MUST NOT begin sending the Object if it
 has resided in the cache for longer than that time interval. When sending an

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1247,6 +1247,14 @@ Object, the amount of time the Object spent in cache is deducted from the
 Max Cache Duration value before the Object is sent. Exceeding the duration
 does not cause a change in the 'Object Status'.
 
+The Cache Duration is only expressed in the stream header, so the Object
+Forwarding Preference dictates the granularity of cache duration, because a
+single value applies to all Objects within the stream. For example, if a Group
+has two Objects, and the Object Forwarding Preference is 'Group', then
+only a single Max Cache Duration can be conveyed to a future subscriber,
+even if there was a substantial time gap between receiving the first and
+second Object.
+
 * Object Status: As enumeration used to indicate missing
 objects or mark the end of a group or track. See {{object-status}} below.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -983,7 +983,8 @@ object. The preferences are Track, Group, Object and Datagram.  An Object MUST
 be sent according to its `Object Forwarding Preference`, described below.
 
 * Cache Duration: The length of time in milliseconds a caching relay SHOULD
-cache an Object for.  The relay SHOULD NOT begin sending the Object if it
+cache an Object for.  A value of 0 indicates the relay should decide how
+long to cache the Object. The relay SHOULD NOT begin sending the Object if it
 has resided in the cache for longer than that time interval.
 
 * Object Status: As enumeration used to indicate missing

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -982,10 +982,12 @@ group.
 object. The preferences are Track, Group, Object and Datagram.  An Object MUST
 be sent according to its `Object Forwarding Preference`, described below.
 
-* Cache Duration: The length of time in milliseconds a caching relay SHOULD
-cache an Object for.  A value of 0 indicates the relay should decide how
-long to cache the Object. The relay SHOULD NOT begin sending the Object if it
-has resided in the cache for longer than that time interval.
+* Max Cache Duration: The maximum length of time in milliseconds a caching
+relay MAY cache an Object for.  A value of 0 indicates the relay should decide
+how long to cache the Object. The relay MUST NOT begin sending the Object if it
+has resided in the cache for longer than that time interval. When sending an
+Object, the amount of time the Object spent in cache is deducted from the
+Max Cache Duration value before the Object is sent.
 
 * Object Status: As enumeration used to indicate missing
 objects or mark the end of a group or track. See {{object-status}} below.
@@ -1063,7 +1065,7 @@ OBJECT_STREAM Message {
   Group ID (i),
   Object ID (i),
   Object Send Order (i),
-  Cache Duration (i),
+  Max Cache Duration (i),
   Object Status (i),
   Object Payload (..),
 }
@@ -1101,7 +1103,7 @@ OBJECT_DATAGRAM Message {
   Group ID (i),
   Object ID (i),
   Object Send Order (i),
-  Cache Duration (i),
+  Max Cache Duration (i),
   Object Status (i),
   Object Payload (..),
 }
@@ -1134,7 +1136,7 @@ STREAM_HEADER_TRACK Message {
   Subscribe ID (i)
   Track Alias (i),
   Object Send Order (i),
-  Cache Duration (i),
+  Max Cache Duration (i),
 }
 ~~~
 {: #stream-header-track-format title="MOQT STREAM_HEADER_TRACK Message"}
@@ -1175,7 +1177,7 @@ STREAM_HEADER_GROUP Message {
   Track Alias (i),
   Group ID (i),
   Object Send Order (i),
-  Cache Duration (i),
+  Max Cache Duration (i),
 }
 ~~~
 {: #stream-header-group-format title="MOQT STREAM_HEADER_GROUP Message"}
@@ -1211,7 +1213,7 @@ STREAM_HEADER_TRACK {
   Subscribe ID = 1
   Track Alias = 1
   Object Send Order = 0
-  Cache Duration = 1000
+  Max Cache Duration = 1000
 }
 {
   Group ID = 0
@@ -1238,7 +1240,7 @@ STREAM_HEADER_GROUP {
   Track Alias = 2
   Group ID = 0
   Object Send Order = 0
-  Cache Duration = 1000
+  Max Cache Duration = 1000
 }
 {
   Object ID = 0
@@ -1259,7 +1261,7 @@ OBJECT_STREAM {
   Group ID = 0
   Object ID = 1
   Object Send Order = 0
-  Cache Duration = 1000
+  Max Cache Duration = 1000
   Payload = "moqrocks"
 }
 ~~~

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -987,7 +987,8 @@ relay MAY cache an Object for.  A value of 0 indicates the relay should decide
 how long to cache the Object. The relay MUST NOT begin sending the Object if it
 has resided in the cache for longer than that time interval. When sending an
 Object, the amount of time the Object spent in cache is deducted from the
-Max Cache Duration value before the Object is sent.
+Max Cache Duration value before the Object is sent. Exceeding the duration
+does not cause a change in the 'Object Status'.
 
 * Object Status: As enumeration used to indicate missing
 objects or mark the end of a group or track. See {{object-status}} below.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1253,7 +1253,7 @@ single value applies to all Objects within the stream. For example, if a Group
 has two Objects, and the Object Forwarding Preference is 'Group', then
 only a single Max Cache Duration can be conveyed to a future subscriber,
 even if there was a substantial time gap between receiving the first and
-second Object.
+second Object in the Group.
 
 * Object Status: As enumeration used to indicate missing
 objects or mark the end of a group or track. See {{object-status}} below.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1239,7 +1239,7 @@ group.
 object. The preferences are Track, Group, Object and Datagram.  An Object MUST
 be sent according to its `Object Forwarding Preference`, described below.
 
-* Max Cache Duration: The maximum length of time in seconds a caching
+* Max Cache Duration: The maximum length of time in milliseconds a caching
 relay MAY cache an Object for.  A value of 0 indicates the relay should decide
 how long to cache the Object. The relay MUST NOT begin sending the Object if it
 has resided in the cache for longer than that time interval. When sending an


### PR DESCRIPTION
Based on discussion last week and on slack, I believe this is where the WG is heading.

It is possible this could be a per-track or per-subscription value to save bytes on the wire, particularly for the Object per Stream or Object per Datagram modes.

It's possible this value could be decreased by the cache dwell time at each hop, but I didn't hear clear consensus either way on that question.

Fixes #440
Fixes #415 