### PR TITLE
Delivery Order (aka Fetch lives)

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1012,14 +1012,16 @@ completeness and Latest prioritizes receiving the most recent Objects.
 
 There are 2 delivery orders:
 
-In Order (0x1): Delivers Objects in ascending Group Id, and then ascending
-Object Id order, as fast as possible.  Objects are sent on a single stream at
+In Order (0x1): Delivers Objects in order of ascending Group Id and then
+ascending Object Id, as fast as possible.  Objects are sent on a single stream at
 once, starting with the 'Stream Header Track' header. When an Object or Group
 is no longer available, the status ({{object-status}}) indicates that.
 A SUBSCRIBE_UPDATE could narrow a subscription and it could make sense to skip
 over ranges of Objects. In this case, a publisher MAY reset the existing stream
 and start sending on a new one, with the same Subscribe ID.  Publishers MUST NOT
-skip Objects otherwise.
+skip Objects otherwise.  Because there are no unexplained Object gaps, it is
+not necessary to send Objects with the 'End of Group' status or 'End of Track'
+status.
 
 Latest (0x2): Objects from the most recent Group SHOULD be delivered first,
 in ascending Object ID order when possible, unless indicated otherwise by

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1592,7 +1592,7 @@ end prior to the expiry time or last longer.
 
 * Delivery Timeout: The number of milliseconds the publisher has agreed to attempt
 forwarding objects, or zero to indicate no limit.  MUST be 0 when the SUBSCRIBE
-specified a 'Delivery Order' of 'Strict In Order'. See ({{delivery-timeout}}) above.
+requested a 'Delivery Order' of 'Strict In Order'. See ({{delivery-timeout}}) above.
 
 * ContentExists: 1 if an object has been published on this track, 0 if not.
 If 0, then the Largest Group ID and Largest Object ID fields will not be

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1043,6 +1043,7 @@ would be sent as soon as the publisher or relay received them.
 
 ### Delivery Timeout {#delivery-timeout}
 
+The maximum number of milliseconds a publisher should attempt forwarding objects.
 The semantics of the timeout depend on the forwarding preference
 ({{object-message-formats}}) of the track:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1086,8 +1086,8 @@ requested. Only present for "AbsoluteStart" and "AbsoluteRange" filter types.
 * EndObject: The end Object ID, plus 1. A value of 0 means the entire group is
 requested. Only present for the "AbsoluteRange" filter type.
 
-* Delivery Preference: Indicates how Objects should be transmitted and dropped.
-See ({{delivery-preference}}) above.
+* Delivery Order: Indicates how Objects should be transmitted and dropped.
+See ({{delivery-order}}) above.
 
 * Track Request Parameters: The parameters are defined in
 {{version-specific-params}}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1019,9 +1019,8 @@ is no longer available, the status ({{object-status}}) indicates that.
 A SUBSCRIBE_UPDATE could narrow a subscription and it could make sense to skip
 over ranges of Objects. In this case, a publisher MAY reset the existing stream
 and start sending on a new one, with the same Subscribe ID.  Publishers MUST NOT
-skip Objects otherwise.  Because there are no unexplained Object gaps, it is
-not necessary to send Objects with the 'End of Group' status or 'End of Track'
-status.
+skip Objects otherwise.  Because there is no explicit Group ID, publishers MUST
+send Objects with the 'End of Group' status to indicate the end of the Group.
 
 Latest (0x2): Objects from the most recent Group SHOULD be delivered first,
 in ascending Object ID order when possible, unless indicated otherwise by
@@ -1406,7 +1405,9 @@ ID`.
 
 ~~~
 STREAM_HEADER_TRACK Message {
-  Subscribe ID (i)
+  Subscribe ID (i),
+  Group ID (i),
+  Object ID (i),
 }
 ~~~
 {: #stream-header-track-format title="MOQT STREAM_HEADER_TRACK Message"}
@@ -1421,8 +1422,6 @@ The Object Status field is only sent if the Object Payload Length is zero.
 
 ~~~
 {
-  Group ID (i),
-  Object ID (i),
   Object Payload Length (i),
   [Object Status (i)],
   Object Payload (..),

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1012,13 +1012,14 @@ completeness and Latest prioritizes receiving the most recent Objects.
 
 There are 2 delivery orders:
 
-In Order (0x1): In Order subscriptions are delivered as fast as possible on
-a single stream at once, starting with the 'Stream Header Track' header.
-When an Object or Group is no longer available, the status ({{object-status}})
-should indicate that. A SUBSCRIBE_UPDATE could narrow a subscription and
-it could make sense to skip over ranges of Objects. In this case, a publisher
-MAY reset the existing stream and start sending on a new one, with the same
-Subscribe ID.  Publishers MUST NOT skip Objects otherwise.
+In Order (0x1): Delivers Objects in ascending Group Id, and then ascending
+Object Id order, as fast as possible.  Objects are sent on a single stream at
+once, starting with the 'Stream Header Track' header. When an Object or Group
+is no longer available, the status ({{object-status}}) indicates that.
+A SUBSCRIBE_UPDATE could narrow a subscription and it could make sense to skip
+over ranges of Objects. In this case, a publisher MAY reset the existing stream
+and start sending on a new one, with the same Subscribe ID.  Publishers MUST NOT
+skip Objects otherwise.
 
 Latest (0x2): Objects from the most recent Group SHOULD be delivered first,
 in ascending Object ID order when possible, unless indicated otherwise by


### PR DESCRIPTION
Takes an opinionated approach to adding 'Fetch' style functionality within the existing mechanisms.

Can be split up if people prefer.

Pulls in concepts from #411, #428 and #449 (Delivery Timeout)

Fixes #269
Fixes #326
Fixes #350
Fixes #396 
Fixes #419
Fixes #431 
Fixes #442

Relevant to #422, because we can omit the Object ID for 'In Order' delivery mode.

Closes #421
Closes #449