### PR TITLE
Adding an Extensible Object Header

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2337,7 +2337,8 @@ that information is not reliable and cacheable.
 
 #### Object Extension Header {#object-extensions}
 Object Extension Headers are visible to relays and allow the transmission of
-future metadata relevant to MOQT Object distribution. Any Object metadata never accessed by the transport or relays SHOULD be serialized as part of the Object
+future metadata relevant to MOQT Object distribution. Any Object metadata never
+accessed by the transport or relays SHOULD be serialized as part of the Object
 payload and not as an extension header.
 
 Extension Headers are defined in external specifications and registered in an

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -984,13 +984,20 @@ client MUST set the PATH parameter to the `path-abempty` portion of the
 URI; if `query` is present, the client MUST concatenate `?`, followed by
 the `query` portion of the URI to the parameter.
 
-#### REQUIRED-EXTENSION parameter {#required-extensions}
+#### REQUESTED-EXTENSION parameter {#requested-extensions}
 
-The REQUIRED-EXTENSION parameter (key 0x02) allows the client to specify
-multiple Extension Header types {{object-extensions}} which are required for
-operation. The value is a concatenation of varints, each describing a
-32-bit extension header type. This parameter is optional. If the server does
-not support a requested REQUIRED-EXTENSION, then it MUST close the connection.
+The REQUESTED-EXTENSION parameter (key 0x02) allows the client to request
+the server to acknowledge support for  multiple Extension Header types
+{{object-extensions}} which are required for operation. The value is a
+concatenation of varints, each describing a 32-bit extension header type.
+This parameter is optional. If this parameter is present in the
+CLIENT_SETUP message, then the server MUST respond with a
+REQUESTED-EXTENSION parameter in its SERVER_SETUP message. This parameter
+MUST list the subset of those extensions previously requested by the client
+which the server supports. If the server does not support any of the
+requested extensions, then it MUST respond with a parameter value length of 0.
+The client can then choose to continue or disconnect the session, at its
+discretion.
 
 ## GOAWAY {#message-goaway}
 The server sends a `GOAWAY` message to initiate session migration

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1578,18 +1578,13 @@ are sent on a new stream. This is to avoid the status message being lost
 in cases such as a relay dropping a group and reseting the stream the
 group is being sent on.
 
-#### Object Extension {#object-extensions}
-An Object Extension is a concatenation of optional Extension Headers. These
-headers are visible to relays. Extension headers MUST be forwarded and
-MUST NOT be modified by relays. The purpose of Extension Headers is to
-facilitate the future evolution of the transport protocol. Object
-Extensions are serialized as defined below:
+#### Object Extension Header {#object-extensions}
+Object Extension Headers are visible to relays. Extension Headers MUST be
+forwarded and MUST NOT be modified by relays. The purpose of Extension
+Headers is to facilitate the future evolution of the transport protocol.
+Object Extension Headers are serialized as defined below:
 
 ~~~
