### PR TITLE
Add an explicit length to OBJECT_STREAM and OBJECT_DATAGRAM

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1300,8 +1300,7 @@ SHOULD close the session with an error of 'Protocol Violation'.
 
 **Object Stream Message**
 
-An `OBJECT_STREAM` message carries a single object on a stream.  There is no
-explicit length of the payload; it is determined by the end of the stream.  An
+An `OBJECT_STREAM` message carries a single object on a stream.  An
 `OBJECT_STREAM` message MUST be the first and only message on a unidirectional
 stream.
 
@@ -1318,7 +1317,8 @@ OBJECT_STREAM Message {
   Group ID (i),
   Object ID (i),
   Publisher Priority (8),
-  Object Status (i),
+  Object Payload Length (i),
+  [Object Status (i)],
   Object Payload (..),
 }
 ~~~
@@ -1338,8 +1338,6 @@ the subscriber MUST close the session with a Protocol Violation.
 **Object Datagram Message**
 
 An `OBJECT_DATAGRAM` message carries a single object in a datagram.
-There is no explicit length of the payload; it is determined by the
-length of the datagram.
 
 An Object received in an `OBJECT_DATAGRAM` message has an `Object
 Forwarding Preference` = `Datagram`. To send an Object with `Object
@@ -1355,7 +1353,8 @@ OBJECT_DATAGRAM Message {
   Group ID (i),
   Object ID (i),
   Publisher Priority (8),
-  Object Status (i),
+  Object Payload Length (i),
+  [Object Status (i)],
   Object Payload (..),
 }
 ~~~


### PR DESCRIPTION
This had consensus in the past, but a PR wasn't written.

Particularly now that we have Object Status, which is optional for all other mappings, it makes sense to add the length and make things consistent.

Fixes #355