### PR TITLE
Add MAX_SUBSCRIBE_ID to limit number of subscriptions

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -958,9 +958,8 @@ the `query` portion of the URI to the parameter.
 #### MAX_SUBSCRIBE_ID {#max-subscribe-id}
 
 The MAX_SUBSCRIBE_ID parameter (key 0x02) communicates an initial value for
-the Maximum Subscribe ID the peer can use when making subscriptions.
-The default value is 0, so if not specified, the peer MUST NOT create
-subscriptions.
+the Maximum Subscribe ID to the receiving subscriber. The default value is 0,
+so if not specified, the peer MUST NOT create subscriptions.
 
 
 ## GOAWAY {#message-goaway}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -504,7 +504,7 @@ code, as defined below:
   that was already in use.
 
 * Too Many Subscribes: The session was closed because the subscriber used
-  a Subscribe ID larger than the current Maximum Subscribe ID.
+  a Subscribe ID equal or larger than the current Maximum Subscribe ID.
 
 * GOAWAY Timeout: The session was closed because the client took too long to
   close the session in response to a GOAWAY ({{message-goaway}}) message.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1651,8 +1651,8 @@ MAX_SUBSCRIBE_ID
 ~~~
 {: #moq-transport-max-subscribe-id format title="MOQT MAX_SUBSCRIBE_ID Message"}
 
-* Subscribe ID: The new Maximums Subscribe ID for the session. If a Subscribe ID
-equal or larger than this is used in any message, including SUBSCRIBE,
+* Subscribe ID: The new Maximum Subscribe ID for the session. If a Subscribe ID
+equal or larger than this is received in any message, including SUBSCRIBE,
 the publisher MUST close the session with an error of 'Too Many Subscribes'.
 More on Subscribe ID in {{message-subscribe-req}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -864,9 +864,8 @@ ASCII string.
 
 The MAX_SUBSCRIBE_ID parameter (key 0x03) communicates an initial value for
 the Maximum Subscribe ID the peer can use when making subscriptions.
-If not specified, the peer MUST NOT create subscriptions. Subscribers (0x02)
-MUST NOT specify a MAX_SUBSCIBE_ID, because the role indicates it cannot
-handle subscriptions.
+The default value is 0, so if not specified, the peer MUST NOT create
+subscriptions.
 
 
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -389,10 +389,10 @@ URI with a "moq" scheme.  The "moq" URI scheme is defined as follows,
 using definitions from {{!RFC3986}}:
 
 ~~~~~~~~~~~~~~~
-moq-URI = "moqt" "://" authority path-abempty [ "?" query ]
+moq-URI = "moqt" "://" ty path-abempty [ "?" query ]
 ~~~~~~~~~~~~~~~
 
-The `authority` portion MUST NOT contain a non-empty `host` portion.
+The `ty` portion MUST NOT contain a non-empty `host` portion.
 The `moq` URI scheme supports the `/.well-known/` path prefix defined in
 {{!RFC8615}}.
 
@@ -860,13 +860,6 @@ information in a SUBSCRIBE or ANNOUNCE message. This parameter is populated for
 cases where the authorization is required at the track level. The value is an
 ASCII string.
 
-#### MAX_SUBSCRIBE_ID {#max-subscribe-id}
-
-The MAX_SUBSCRIBE_ID parameter (key 0x03) communicates an initial value for
-the Maximum Subscribe ID the peer can use when making subscriptions.
-The default value is 0, so if not specified, the peer MUST NOT create
-subscriptions.
-
 
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}
 
@@ -922,7 +915,7 @@ identified as 0xff00000D.
 
 ### Setup Parameters {#setup-params}
 
-#### ROLE parameter {#role}
+#### ROLE {#role}
 
 The ROLE parameter (key 0x00) allows each endpoint to independently specify what
 functionality they support for the session. It has three possible values,
@@ -949,7 +942,7 @@ Both endpoints MUST send a ROLE parameter with one of the three values
 specified above. Both endpoints MUST close the session if the ROLE
 parameter is missing or is not one of the three above-specified values.
 
-#### PATH parameter {#path}
+#### PATH {#path}
 
 The PATH parameter (key 0x01) allows the client to specify the path of
 the MoQ URI when using native QUIC ({{QUIC}}).  It MUST NOT be used by
@@ -961,6 +954,14 @@ When connecting to a server using a URI with the "moq" scheme, the
 client MUST set the PATH parameter to the `path-abempty` portion of the
 URI; if `query` is present, the client MUST concatenate `?`, followed by
 the `query` portion of the URI to the parameter.
+
+#### MAX_SUBSCRIBE_ID {#max-subscribe-id}
+
+The MAX_SUBSCRIBE_ID parameter (key 0x02) communicates an initial value for
+the Maximum Subscribe ID the peer can use when making subscriptions.
+The default value is 0, so if not specified, the peer MUST NOT create
+subscriptions.
+
 
 ## GOAWAY {#message-goaway}
 The server sends a `GOAWAY` message to initiate session migration

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -404,7 +404,7 @@ The client can establish a connection to a MoQ server identified by a
 given URI by setting up a QUIC connection to the host and port
 identified by the `authority` section of the URI.  The `path-abempty`
 and `query` portions of the URI are communicated to the server using the
-PATH parameter ({{path}}) which is sent in the CLIENT_SETUP message at the
+PATH parameter ({{path}}) which is sent in the CLIENT_message at the
 start of the session.  The ALPN value {{!RFC7301}} used by the protocol
 is `moq-00`.
 
@@ -853,12 +853,21 @@ it can appear. If it appears in some other type of message, it MUST be ignored.
 Note that since Setup parameters use a separate namespace, it is impossible for
 these parameters to appear in Setup messages.
 
-#### AUTHORIZATION INFO Parameter {#authorization-info}
+#### AUTHORIZATION INFO {#authorization-info}
 
 AUTHORIZATION INFO parameter (key 0x02) identifies a track's authorization
 information in a SUBSCRIBE or ANNOUNCE message. This parameter is populated for
 cases where the authorization is required at the track level. The value is an
 ASCII string.
+
+#### MAX_SUBSCRIBE_ID {#max-subscribe-id}
+
+The MAX_SUBSCRIBE_ID parameter (key 0x03) communicates an initial value for
+the Maximum Subscribe ID the peer can use when making subscriptions.
+If not specified, the peer MUST NOT create subscriptions. Subscribers (0x02)
+MUST NOT specify a MAX_SUBSCIBE_ID, because the role indicates it cannot
+handle subscriptions.
+
 
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1651,7 +1651,7 @@ MAX_SUBSCRIBE_ID
 ~~~
 {: #moq-transport-max-subscribe-id format title="MOQT MAX_SUBSCRIBE_ID Message"}
 
-* Subscribe ID: The maximum valid Subscribe ID for the session. If a Subscribe ID
+* Subscribe ID: The new Maximums Subscribe ID for the session. If a Subscribe ID
 equal or larger than this is used in any message, including SUBSCRIBE,
 the publisher MUST close the session with an error of 'Too Many Subscribes'.
 More on Subscribe ID in {{message-subscribe-req}}.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -404,7 +404,7 @@ The client can establish a connection to a MoQ server identified by a
 given URI by setting up a QUIC connection to the host and port
 identified by the `authority` section of the URI.  The `path-abempty`
 and `query` portions of the URI are communicated to the server using the
-PATH parameter ({{path}}) which is sent in the CLIENT_message at the
+PATH parameter ({{path}}) which is sent in the CLIENT_SETUP message at the
 start of the session.  The ALPN value {{!RFC7301}} used by the protocol
 is `moq-00`.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -389,10 +389,10 @@ URI with a "moq" scheme.  The "moq" URI scheme is defined as follows,
 using definitions from {{!RFC3986}}:
 
 ~~~~~~~~~~~~~~~
-moq-URI = "moqt" "://" ty path-abempty [ "?" query ]
+moq-URI = "moqt" "://" authority path-abempty [ "?" query ]
 ~~~~~~~~~~~~~~~
 
-The `ty` portion MUST NOT contain a non-empty `host` portion.
+The `authority` portion MUST NOT contain a non-empty `host` portion.
 The `moq` URI scheme supports the `/.well-known/` path prefix defined in
 {{!RFC8615}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1652,8 +1652,8 @@ MAX_SUBSCRIBE_ID
 {: #moq-transport-max-subscribe-id format title="MOQT MAX_SUBSCRIBE_ID Message"}
 
 * Subscribe ID: The maximum valid Subscribe ID for the session. If a Subscribe ID
-larger than this is used in any message, including SUBSCRIBE, the publisher MUST
-close the session with an error of 'Too Many Subscribes'.
+equal or larger than this is used in any message, including SUBSCRIBE,
+the publisher MUST close the session with an error of 'Too Many Subscribes'.
 More on Subscribe ID in {{message-subscribe-req}}.
 
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -485,6 +485,8 @@ code, as defined below:
 |------|---------------------------|
 | 0x5  | Parameter Length Mismatch |
 |------|---------------------------|
+| 0x6  | Too Many Subscribes       |
+|------|---------------------------|
 | 0x10 | GOAWAY Timeout            |
 |------|---------------------------|
 
@@ -500,6 +502,9 @@ code, as defined below:
 
 * Duplicate Track Alias: The endpoint attempted to use a Track Alias
   that was already in use.
+
+* Too Many Subscribes: The session was closed because the subscriber used
+  a Subscribe ID larger than the current Maximum Subscribe ID.
 
 * GOAWAY Timeout: The session was closed because the client took too long to
   close the session in response to a GOAWAY ({{message-goaway}}) message.
@@ -1022,17 +1027,17 @@ SUBSCRIBE Message {
 ~~~
 {: #moq-transport-subscribe-format title="MOQT SUBSCRIBE Message"}
 
-* Subscribe ID: The subscription identifier that is unique within the session.
-`Subscribe ID` is a monotonically increasing variable length integer which
-MUST not be reused within a session. `Subscribe ID` is used by subscribers and
-the publishers to identify a given subscription. Subscribers specify the
-`Subscribe ID` and it is included in the corresponding SUBSCRIBE_OK or
-SUBSCRIBE_ERROR messages.
+* Subscribe ID: The subscriber specified identifier used to manage a
+subscription. `Subscribe ID` is a variable length integer that MUST be
+unique and monotonically increasing within a session and MUST be less
+than the session's Maximum Subscribe ID.
 
 * Track Alias: A session specific identifier for the track.
 Messages that reference a track, such as OBJECT ({{message-object}}),
 reference this Track Alias instead of the Track Name and Track Namespace to
-reduce overhead. If the Track Alias is already being used for a different track, the publisher MUST close the session with a Duplicate Track Alias error ({{session-termination}}).
+reduce overhead. If the Track Alias is already being used for a different
+track, the publisher MUST close the session with a Duplicate Track Alias
+error ({{session-termination}}).
 
 * Track Namespace: Identifies the namespace of the track as defined in
 ({{track-name}}).
@@ -1619,6 +1624,29 @@ message in this track.
 
 * Final Object: The largest Object ID sent by the publisher in an OBJECT
 message in the `Final Group` for this track.
+
+## MAX_SUBSCRIBE_ID {#message-max-subscribe-id}
+
+A publisher sends a MAX_SUBSCRIBE_ID message to increase the number of
+subscriptions a subscriber can create within a session.
+
+The Maximum Subscribe Id MUST only increase within a session, and
+receipt of a MAX_SUBSCRIBE_ID message with an equal or smaller Subscribe ID
+value is a 'Protocol Violation'.
+
+~~~
+MAX_SUBSCRIBE_ID
+{
+  Subscribe ID (i),
+}
+~~~
+{: #moq-transport-max-subscribe-id format title="MOQT MAX_SUBSCRIBE_ID Message"}
+
+* Subscribe ID: The maximum valid Subscribe ID for the session. If a Subscribe ID
+larger than this is used in any message, including SUBSCRIBE, the publisher MUST
+close the session with an error of 'Too Many Subscribes'.
+More on Subscribe ID in {{message-subscribe-req}}.
+
 
 ## ANNOUNCE {#message-announce}
 


### PR DESCRIPTION
Fixes #272

Some diffs are due to me reflowing text to fit the line limits, so please ignore those.

Once we have this and a limit on announce IDs, it seems likely that we'll be able to get rid of 'Role', but for now it can stay.