-Object Extension {
-  Extension Header (..) ...
-}
-
 Extension Header {
   Header Type (i),
   [Header Value (i)]

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2327,9 +2327,9 @@ that information is not reliable and cacheable.
 
 #### Object Extension Header {#object-extensions}
 Object Extension Headers are visible to relays and allow the transmission of
-future metadata relevant to MOQT Object distribution. Extension Headers MUST NOT
-carry metadata bound to the Object payload. Such metadata should instead
-be serialized into the payload.
+future metadata relevant to MOQT Object distribution. Any Object metadata not
+used by the transport SHOULD be serialized as part of the Object and not as
+an extension header.
 
 Extension Headers are defined in external specifications and registered in an
 IANA table {{iana}}. These specifications define the type and value of the
@@ -2338,11 +2338,11 @@ forwarding. A relay which is coded to implement these rules is said to
 "support" the extension.
 
 If unsupported by the relay, Extension Headers MUST NOT be modified, MUST be
-cached as part of the Object and MUST be forwarded by relays
+cached as part of the Object and MUST be forwarded by relays.
 
 If supported by the relay and subject to the processing rules specified in the
-definition of the extension, Extension Headers MAY be modified, MAY be cached
-and MAY be forwarded.
+definition of the extension, Extension Headers MAY be modified, added, removed,
+and/or cached by relays.
 
 Object Extension Headers are serialized as defined below:
 
@@ -2360,9 +2360,8 @@ Extension Header {
   of the extension and also the subsequent serialization.
 * Header values: even types are followed by a single varint encoded value. Odd
   types are followed by a varint encoded length and then the header value.
-  Every integer multiple of 17 or 18 is a reserved greasing value. These types
-  MUST be treated as unsupported by a relay. Header types are registered in the
-  IANA table 'MOQ Extension Headers'. See {{iana}}.
+  Header types are registered in the IANA table 'MOQ Extension Headers'.
+  See {{iana}}.
 
 ## Object Datagram {#object-datagram}
 
@@ -2670,11 +2669,9 @@ TODO: fill out currently missing registries:
 * MOQ Extension headers - we wish to reserve extension types 0-127 for
   standards utilization where space is a premium, 128 - 16383 for
   standards utilization where space is less of a concern, and 16384 and
-  above for first-come-first-served non-standardization usage. Additionally,
-  every integer multiple of 17 or 18 is a reserved greasing value and MUST
-  NOT be registered.
+  above for first-come-first-served non-standardization usage.
 
-TODO: register the URI scheme and the ALPN
+TODO: register the URI scheme and the ALPN and grease the Extension types
 
 # Contributors
 {:numbered="false"}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1304,9 +1304,11 @@ MUST be sent according to its `Object Forwarding Preference`, described below.
 * Object Status: As enumeration used to indicate missing
 objects or mark the end of a group or track. See {{object-status}} below.
 
-* Object Extension count: the number of Object Extension Headers present. See
-  {{object-extensions}} below. A value of 0 indicates that no Object Extension
-  Headers are present.
+* Object Extension Count: The number of Object Extensions present. A value of 0
+  indicates that no Object Extension Headers are present.
+  
+* Object Extensions : an optional concatenation of Object Extension Headers. See
+  {{object-extensions}} below.
 
 * Object Payload: An opaque payload intended for an End Subscriber and SHOULD
 NOT be processed by a relay. Only present when 'Object Status' is Normal (0x0).
@@ -1356,13 +1358,11 @@ group is being sent on.
 
 #### Object Extension {#object-extensions}
 An Object Extension is a concatenation of optional Extension Headers. These
-headers are visible to relays. Extension headers specified via the
-REQUIRED-EXTENSIONS parameter {{required-extensions}} in the SETUP message
-MUST be parsed by relays. Extension headers not specified via the
-REQUIRED-EXTENSIONS parameter MAY be ignored by relays. The purpose of
-Extension Headers is to allow the transmission of application-specific
-data as well as future evolution of the transport protocol. Object
-Extensions are serialized as defined below:
+headers are visible to relays. Extension headers MUST be forwarded and
+MUST NOT be modified by relays. The purpose of Extension Headers is to
+allow the transmission of application-specific data as well as future
+evolution of the transport protocol. Object Extensions are serialized as
+defined below:
 
 ~~~
 Object Extension {

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2115,7 +2115,7 @@ objects or mark the end of a group or track. See {{object-status}} below.
 * Object Extension Count: The number of Object Extensions present. A value of 0
   indicates that no Object Extension Headers are present.
 
-* Object Extensions : an optional concatenation of Object Extension Headers. See
+* Object Extensions : A sequence of Object Extension Headers. See
   {{object-extensions}} below.
 
 * Object Payload: An opaque payload intended for an End Subscriber and SHOULD

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2327,9 +2327,8 @@ that information is not reliable and cacheable.
 
 #### Object Extension Header {#object-extensions}
 Object Extension Headers are visible to relays and allow the transmission of
-future metadata relevant to MOQT Object distribution. Any Object metadata not
-used by the transport SHOULD be serialized as part of the Object and not as
-an extension header.
+future metadata relevant to MOQT Object distribution. Any Object metadata never accessed by the transport or relays SHOULD be serialized as part of the Object
+payload and not as an extension header.
 
 Extension Headers are defined in external specifications and registered in an
 IANA table {{iana}}. These specifications define the type and value of the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1592,14 +1592,19 @@ Object Extension {
 
 Extension Header {
   Header Type (i),
-  Header Length (i),
-  Header Value (..)
+  [Header Value (i)]
+  [Header Length (i),
+   Header Value (..)]
 }
 ~~~
 {: #object-extension-format title="Object Extension Header Format"}
 
-* Header type: an unsigned integer, encoded as a varint and registered in the
-  IANA table 'MOQ Extension Headers'. See {{iana}}.
+* Header type: an unsigned integer, encoded as a varint, identifying the type
+  of extension and also the subsequent serialization. Header types in the range
+  0x00 - 0x20 inclusive are followed by a single varint encoded value. Header
+  types 0x21 and above are followed by a varint encoded length and then the
+  header value. Header types are registered in the IANA table 'MOQ Extension
+  Headers'. See {{iana}}.
 
 ### Object Message Formats
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2675,8 +2675,8 @@ TODO: fill out currently missing registries:
 * Announce Error codes
 * Announce Cancel Reason codes
 * Message types
-* MOQ Extension headers - we wish to reserve extension types 0-127 for
-  standards utilization where space is a premium, 128 - 16383 for
+* MOQ Extension headers - we wish to reserve extension types 0-63 for
+  standards utilization where space is a premium, 64 - 16383 for
   standards utilization where space is less of a concern, and 16384 and
   above for first-come-first-served non-standardization usage.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -989,7 +989,7 @@ the `query` portion of the URI to the parameter.
 The REQUESTED-EXTENSION parameter (key 0x02) allows the client to request
 the server to acknowledge support for  multiple Extension Header types
 {{object-extensions}} which are required for operation. The value is a
-concatenation of varints, each describing a 32-bit extension header type.
+concatenation of varints, each describing an integer extension header type.
 This parameter is optional. If this parameter is present in the
 CLIENT_SETUP message, then the server MUST respond with a
 REQUESTED-EXTENSION parameter in its SERVER_SETUP message. This parameter
@@ -1599,8 +1599,8 @@ Extension Header {
 ~~~
 {: #object-extension-format title="Object Extension Header Format"}
 
-* Header type: an unsigned 32-bit integer, registered in the IANA table
-  'MOQ Extension Headers'. See {{iana}}.
+* Header type: an unsigned integer, encoded as a varint and registered in the
+  IANA table 'MOQ Extension Headers'. See {{iana}}.
 
 ##### Extension Header type 0 {#extension-header-zero}
 
@@ -1919,7 +1919,10 @@ TODO: fill out currently missing registries:
 * Subscribe Error codes
 * Announce Error codes
 * Message types
-* MOQ Extension headers
+* MOQ Extension headers - we wish to reserve extension types 0-127 for
+  standards utilization where space is a premium, 128 - 16383 for
+  standards utilization where space is less of a concern, and 16384 and
+  above for first-come-first-served non-standardization usage.
 
 TODO: register the URI scheme and the ALPN
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1370,7 +1370,7 @@ Extension Header {
 {: #object-extension-format title="Object Extension Header Format"}
 
 * Header type: an unsigned 32-bit integer, registered in the IANA table
-  'MOQ Extension Headers'. See {{#iana}}.
+  'MOQ Extension Headers'. See {{iana}}.
 
 ##### Extension Header type 0 {#extension-header-zero}
 
@@ -1397,7 +1397,6 @@ Header Value {
   and is not IANA registered.
 * Payload: the contents of the header. The combined size of the name and payload
   contents MUST NOT exceed 10240 bytes.
-  
 
 ### Object Message Formats
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1178,21 +1178,6 @@ The MAX_SUBSCRIBE_ID parameter (Parameter Type 0x02) communicates an initial
 value for the Maximum Subscribe ID to the receiving subscriber. The default
 value is 0, so if not specified, the peer MUST NOT create subscriptions.
 
-#### REQUESTED-EXTENSION parameter {#requested-extensions}
-
-The REQUESTED-EXTENSION parameter (key 0x03) allows the client to request
-the server to acknowledge support for  multiple Extension Header types
-{{object-extensions}} which are required for operation. The value is a
-sequence of varints, each describing an integer extension header type.
-This parameter is optional. If this parameter is present in the
-CLIENT_SETUP message, and if the then the server MUST respond with a
-REQUESTED-EXTENSION parameter in its SERVER_SETUP message. This parameter
-MUST list the subset of those extensions previously requested by the client
-which the server supports. If the server does not support any of the
-requested extensions, then it MUST respond with a parameter value length of 0.
-The client can then choose to continue or disconnect the session, at its
-discretion.
-
 ## GOAWAY {#message-goaway}
 
 An endpoint sends a `GOAWAY` message to inform the peer it intends to close

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2157,8 +2157,8 @@ that information is not reliable and cacheable.
 
 
 #### Object Extension Header {#object-extensions}
-Object Extension Headers are visible to relays. Extension Headers MUST be
-forwarded and MUST NOT be modified by relays. The purpose of Extension
+Object Extension Headers are visible to relays. Extension Headers SHOULD be
+forwarded and SHOULD NOT be modified by relays. The purpose of Extension
 Headers is to facilitate the future evolution of the transport protocol.
 Object Extension Headers are serialized as defined below:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -485,16 +485,26 @@ PATH parameter ({{path}}) which is sent in the CLIENT_SETUP message at the
 start of the session.  The ALPN value {{!RFC7301}} used by the protocol
 is `moq-00`.
 
-## Version Negotiation {#version-negotiation}
+## Version Negotiation and Extension Negotiation {#version-negotiation}
 
-Endpoints use the exchange of Setup messages to negotiate the MOQT version.
+Endpoints use the exchange of Setup messages to negotiate the MOQT version and
+any extensions to use.
 
 The client indicates the MOQT versions it supports in the CLIENT_SETUP message
 (see {{message-setup}}). It also includes the union of all Setup Parameters
 {{setup-params}} required for a handshake by any of those versions.
 
+Within any MOQT version, clients request the use of extensions by adding Setup
+parameters corresponding to that extension. No extensions are defined in this
+document.
+
 The server replies with a SERVER_SETUP message that indicates the chosen
-version, includes all parameters required for a handshake in that version.
+version, includes all parameters required for a handshake in that version, and
+parameters for every extension requested by the client that it supports.
+
+New versions of MOQT MUST specify which existing extensions can be used with
+that version. New extensions MUST specify the existing versions with which they
+can be used.
 
 If a given parameter carries the same information in multiple versions,
 but might have different optimal values in those versions, there SHOULD be

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1521,7 +1521,7 @@ objects or mark the end of a group or track. See {{object-status}} below.
 
 * Object Extension Count: The number of Object Extensions present. A value of 0
   indicates that no Object Extension Headers are present.
-  
+
 * Object Extensions : an optional concatenation of Object Extension Headers. See
   {{object-extensions}} below.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1715,6 +1715,8 @@ The Object Status field is only sent if the Object Payload Length is zero.
 {
   Group ID (i),
   Object ID (i),
+  Extension Count (i),
+  [Extension headers (...)],
   Object Payload Length (i),
   [Object Status (i)],
   Object Payload (..),
@@ -1756,6 +1758,8 @@ The Object Status field is only sent if the Object Payload Length is zero.
 ~~~
 {
   Object ID (i),
+  Extension Count (i),
+  [Extension headers (...)],
   Object Payload Length (i),
   [Object Status (i)],
   Object Payload (..),

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -996,11 +996,10 @@ the `query` portion of the URI to the parameter.
 #### REQUIRED-EXTENSION parameter {#required-extensions}
 
 The REQUIRED-EXTENSION parameter (key 0x02) allows the client to specify
-an Extension Header type {{object-extensions}} which is required for
-operation. The value is the 32-bit type expressed as a varint. This
-parameter is optional. Multiple of these parameters may be sent in a
-SETUP message. If the server does not support a requested
-REQUIRED-EXTENSION, then it MUST close the connection.
+multiple Extension Header types {{object-extensions}} which are required for
+operation. The value is a concatenation of varints, each describing a
+32-bit extension header type. This parameter is optional. If the server does
+not support a requested REQUIRED-EXTENSION, then it MUST close the connection.
 
 ## GOAWAY {#message-goaway}
 The server sends a `GOAWAY` message to initiate session migration

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1582,9 +1582,8 @@ group is being sent on.
 An Object Extension is a concatenation of optional Extension Headers. These
 headers are visible to relays. Extension headers MUST be forwarded and
 MUST NOT be modified by relays. The purpose of Extension Headers is to
-allow the transmission of application-specific data as well as future
-evolution of the transport protocol. Object Extensions are serialized as
-defined below:
+facilitate the future evolution of the transport protocol. Object
+Extensions are serialized as defined below:
 
 ~~~
 Object Extension {
@@ -1601,32 +1600,6 @@ Extension Header {
 
 * Header type: an unsigned integer, encoded as a varint and registered in the
   IANA table 'MOQ Extension Headers'. See {{iana}}.
-
-##### Extension Header type 0 {#extension-header-zero}
-
-This specification defines a utility extension header. The value of this header
-is itself a name-value pair.
-
-
-| Type |                         Value                        |
-| ---- | ---------------------------------------------------- |
-| 0x0  | Header Value  - see {{extension-header-zero-format}} |
-
-
-~~~
-Header Value {
-  Name Length (i),
-  Name Value (..)
-  Payload (..)
-}
-~~~
-{: #extension-header-zero-format title="Extension header 0 value format"}
-
-* Name Length: the size of the name value in bytes.
-* Name Value: a string encoded using ISO-8859-1. This name is application-defined
-  and is not IANA registered.
-* Payload: the contents of the header. The combined size of the name and payload
-  contents MUST NOT exceed 10240 bytes.
 
 ### Object Message Formats
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -485,7 +485,7 @@ PATH parameter ({{path}}) which is sent in the CLIENT_SETUP message at the
 start of the session.  The ALPN value {{!RFC7301}} used by the protocol
 is `moq-00`.
 
-## Version Negotiation and Extension Negotiation {#version-negotiation}
+## Version and Extension Negotiation {#version-negotiation}
 
 Endpoints use the exchange of Setup messages to negotiate the MOQT version and
 any extensions to use.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1183,9 +1183,9 @@ value is 0, so if not specified, the peer MUST NOT create subscriptions.
 The REQUESTED-EXTENSION parameter (key 0x03) allows the client to request
 the server to acknowledge support for  multiple Extension Header types
 {{object-extensions}} which are required for operation. The value is a
-concatenation of varints, each describing an integer extension header type.
+sequence of varints, each describing an integer extension header type.
 This parameter is optional. If this parameter is present in the
-CLIENT_SETUP message, then the server MUST respond with a
+CLIENT_SETUP message, and if the then the server MUST respond with a
 REQUESTED-EXTENSION parameter in its SERVER_SETUP message. This parameter
 MUST list the subset of those extensions previously requested by the client
 which the server supports. If the server does not support any of the
@@ -2407,8 +2407,8 @@ STREAM_HEADER_SUBGROUP {
 }
 ~~~
 
-Sending a group on one stream, with the first object containing an
-Extension Header.
+Sending a group on one stream, with the first object containing two
+Extension Headers.
 
 ~~~
 Stream = 2
@@ -2421,13 +2421,13 @@ STREAM_HEADER_GROUP {
 }
 {
   Object ID = 0
-  Extension Count  = 1
-    { Type = 0
+  Extension Count  = 2
+    { Type = 5
+      Value = 2186796243
+    },
+    { Type = 76
       Length = 21
-        { Name length = 15
-          Name value = "example-traceID"
-          Payload = "123456"
-        }
+      Value = "traceID:123456"
     }
   Object Payload Length = 4
   Payload = "abcd"


### PR DESCRIPTION
This PR adds an extensible header to Objects, as well as updating the SETUP parameters to allow negotiation of required extension header parameters. Extensible headers have types which are IANA registered. A new Extensible header is defined and reserved with type 0x0, allowing name/value data to be passed in a manner compatible with HTTP headers.  A new example is added showing serialization of an Object with an extensible header. 

Fixes: #433 