### PR TITLE
Remove normative restriction on relays forwarding decision input

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -717,8 +717,9 @@ the session that sent ANNOUNCE namespace=foobar.
 OBJECT message headers carry a short hop-by-hop `Track Alias` that maps to
 the Full Track Name (see {{message-subscribe-ok}}). Relays use the
 `Track Alias` of an incoming OBJECT message to identify its track and find
-the active subscribers for that track. Unless determined by congestion response,
-Relays MUST forward the OBJECT message to the matching subscribers.
+the active subscribers for that track. Relays MUST forward OBJECT messages to
+matching subscribers in accordance to each subscription's priority, group order,
+and delivery timeout.
 
 ## Relay Object Handling
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -717,11 +717,8 @@ the session that sent ANNOUNCE namespace=foobar.
 OBJECT message headers carry a short hop-by-hop `Track Alias` that maps to
 the Full Track Name (see {{message-subscribe-ok}}). Relays use the
 `Track Alias` of an incoming OBJECT message to identify its track and find
-the active subscribers for that track. Relays MUST NOT depend on OBJECT
-payload content for making forwarding decisions and MUST only depend on the
-fields, such as priority order and other metadata properties in the
-OBJECT message header. Unless determined by congestion response, Relays
-MUST forward the OBJECT message to the matching subscribers.
+the active subscribers for that track. Unless determined by congestion response,
+Relays MUST forward the OBJECT message to the matching subscribers.
 
 ## Relay Object Handling
 


### PR DESCRIPTION
I removed this sentence:

Relays MUST NOT depend on OBJECT payload content for making forwarding decisions and MUST only depend on the fields, such as priority order and other metadata properties in the OBJECT message header.

We already have text explaining that the object payload content can be encrypted (section 2.1).  I think that makes it clear that a relay can't do anything with the object payload unless it has the encryption keys or a priori knowledge they are cleartext.

The sentence itself was overly restrictive (relays could use other inputs, for example out of band information from configuration or business relationships).  The preceding sentence explains how to find subscribers to this track, the subsequent one says "MUST forward", and we have an entire section explaining what to do with priority order now.

Fixes: #217