### PR TITLE
At least one SUBSCRIBE_OK to return SUBSCRIBE_OK

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -625,6 +625,11 @@ the subscription, via SUBSCRIBE_OK ({{message-subscribe-ok}}) or the
 SUBSCRIBE_ERROR {{message-subscribe-error}} control message.
 The entity receiving the SUBSCRIBE MUST send only a single response to
 a given SUBSCRIBE of either SUBSCRIBE_OK or SUBSCRIBE_ERROR.
+If a relay does not already have a subscription for the track,
+or if the subscription does not cover all the requested Objects, it
+will need to make an upstream subscription.  The relay SHOULD NOT
+return a SUBCRIBE_OK until at least one SUBSCRIBE_OK has been
+received for the track, to ensure the Group Order is correct.
 
 For successful subscriptions, the publisher maintains a list of
 subscribers for each track. Each new OBJECT belonging to the
@@ -642,8 +647,8 @@ forwarding to subscribers, unless it has application specific information.
 
 Relays MAY aggregate authorized subscriptions for a given track when
 multiple subscribers request the same track. Subscription aggregation
-allows relays to make only a single forward subscription for the
-track. The published content received from the forward subscription
+allows relays to make only a single upstream subscription for the
+track. The published content received from the upstream subscription
 request is cached and shared among the pending subscribers.
 
 The application SHOULD use a relevant error code in SUBSCRIBE_ERROR,


### PR DESCRIPTION
This is a bit different from HTTP, but having at least one SUBSCRIBE_OK succeed ensures the track exists in some sense, as well as allowing a relay to populate the Group Order field.

This is intended as a clarification, but it adds normative language.