### PR TITLE
Add Priority and Group Send Order to SUBSCRIBE, clarify Publisher Priority

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -545,10 +545,10 @@ subscribed Objects.
 
 The subscriber indicates the priority of a subscription via the
 Subscriber Priority field and the original publisher indicates priority
-in every stream header.  As such, the subscriber's priority is a property
-of the subscription and the original publisher's priority is a property
-of the Track and the Objects it contains. In both cases, a lower value
-indicates a higher priority, with 0 being the highest priority.
+in every stream or datagram header.  As such, the subscriber's priority is a
+property of the subscription and the original publisher's priority is a
+property of the Track and the Objects it contains. In both cases, a lower
+value indicates a higher priority, with 0 being the highest priority.
 
 The Subscriber Priority is considered first when selecting
 a subscription to send data on within a given session. The original

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1094,7 +1094,6 @@ SUBSCRIBE_UPDATE Message {
   EndGroup (i),
   EndObject (i),
   Subscriber Priority (8),
-  Group Order (8),
   Number of Parameters (i),
   Subscribe Parameters (..) ...
 }
@@ -1117,11 +1116,6 @@ requested.
 * Subscriber Priority: Specifies the priority of a subscription relative to
 other subscriptions in the same session. Lower numbers get higher priority.
 See {{priorities}}.
