### PR TITLE
Invalid SUBSCRIBE_UPDATE is a Protocol Violation

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1080,8 +1080,8 @@ there is no guarantee that a publisher will not have already sent Objects before
 the new start Object.  The end Object MUST NOT increase and when it decreases,
 there is no guarantee that a publisher will not have already sent Objects after
 the new end Object. A publisher SHOULD close the Session as a 'Protocol Violation'
-if the SUBSCRIBE_UPDATE violates either rule or if the subscriber specifies a Subscribe
-ID that has never existed within the Session.
+if the SUBSCRIBE_UPDATE violates either rule or if the subscriber specifies a
+Subscribe ID that does not exist within the Session.
 
 Unlike a new subscription, SUBSCRIBE_UPDATE can not cause an Object to be
 delivered multiple times.  Like SUBSCRIBE, EndGroup and EndObject MUST specify the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1079,8 +1079,9 @@ subscription can be made. The start Object MUST NOT decrease and when it increas
 there is no guarantee that a publisher will not have already sent Objects before
 the new start Object.  The end Object MUST NOT increase and when it decreases,
 there is no guarantee that a publisher will not have already sent Objects after
-the new end Object. A publisher SHOULD close the Session with an error of
-'Protocol Violation' if the SUBSCRIBE_UPDATE violates either rule.
+the new end Object. A publisher SHOULD close the Session as a 'Protocol Violation'
+if the SUBSCRIBE_UPDATE violates either rule or if it specifies a Subscribe ID
+that has never existed within the Session.
 
 Unlike a new subscription, SUBSCRIBE_UPDATE can not cause an Object to be
 delivered multiple times.  Like SUBSCRIBE, EndGroup and EndObject MUST specify the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1079,7 +1079,8 @@ subscription can be made. The start Object MUST NOT decrease and when it increas
 there is no guarantee that a publisher will not have already sent Objects before
 the new start Object.  The end Object MUST NOT increase and when it decreases,
 there is no guarantee that a publisher will not have already sent Objects after
-the new end Object.
+the new end Object. A publisher SHOULD close the Session with an error of
+'Protocol Violation' if the SUBSCRIBE_UPDATE violates either rule.
 
 Unlike a new subscription, SUBSCRIBE_UPDATE can not cause an Object to be
 delivered multiple times.  Like SUBSCRIBE, EndGroup and EndObject MUST specify the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1080,8 +1080,8 @@ there is no guarantee that a publisher will not have already sent Objects before
 the new start Object.  The end Object MUST NOT increase and when it decreases,
 there is no guarantee that a publisher will not have already sent Objects after
 the new end Object. A publisher SHOULD close the Session as a 'Protocol Violation'
-if the SUBSCRIBE_UPDATE violates either rule or if it specifies a Subscribe ID
-that has never existed within the Session.
+if the SUBSCRIBE_UPDATE violates either rule or if the subscriber specifies a Subscribe
+ID that has never existed within the Session.
 
 Unlike a new subscription, SUBSCRIBE_UPDATE can not cause an Object to be
 delivered multiple times.  Like SUBSCRIBE, EndGroup and EndObject MUST specify the


### PR DESCRIPTION
This case seems easily avoidable by a subscriber, so the simplest option is to close the session.

Fixes #455
Fixes #467