### PR TITLE
Updated Terminology

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -185,7 +185,7 @@ Original Publisher:
 
 End Subscriber:
 
-: A subscriber that independently initiates a subscription.
+: A subscriber that initiates a subscription and does not send the data on to other subscribers.
 
 Relay:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -173,7 +173,7 @@ Endpoint:
 
 Publisher:
 
-: An endpoint that sends tracks.
+: An endpoint that handles subscriptions by sending requested Objects from the requested track.
 
 Subscriber:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1310,8 +1310,8 @@ group is being sent on.
 
 ### Object Message Formats
 
-Every Track has a single 'Object Forwarding Preference' the Original Publisher
-MUST NOT mix different forwarding preferences within a single track.
+Every Track has a single 'Object Forwarding Preference' and the Original
+Publisher MUST NOT mix different forwarding preferences within a single track.
 If a subscriber receives different forwarding preferences for a track, it
 SHOULD close the session with an error of 'Protocol Violation'.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -181,7 +181,7 @@ Subscriber:
 
 Original Publisher:
 
-: The first publisher of a given track.
+: The initial publisher of a given track.
 
 End Subscriber:
 


### PR DESCRIPTION
Replaces producer/consumer with publisher/subscriber, and introduces new terms for the Original Publisher, End Subscriber and relay.  Also replaced some instances of sender/receiver with publisher/subscriber, except instances that were referring to a particular message.

Added Upstream and Downstream to the definitions section.  Upstream has two uses so far and downstream has none.

Fixes: #157
Fixes: #229
Fixes: #438