-
-* Group Order: Allows the subscriber to request Objects be delivered in
-Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
-A value of 0x0 indicates the original publisher's Group Order SHOULD be
-used. Values larger than 0x2 are a protocol error.
 
 * Subscribe Parameters: The parameters are defined in {{version-specific-params}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -564,7 +564,7 @@ The subscriber's priority can be changed via a SUBSCRIBE_UPDATE message.
 
 In addition, SUBSCRIBE specifies a Delivery Order of either
 'Ascending' or 'Descending', which indicates whether the lowest or
-highest Group Id SHOULD be delivered first when multiple Groups are
+highest Group Id SHOULD be sent first when multiple Groups are
 available to send.
 
 Within the same group, and the same priority level,

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -550,15 +550,16 @@ property of the subscription and the original publisher's priority is a
 property of the Track and the Objects it contains. In both cases, a lower
 value indicates a higher priority, with 0 being the highest priority.
 
-The Subscriber Priority is considered first when selecting
-a subscription to send data on within a given session. When two or more tracks
+The Subscriber Priority is considered first when selecting a subscription
+to send data on within a given session. When two or more subscriptions
 have equal subscriber priority, the original publisher priority is considered
 next and can change within the track, so subscriptions are prioritized based
 on the highest priority data available to send. For example, if the subscription
 had data at priority 6 and priority 10 to send, the subscription priority would
 be 6. When both the subscriber and original publisher priorities for a
-subscription are equal, send order is implementation-dependent, but the
-expectation is that all subscriptions will be able to send some data.
+subscription are equal, how much data to send from each subscription is
+implementation-dependent, but the expectation is that all subscriptions will
+be able to send some data.
 
 The subscriber's priority can be changed via a SUBSCRIBE_UPDATE message.
 This updates the priority of all unsent data within the subscription,

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -85,7 +85,7 @@ discovery and subscription.
 
 * {{session}} covers aspects of setting up a MOQT session.
 
-* {{priority}} covers mechanisms for prioritizing subscriptions.
+* {{priorities}} covers mechanisms for prioritizing subscriptions.
 
 * {{relays-moq}} covers behavior at the relay entities.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -561,6 +561,8 @@ subscription are equal, send order is implementation-dependent, but the
 expectation is that all subscriptions will be able to send some data.
 
 The subscriber's priority can be changed via a SUBSCRIBE_UPDATE message.
+This updates the priority of all unsent data within the subscription,
+though the details of the reprioitization are implementation-specific.
 
 In addition, SUBSCRIBE or SUBSCRIBE_OK specifies a Group Order of
 either 'Ascending' or 'Descending', which indicates whether the lowest or

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -551,12 +551,12 @@ property of the Track and the Objects it contains. In both cases, a lower
 value indicates a higher priority, with 0 being the highest priority.
 
 The Subscriber Priority is considered first when selecting
-a subscription to send data on within a given session. The original
-publisher priority is considered next and can change within the track,
-so subscriptions are prioritized based on the highest priority data
-available to send. For example, if the subscription had data at
-priority 6 and priority 10 to send, the subscription priority would be 6.
-When both the subscriber and original publisher priorities for a
+a subscription to send data on within a given session. When two or more tracks
+have equal subscriber priority, the original publisher priority is considered
+next and can change within the track, so subscriptions are prioritized based
+on the highest priority data available to send. For example, if the subscription
+had data at priority 6 and priority 10 to send, the subscription priority would
+be 6. When both the subscriber and original publisher priorities for a
 subscription are equal, send order is implementation-dependent, but the
 expectation is that all subscriptions will be able to send some data.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1515,6 +1515,7 @@ SUBSCRIBE_OK
 {
   Subscribe ID (i),
   Expires (i),
+  Group Order (8),
   ContentExists (f),
   [Largest Group ID (i)],
   [Largest Object ID (i)]
@@ -1528,6 +1529,10 @@ SUBSCRIBE_OK
 longer valid. A value of 0 indicates that the subscription does not expire
 or expires at an unknown time.  Expires is advisory and a subscription can
 end prior to the expiry time or last longer.
+
+* Group Order: Indicates the subscrption will be delivered in
+Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
+Values of 0x0 and those larger than 0x2 are a protocol error.
 
 * ContentExists: 1 if an object has been published on this track, 0 if not.
 If 0, then the Largest Group ID and Largest Object ID fields will not be

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -539,6 +539,10 @@ MoQ priorities allow a subscriber and original publisher to influence
 the transmission order of Objects within a session in the presence of
 congestion.
 
+Given the critical nature of control messages and their relatively
+small size, the control stream SHOULD be prioritized higher than all
+subscribed Objects.
+
 The subscriber indicates the priority of a subscription via the
 Subscriber Priority field and the original publisher indicates priority
 in every stream header.  As such, the subscriber's priority is a property

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -539,14 +539,14 @@ MoQ priorities allow a subscriber and original publisher to influence
 the transmission order of Objects within a session in the presence of
 congestion.
 
-The subscriber can indicate the priority of a subscription via the
-SUBSCRIBER_PRIORITY param and the original publisher indicates priority
+The subscriber indicates the priority of a subscription via the
+Subscriber Priority field and the original publisher indicates priority
 in every stream header.  As such, the subscriber's priority is a property
 of the subscription and the original publisher's priority is a property
 of the Track and the Objects it contains. In both cases, a lower value
 indicates a higher priority, with 0 being the highest priority.
 
-When specified, the SUBSCRIBER_PRIORITY is considered first in selecting
+The Subscriber Priority is considered first when selecting
 a subscription to send data on within a given session.  The original
 subscriber priority can change within the track, so subscription is
 prioritized based on the highest priority data currently available to send.
@@ -570,9 +570,9 @@ Within the same group, and the same priority level,
 objects with a lower Object Id are always sent before objects with a
 higher Object Id, regardless of the specified Delivery Order.
 
-Relays SHOULD NOT directly use SUBSCRIBER_PRIORITY or Delivery Order
+Relays SHOULD NOT directly use Subscriber Priority or Delivery Order
 from incoming subscriptions for upstream subscriptions. Relays use of
-SUBSCRIBER_PRIORITY for upstream subscriptions is based on
+Subscriber Priority for upstream subscriptions is based on
 a number of factors specific to it, such as the populatity of the
 content or policy.
 
@@ -842,13 +842,6 @@ information in a SUBSCRIBE or ANNOUNCE message. This parameter is populated for
 cases where the authorization is required at the track level. The value is an
 ASCII string.
 
-#### SUBSCRIBER_PRIORITY Parameter
-
-The SUBSCRIBER_PRIORITY parameter (key 0x03) allows a subscriber to specify the
-priority of a subscription relative to other subscriptions in the same session.
-Lower numbers get higher priority and values range from 0 to 255 inclusive.
-More details on priorities are documented in {{priorities}}
-
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}
 
 The `CLIENT_SETUP` and `SERVER_SETUP` messages are the first messages exchanged
@@ -1003,6 +996,7 @@ SUBSCRIBE Message {
   Track Alias (i),
   Track Namespace (b),
   Track Name (b),
+  Priority (8),
   Delivery Order (8),
   Filter Type (i),
   [StartGroup (i),
@@ -1032,6 +1026,10 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 ({{track-name}}).
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
+
+* Subscriber Priority: Specifies the priority of a subscription relative to
+other subscriptions in the same session. Lower numbers get higher priority.
+More details on priorities are documented in {{priorities}}.
 
 * Delivery Order: Requests Objects for the subscription be delievered in
 Ascending (0x0) or Descending (0x1) order. See {{priorities}}.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -588,7 +588,7 @@ factors specific to it, such as the popularity of the
 content or policy, or relays can specify the same value for all
 upstream subscriptions.
 
-MoQ Sessions can span multiple namespaces, and priorities may or may not
+MoQ Sessions can span multiple namespaces, and priorities might not
 be coordinated across namespaces.  The subscriber's priority is
 considered first, so there is a mechanism for a subscriber to fix
 incompatibilities between different namespaces prioritization schemes.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -573,7 +573,7 @@ higher Object Id, regardless of the specified Delivery Order.
 Relays SHOULD NOT directly use Subscriber Priority or Delivery Order
 from incoming subscriptions for upstream subscriptions. Relays use of
 Subscriber Priority for upstream subscriptions is based on
-a number of factors specific to it, such as the populatity of the
+a number of factors specific to it, such as the popularity of the
 content or policy.
 
 MoQ Sessions can span multiple namespaces, and priorities are treated

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -549,7 +549,7 @@ indicates a higher priority, with 0 being the highest priority.
 The publisher SHOULD respect the subscriber and original publisher's
 priorities.
 
-In addition, the SUBSCRIBE specifies a Delivery Order of either
+In addition, SUBSCRIBE specifies a Delivery Order of either
 'Ascending' or 'Descending', which indicates whether the lowest or
 highest Group Id SHOULD be delivered first when multiple Groups are
 available to send.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -562,8 +562,8 @@ expectation is that all subscriptions will be able to send some data.
 
 The subscriber's priority can be changed via a SUBSCRIBE_UPDATE message.
 
-In addition, SUBSCRIBE specifies a Group Order of either
-'Ascending' or 'Descending', which indicates whether the lowest or
+In addition, SUBSCRIBE or SUBSCRIBE_OK specifies a Group Order of
+either 'Ascending' or 'Descending', which indicates whether the lowest or
 highest Group Id SHOULD be sent first when multiple Groups are
 available to send.
 
@@ -1033,9 +1033,10 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 other subscriptions in the same session. Lower numbers get higher priority.
 See {{priorities}}.
 
-* Group Order: Requests Objects for the subscription be delievered in
-Ascending (0x0) or Descending (0x1) order by group. See {{priorities}}.
-Values larger than 0x1 are a protocol error.
+* Group Order: Allows the subscriber to requests Objects be delivered in
+Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
+A value of 0x0 indicates the original publisher's Group Order SHOULD be
+used. Values larger than 0x2 are a protocol error.
 
 * Filter Type: Identifies the type of filter, which also indicates whether
 the StartGroup/StartObject and EndGroup/EndObject fields will be present.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -588,9 +588,6 @@ possibly part of the same application.  In cases when pooling among
 namespaces is expected to cause issues, multiple MoQ sessions, either
 within a single connection or on multiple connections can be used.
 
-## Priority Algorithm
-
-
 
 # Relays {#relays-moq}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -573,6 +573,9 @@ Within the same group, and the same priority level,
 objects with a lower Object Id are always sent before objects with a
 higher Object Id, regardless of the specified Group Order.
 
+The Group Order cannot be changed via a SUBSCRIBE_UPDATE message, and
+instead an UNSUBSCRIBE and SUBSCRIBE can be used.
+
 Relays SHOULD respect the subscriber and original publisher's priorities.
 Relays SHOULD NOT directly use Subscriber Priority or Group Order
 from incoming subscriptions for upstream subscriptions. Relays use of

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -541,10 +541,13 @@ congestion.
 
 The subscriber can indicate the priority of a subscription via the
 SUBSCRIBER_PRIORITY param and the original publisher indicates priority
-in every stream header.  In both cases, a lower value indicates a
-higher priority, with 0 being the highest priority.
+in every stream header.  As such, the subscriber's priority is a property
+of the subscription and the original publisher's priority is a property
+of the Track and the Objects it contains. In both cases, a lower value
+indicates a higher priority, with 0 being the highest priority.
 
-The publisher SHOULD respect the subscriber and publisher's priorities.
+The publisher SHOULD respect the subscriber and original publisher's
+priorities.
 
 In addition, the SUBSCRIBE specifies a Delivery Order of either
 'Ascending' or 'Descending', which indicates whether the lowest or

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -547,11 +547,11 @@ of the Track and the Objects it contains. In both cases, a lower value
 indicates a higher priority, with 0 being the highest priority.
 
 When specified, the SUBSCRIBER_PRIORITY is considered first in selecting
-a subscription to send data on within a given session.  The effective
-original subscriber priority is that of the highest priority data
-currently available to send for that subscription.  For example, if
-the subscription had some data at priority 6 and other data at priority
-10, then the subscription priority would be 6.
+a subscription to send data on within a given session.  The original
+subscriber priority can change within the track, so subscription is
+prioritized based on the highest priority data currently available to send.
+For example, if the subscription had some data at priority 6 and other data
+at priority 10, then the subscription priority would be 6.
 
 The subscriber's priority can be changed via a SUBSCRIBE_UPDATE message.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1032,7 +1032,7 @@ other subscriptions in the same session. Lower numbers get higher priority.
 See {{priorities}}.
 
 * Delivery Order: Requests Objects for the subscription be delievered in
-Ascending (0x0) or Descending (0x1) order. See {{priorities}}.
+Ascending (0x0) or Descending (0x1) order by group. See {{priorities}}.
 Values larger than 0x1 are a protocol error.
 
 * Filter Type: Identifies the type of filter, which also indicates whether

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -597,9 +597,7 @@ similar in functionality to Content Delivery Networks
 (CDNs). Additionally, relays serve as policy enforcement points by
 validating subscribe and publish requests at the edge of a network.
 
-Relays are not required to cache Objects, but relays need to have
-the ability to distribute one upstream subscription to multiple
-downstream subscriptions.
+Relays can cache Objects, but are not required to.
 
 ## Subscriber Interactions
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1033,7 +1033,7 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 other subscriptions in the same session. Lower numbers get higher priority.
 See {{priorities}}.
 
-* Group Order: Allows the subscriber to requests Objects be delivered in
+* Group Order: Allows the subscriber to request Objects be delivered in
 Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
 A value of 0x0 indicates the original publisher's Group Order SHOULD be
 used. Values larger than 0x2 are a protocol error.
@@ -1089,6 +1089,7 @@ SUBSCRIBE_UPDATE Message {
   EndGroup (i),
   EndObject (i),
   Subscriber Priority (8),
+  Group Order (8),
   Number of Parameters (i),
   Subscribe Parameters (..) ...
 }
@@ -1111,6 +1112,11 @@ requested.
 * Subscriber Priority: Specifies the priority of a subscription relative to
 other subscriptions in the same session. Lower numbers get higher priority.
 See {{priorities}}.
+
+* Group Order: Allows the subscriber to request Objects be delivered in
+Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
+A value of 0x0 indicates the original publisher's Group Order SHOULD be
+used. Values larger than 0x2 are a protocol error.
 
 * Subscribe Parameters: The parameters are defined in {{version-specific-params}}.
 
@@ -1530,7 +1536,7 @@ longer valid. A value of 0 indicates that the subscription does not expire
 or expires at an unknown time.  Expires is advisory and a subscription can
 end prior to the expiry time or last longer.
 
-* Group Order: Indicates the subscrption will be delivered in
+* Group Order: Indicates the subscription will be delivered in
 Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
 Values of 0x0 and those larger than 0x2 are a protocol error.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -534,32 +534,19 @@ expects more OBJECTs to be delivered. The server closes the session with a
 'GOAWAY Timeout' if the client doesn't close the session quickly enough.
 
 
-# Prioritization and Congestion Response {#priority-congestion}
-
-TODO: This is a placeholder section to capture details on how the MOQT
-protocol deals with prioritization and congestion overall.
-
-This section is expected to cover details on:
-
-- Prioritization Schemes.
-- Congestion Algorithms and impacts.
-- Mapping considerations for one object per stream vs multiple objects
-  per stream.
-- Considerations for merging multiple streams across domains onto single
-  connection and interactions with specific prioritization schemes.
-
-## Priorities {#priorities}
+# Priorities {#priorities}
 
 MoQ priorities allow a subscriber and original publisher to influence
 the transmission order of Objects within a session in the presence of
 congestion.
 
-The subscriber can optionally indicate a priority in a SUBSCRIBE and
-the original publisher indicates a priority within every stream header.
+The subscriber can indicate the priority of a subscription via the
+SUBSCRIBER_PRIORITY param and the original publisher indicates priority
+in every stream header.
 
 The publisher SHOULD respect the subscriber and publisher's priorities.
 
-In addition, the SUBSCRIBE specifies a delivery_order of either
+In addition, the SUBSCRIBE specifies a Delivery Order of either
 'Ascending' or 'Descending', which indicates whether the lowest or
 highest Group Id SHOULD be delivered first when multiple Groups are
 available to send.
@@ -568,6 +555,11 @@ Within the same group, and the same priority level,
 objects with a lower Object Id are always sent before objects with a
 higher Object Id, regardless of the specified delivery_order.
 
+Relays SHOULD NOT directly use SUBSCRIBER_PRIORITY or Delivery Order 
+from incoming subscriptions for upstream subscriptions. Relays use of
+SUBSCRIBER_PRIORITY for upstream subscriptions is based on
+a number of factors specific to it, such as the populatity of the
+content or policy.
 
 # Relays {#relays-moq}
 
@@ -576,6 +568,10 @@ architecture. Relays can be used to form an overlay delivery network,
 similar in functionality to Content Delivery Networks
 (CDNs). Additionally, relays serve as policy enforcement points by
 validating subscribe and publish requests at the edge of a network.
+
+Relays are not required to cache Objects, but relays need to have
+the ability to distribute one upstream subscription to multiple
+downstream subscriptions.
 
 ## Subscriber Interactions
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -825,7 +825,7 @@ ASCII string.
 The SUBSCRIBER_PRIORITY parameter (key 0x03) allows a subscriber to specify the
 priority of a subscription relative to other subscriptions in the same session.
 Lower numbers get higher priority and values range from 0 to 255 inclusive.
-More details on priorities are documented in {{}}
+More details on priorities are documented in {{priorities}}
 
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -546,6 +546,15 @@ of the subscription and the original publisher's priority is a property
 of the Track and the Objects it contains. In both cases, a lower value
 indicates a higher priority, with 0 being the highest priority.
 
+When specified, the SUBSCRIBER_PRIORITY is considered first in selecting
+a subscription to send data on within a given session.  The effective
+original subscriber priority is that of the highest priority data
+currently available to send for that subscription.  For example, if
+the subscription had some data at priority 6 and other data at priority
+10, then the subscription priority would be 6.
+
+The subscriber's priority can be changed via a SUBSCRIBE_UPDATE message.
+
 The publisher SHOULD respect the subscriber and original publisher's
 priorities.
 
@@ -564,7 +573,7 @@ SUBSCRIBER_PRIORITY for upstream subscriptions is based on
 a number of factors specific to it, such as the populatity of the
 content or policy.
 
-MoQ Sessions can span multiple namespaces, but priorities are treated
+MoQ Sessions can span multiple namespaces, and priorities are treated
 equally, regardless of the namespace.  The subscriber's priority is
 considered first, so there is no incentive for the original publisher
 to attempt to prioritize all of its Tracks higher than another
@@ -573,6 +582,10 @@ are present within a session, the namespaces could be coordinating,
 possibly part of the same application.  In cases when pooling among
 namespaces is expected to cause issues, multiple MoQ sessions, either
 within a single connection or on multiple connections can be used.
+
+## Priority Algorithm
+
+
 
 # Relays {#relays-moq}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -554,7 +554,7 @@ Within the same group, and the same priority level,
 objects with a lower Object Id are always sent before objects with a
 higher Object Id, regardless of the specified delivery_order.
 
-Relays SHOULD NOT directly use SUBSCRIBER_PRIORITY or Delivery Order 
+Relays SHOULD NOT directly use SUBSCRIBER_PRIORITY or Delivery Order
 from incoming subscriptions for upstream subscriptions. Relays use of
 SUBSCRIBER_PRIORITY for upstream subscriptions is based on
 a number of factors specific to it, such as the populatity of the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -562,17 +562,17 @@ expectation is that all subscriptions will be able to send some data.
 
 The subscriber's priority can be changed via a SUBSCRIBE_UPDATE message.
 
-In addition, SUBSCRIBE specifies a Delivery Order of either
+In addition, SUBSCRIBE specifies a Group Order of either
 'Ascending' or 'Descending', which indicates whether the lowest or
 highest Group Id SHOULD be sent first when multiple Groups are
 available to send.
 
 Within the same group, and the same priority level,
 objects with a lower Object Id are always sent before objects with a
-higher Object Id, regardless of the specified Delivery Order.
+higher Object Id, regardless of the specified Group Order.
 
 Relays SHOULD respect the subscriber and original publisher's priorities.
-Relays SHOULD NOT directly use Subscriber Priority or Delivery Order
+Relays SHOULD NOT directly use Subscriber Priority or Group Order
 from incoming subscriptions for upstream subscriptions. Relays use of
 Subscriber Priority for upstream subscriptions is based on
 a number of factors specific to it, such as the popularity of the
@@ -999,7 +999,7 @@ SUBSCRIBE Message {
   Track Namespace (b),
   Track Name (b),
   Subscriber Priority (8),
-  Delivery Order (8),
+  Group Order (8),
   Filter Type (i),
   [StartGroup (i),
    StartObject (i)],
@@ -1033,7 +1033,7 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 other subscriptions in the same session. Lower numbers get higher priority.
 See {{priorities}}.
 
-* Delivery Order: Requests Objects for the subscription be delievered in
+* Group Order: Requests Objects for the subscription be delievered in
 Ascending (0x0) or Descending (0x1) order by group. See {{priorities}}.
 Values larger than 0x1 are a protocol error.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -85,8 +85,7 @@ discovery and subscription.
 
 * {{session}} covers aspects of setting up a MOQT session.
 
-* {{priority-congestion}} covers protocol considerations on
-  prioritization schemes and congestion response overall.
+* {{priority}} covers mechanisms for prioritizing subscriptions.
 
 * {{relays-moq}} covers behavior at the relay entities.
 
@@ -681,12 +680,6 @@ fields, such as priority order and other metadata properties in the
 OBJECT message header. Unless determined by congestion response, Relays
 MUST forward the OBJECT message to the matching subscribers.
 
-## Congestion Response at Relays
-
-TODO: Refer to {{priority-congestion}}. Add details to describe relay
-behavior when merging or splitting streams and interactions with
-congestion response.
-
 ## Relay Object Handling
 
 MOQT encodes the delivery information for a stream via OBJECT headers
@@ -695,8 +688,7 @@ forwarding.
 
 A relay MUST treat the object payload as opaque.  A relay MUST NOT
 combine, split, or otherwise modify object payloads.  A relay SHOULD
-prioritize streams ({{priority-congestion}}) based on the send
-order/priority.
+prioritize sending Objects based on {{priorities}}.
 
 A publisher SHOULD begin sending incomplete objects when available to
 avoid incurring additional latency.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -556,13 +556,23 @@ available to send.
 
 Within the same group, and the same priority level,
 objects with a lower Object Id are always sent before objects with a
-higher Object Id, regardless of the specified delivery_order.
+higher Object Id, regardless of the specified Delivery Order.
 
 Relays SHOULD NOT directly use SUBSCRIBER_PRIORITY or Delivery Order
 from incoming subscriptions for upstream subscriptions. Relays use of
 SUBSCRIBER_PRIORITY for upstream subscriptions is based on
 a number of factors specific to it, such as the populatity of the
 content or policy.
+
+MoQ Sessions can span multiple namespaces, but priorities are treated
+equally, regardless of the namespace.  The subscriber's priority is
+considered first, so there is no incentive for the original publisher
+to attempt to prioritize all of its Tracks higher than another
+namespace.  Additionally, it is anticipated that when multiple namespaces
+are present within a session, the namespaces could be coordinating,
+possibly part of the same application.  In cases when pooling among
+namespaces is expected to cause issues, multiple MoQ sessions, either
+within a single connection or on multiple connections can be used.
 
 # Relays {#relays-moq}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -551,7 +551,10 @@ a subscription to send data on within a given session.  The original
 subscriber priority can change within the track, so subscription is
 prioritized based on the highest priority data currently available to send.
 For example, if the subscription had some data at priority 6 and other data
-at priority 10, then the subscription priority would be 6.
+at priority 10, then the subscription priority would be 6.  When both
+the subscriber and original publisher priorities for a subscription are
+equal, send order is implmentation-depdendent, but the expectation
+is that all subscriptions will be able to send at least some data.
 
 The subscriber's priority can be changed via a SUBSCRIBE_UPDATE message.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -564,14 +564,18 @@ The subscriber's priority can be changed via a SUBSCRIBE_UPDATE message.
 This updates the priority of all unsent data within the subscription,
 though the details of the reprioitization are implementation-specific.
 
-In addition, SUBSCRIBE or SUBSCRIBE_OK specifies a Group Order of
-either 'Ascending' or 'Descending', which indicates whether the lowest or
-highest Group Id SHOULD be sent first when multiple Groups are
-available to send.
+Subscriptions have a Group Order of either 'Ascending' or 'Descending',
+which indicates whether the lowest or highest Group Id SHOULD be sent first
+when multiple Groups are available to send.  A subscriber can specify either
+'Ascending' or 'Descending' in the SUBSCRIBE message or they can specify they
+want to use the Original Publisher's Group Order, which is indicated in
+the corresponding SUBSCRIBE_OK.
 
-Within the same group, and the same priority level,
-objects with a lower Object Id are always sent before objects with a
-higher Object Id, regardless of the specified Group Order.
+Within the same Group, and the same priority level,
+Objects with a lower Object Id are always sent before objects with a
+higher Object Id, regardless of the specified Group Order. If the priority
+varies within a Group, higher priority Objects are sent before lower
+priority Objects.
 
 The Group Order cannot be changed via a SUBSCRIBE_UPDATE message, and
 instead an UNSUBSCRIBE and SUBSCRIBE can be used.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -562,9 +562,6 @@ expectation is that all subscriptions will be able to send some data.
 
 The subscriber's priority can be changed via a SUBSCRIBE_UPDATE message.
 
-The publisher SHOULD respect the subscriber and original publisher's
-priorities.
-
 In addition, SUBSCRIBE specifies a Delivery Order of either
 'Ascending' or 'Descending', which indicates whether the lowest or
 highest Group Id SHOULD be delivered first when multiple Groups are
@@ -574,6 +571,7 @@ Within the same group, and the same priority level,
 objects with a lower Object Id are always sent before objects with a
 higher Object Id, regardless of the specified Delivery Order.
 
+Relays SHOULD respect the subscriber and original publisher's priorities.
 Relays SHOULD NOT directly use Subscriber Priority or Delivery Order
 from incoming subscriptions for upstream subscriptions. Relays use of
 Subscriber Priority for upstream subscriptions is based on

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -588,11 +588,11 @@ factors specific to it, such as the popularity of the
 content or policy, or relays can specify the same value for all
 upstream subscriptions.
 
-MoQ Sessions can span multiple namespaces, and priorities are treated
-equally, regardless of the namespace.  The subscriber's priority is
-considered first, so there is no incentive for the original publisher
-to attempt to prioritize all of its Tracks higher than another
-namespace.  Additionally, it is anticipated that when multiple namespaces
+MoQ Sessions can span multiple namespaces, and priorities may or may not
+be coordinated across namespaces.  The subscriber's priority is
+considered first, so there is a mechanism for a subscriber to fix
+incompatibilities between different namespaces prioritization schemes.
+Additionally, it is anticipated that when multiple namespaces
 are present within a session, the namespaces could be coordinating,
 possibly part of the same application.  In cases when pooling among
 namespaces is expected to cause issues, multiple MoQ sessions, either

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -541,7 +541,8 @@ congestion.
 
 The subscriber can indicate the priority of a subscription via the
 SUBSCRIBER_PRIORITY param and the original publisher indicates priority
-in every stream header.
+in every stream header.  In both cases, a lower value indicates a
+higher priority, with 0 being the highest priority.
 
 The publisher SHOULD respect the subscriber and publisher's priorities.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -547,14 +547,14 @@ of the Track and the Objects it contains. In both cases, a lower value
 indicates a higher priority, with 0 being the highest priority.
 
 The Subscriber Priority is considered first when selecting
-a subscription to send data on within a given session.  The original
-subscriber priority can change within the track, so subscription is
-prioritized based on the highest priority data currently available to send.
-For example, if the subscription had some data at priority 6 and other data
-at priority 10, then the subscription priority would be 6.  When both
-the subscriber and original publisher priorities for a subscription are
-equal, send order is implmentation-depdendent, but the expectation
-is that all subscriptions will be able to send at least some data.
+a subscription to send data on within a given session. The original
+publisher priority is considered next and can change within the track,
+so subscriptions are prioritized based on the highest priority data
+available to send. For example, if the subscription had data at
+priority 6 and priority 10 to send, the subscription priority would be 6.
+When both the subscriber and original publisher priorities for a
+subscription are equal, send order is implementation-dependent, but the
+expectation is that all subscriptions will be able to send some data.
 
 The subscriber's priority can be changed via a SUBSCRIBE_UPDATE message.
 
@@ -996,7 +996,7 @@ SUBSCRIBE Message {
   Track Alias (i),
   Track Namespace (b),
   Track Name (b),
-  Priority (8),
+  Subscriber Priority (8),
   Delivery Order (8),
   Filter Type (i),
   [StartGroup (i),
@@ -1029,7 +1029,7 @@ close the session with a Duplicate Track Alias error ({{session-termination}}).
 
 * Subscriber Priority: Specifies the priority of a subscription relative to
 other subscriptions in the same session. Lower numbers get higher priority.
-More details on priorities are documented in {{priorities}}.
+See {{priorities}}.
 
 * Delivery Order: Requests Objects for the subscription be delievered in
 Ascending (0x0) or Descending (0x1) order. See {{priorities}}.
@@ -1085,6 +1085,7 @@ SUBSCRIBE_UPDATE Message {
   StartObject (i),
   EndGroup (i),
   EndObject (i),
+  Subscriber Priority (8),
   Number of Parameters (i),
   Subscribe Parameters (..) ...
 }
@@ -1103,6 +1104,10 @@ open-ended.
 
 * EndObject: The end Object ID, plus 1. A value of 0 means the entire group is
 requested.
+
+* Subscriber Priority: Specifies the priority of a subscription relative to
+other subscriptions in the same session. Lower numbers get higher priority.
+See {{priorities}}.
 
 * Subscribe Parameters: The parameters are defined in {{version-specific-params}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -583,9 +583,10 @@ instead an UNSUBSCRIBE and SUBSCRIBE can be used.
 Relays SHOULD respect the subscriber and original publisher's priorities.
 Relays SHOULD NOT directly use Subscriber Priority or Group Order
 from incoming subscriptions for upstream subscriptions. Relays use of
-Subscriber Priority for upstream subscriptions is based on
-a number of factors specific to it, such as the popularity of the
-content or policy.
+Subscriber Priority for upstream subscriptions can be based on
+factors specific to it, such as the popularity of the
+content or policy, or relays can specify the same value for all
+upstream subscriptions.
 
 MoQ Sessions can span multiple namespaces, and priorities are treated
 equally, regardless of the namespace.  The subscriber's priority is

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1219,8 +1219,8 @@ A canonical MoQ Object has the following information:
 IDs starts at 0, increasing sequentially for each object within the
 group.
 
-* Priority: An 8 bit integer indicating the publisher's priority for the Object
-{{priorities}}.
+* Publisher Priority: An 8 bit integer indicating the publisher's priority for
+the Object {{priorities}}.
 
 * Object Forwarding Preference: An enumeration indicating how a publisher sends
 an object. The preferences are Track, Group, Object and Datagram.  An Object
@@ -1301,7 +1301,7 @@ OBJECT_STREAM Message {
   Track Alias (i),
   Group ID (i),
   Object ID (i),
-  Priority (8),
+  Publisher Priority (8),
   Object Status (i),
   Object Payload (..),
 }
@@ -1338,7 +1338,7 @@ OBJECT_DATAGRAM Message {
   Track Alias (i),
   Group ID (i),
   Object ID (i),
-  Priority (8),
+  Publisher Priority (8),
   Object Status (i),
   Object Payload (..),
 }
@@ -1370,7 +1370,7 @@ stream header.
 STREAM_HEADER_TRACK Message {
   Subscribe ID (i)
   Track Alias (i),
-  Priority (8),
+  Publisher Priority (8),
 }
 ~~~
 {: #stream-header-track-format title="MOQT STREAM_HEADER_TRACK Message"}
@@ -1410,7 +1410,7 @@ STREAM_HEADER_GROUP Message {
   Subscribe ID (i),
   Track Alias (i),
   Group ID (i),
-  Priority (8),
+  Publisher Priority (8),
 }
 ~~~
 {: #stream-header-group-format title="MOQT STREAM_HEADER_GROUP Message"}
@@ -1445,7 +1445,7 @@ Sending a track on one stream:
 STREAM_HEADER_TRACK {
   Subscribe ID = 1
   Track Alias = 1
-  Priority = 0
+  Publisher Priority = 0
 }
 {
   Group ID = 0
@@ -1471,7 +1471,7 @@ STREAM_HEADER_GROUP {
   Subscribe ID = 2
   Track Alias = 2
   Group ID = 0
-  Priority = 0
+  Publisher Priority = 0
 }
 {
   Object ID = 0


### PR DESCRIPTION
Adds a SUBSCRIBER_PRIORITY param that can be specified in SUBSCRIBE or SUBSCRIBE_UPDATE to indicate subscriber priority.  Adds Group Order to SUBSCRIBE to allow indicating Ascending or Descending.  Cleans up the existing priorities section and how Original Subscriber driven priorities are used.

Fixes #326 
Fixes #396 
Fixes #403
Fixes #419 

Closes #445