### PR TITLE
Add MAX_CACHE_DURATION to SUBSCRIBE_OK Params

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1558,7 +1558,8 @@ The following property is defined in this document:
 MAX_CACHE_DURATION: An integer expressing a number of milliseconds. If
 present, the relay MUST NOT start forwarding any individual Object received
 through this subscription after the specified number of seconds has elapsed
-since the beginning of the Object was received.
+since the beginning of the Object was received.  This means Objects earlier
+in a stream will expire earlier than Objects later in the stream.
 
 ## SUBSCRIBE_ERROR {#message-subscribe-error}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1595,8 +1595,7 @@ is only present if ContentExists has a value of 1.
 * Largest Object ID: The largest Object ID available within the largest Group ID
 for this track. This field is only present if ContentExists has a value of 1.
 
-* Subscribe Parameters: Optional key-value pairs formatted as described in
-{{version-specific-params}}.
+* Subscribe Parameters: The parameters are defined in {{version-specific-params}}.
 
 
 ## SUBSCRIBE_ERROR {#message-subscribe-error}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1521,7 +1521,9 @@ SUBSCRIBE_OK
   Expires (i),
   ContentExists (f),
   [Largest Group ID (i)],
-  [Largest Object ID (i)]
+  [Largest Object ID (i)],
+  Number of Subscription Parameters (i),
+  Subscription Parameters (..) ...
 }
 ~~~
 {: #moq-transport-subscribe-ok format title="MOQT SUBSCRIBE_OK Message"}
@@ -1537,12 +1539,26 @@ end prior to the expiry time or last longer.
 If 0, then the Largest Group ID and Largest Object ID fields will not be
 present.
 
-* Largest Group ID: the largest Group ID available for this track. This field
+* Largest Group ID: The largest Group ID available for this track. This field
 is only present if ContentExists has a value of 1.
 
-* Largest Object ID: the largest Object ID available within the largest Group ID
+* Largest Object ID: The largest Object ID available within the largest Group ID
 for this track. This field is only present if ContentExists has a value of 1.
 
+* Subscription Parameters: Optional key-value pairs formatted as described in
+{{params}}.
+
+### Subscription Parameters  {#subscription-parameters}
+
+SUBSCRIBE_OK may contain zero or more parameters describing either the
+properties of the track, or the properties of an individual subscription.
+
+The following property is defined in this document:
+
+MAX_CACHE_DURATION: An integer expressing a number of milliseconds. If
+present, the relay MUST NOT start forwarding any individual Object received
+through this subscription after the specified number of seconds has elapsed
+since the beginning of the Object was received.
 
 ## SUBSCRIBE_ERROR {#message-subscribe-error}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1564,7 +1564,7 @@ properties of the track, or the properties of an individual subscription.
 
 The following property is defined in this document:
 
-MAX_CACHE_DURATION: An integer expressing a number of milliseconds. If
+MAX_CACHE_DURATION (key 0x01): An integer expressing a number of milliseconds. If
 present, the relay MUST NOT start forwarding any individual Object received
 through this subscription after the specified number of milliseconds has elapsed
 since the beginning of the Object was received.  This means Objects earlier

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1580,6 +1580,8 @@ present, the relay MUST NOT start forwarding any individual Object received
 through this subscription after the specified number of milliseconds has elapsed
 since the beginning of the Object was received.  This means Objects earlier
 in a multi-object stream will expire earlier than Objects later in the stream.
+Once Objects have expired, their state becomes unknown, and a relay that
+handles a subscription that includes those Objects re-requests them.
 
 ## SUBSCRIBE_ERROR {#message-subscribe-error}
 
@@ -1695,6 +1697,7 @@ TRACK_STATUS Message {
   Status Code (i),
   Last Group ID (i),
   Last Object ID (i),
+  
 }
 ~~~
 {: #moq-track-status-format title="MOQT TRACK_STATUS Message"}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1597,7 +1597,6 @@ for this track. This field is only present if ContentExists has a value of 1.
 
 * Subscribe Parameters: The parameters are defined in {{version-specific-params}}.
 
-
 ## SUBSCRIBE_ERROR {#message-subscribe-error}
 
 A publisher sends a SUBSCRIBE_ERROR control message in response to a

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1697,7 +1697,6 @@ TRACK_STATUS Message {
   Status Code (i),
   Last Group ID (i),
   Last Object ID (i),
-  
 }
 ~~~
 {: #moq-track-status-format title="MOQT TRACK_STATUS Message"}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1559,7 +1559,7 @@ MAX_CACHE_DURATION: An integer expressing a number of milliseconds. If
 present, the relay MUST NOT start forwarding any individual Object received
 through this subscription after the specified number of seconds has elapsed
 since the beginning of the Object was received.  This means Objects earlier
-in a stream will expire earlier than Objects later in the stream.
+in a multi-object stream will expire earlier than Objects later in the stream.
 
 ## SUBSCRIBE_ERROR {#message-subscribe-error}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1577,7 +1577,7 @@ The following property is defined in this document:
 
 MAX_CACHE_DURATION: An integer expressing a number of milliseconds. If
 present, the relay MUST NOT start forwarding any individual Object received
-through this subscription after the specified number of seconds has elapsed
+through this subscription after the specified number of milliseconds has elapsed
 since the beginning of the Object was received.  This means Objects earlier
 in a multi-object stream will expire earlier than Objects later in the stream.
 


### PR DESCRIPTION
A tweaked version of #448 

Fixes #440
Fixes #249

Closes #450 
Closes #448

I'll note that we might want to add params to TRACK_STATUS and allow this to be returned from that as well, which would allow a relay to keep it in its cache.

Attempts to write down where we ended up at the end of the June 12th interim.