### PR TITLE
Simplify SUBSCRIBE as a follow-up to FETCH

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1019,7 +1019,9 @@ There are 3 types of filters:
 
 Latest Object (0x2): Specifies an open-ended subscription beginning from
 the current object of the current group.  If no content has been delivered yet,
-the subscription starts with the first published or received group.
+the subscription starts with the first published or received group. Subscribers
+MUST NOT issue more than one subscription for the Latest Object of a track
+within the same session.
 
 AbsoluteStart (0x3):  Specifies an open-ended subscription beginning
 from the Object identified in the StartGroup and StartObject fields and ending

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1014,6 +1014,12 @@ GOAWAY Message {
 The subscriber specifies a filter on the subscription to allow
 the publisher to identify which objects need to be delivered.
 
+If a subscriber wants to subscribe to Objects both before and after
+the Latest Object, it can send a SUBSCRIBE for the Latest Object
+followed by a SUBSCRIBE of type AbsoluteStart.  Depending upon the
+application, one might want to send both SUBSCRIBEs at the same time
+or wait for the first to return before sending the second.
+
 There are 3 types of filters:
 
 Latest Object (0x2): Specifies an open-ended subscription beginning from

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1214,7 +1214,6 @@ in the current group, via the 'Latest Group' filter.
 The subscriber specifies a filter on the subscription to allow
 the publisher to identify which objects need to be delivered.
 
-
 There are 4 types of filters:
 
 Latest Group (0x1) : Specifies an open-ended subscription with objects

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1215,7 +1215,7 @@ The subscriber specifies a filter on the subscription to allow
 the publisher to identify which objects need to be delivered.
 
 
-There are 3 types of filters:
+There are 4 types of filters:
 
 Latest Group (0x1) : Specifies an open-ended subscription with objects
 from the beginning of the current group.  If no content has been delivered yet,
@@ -1223,9 +1223,7 @@ the subscription starts with the first published or received group.
 
 Latest Object (0x2): Specifies an open-ended subscription beginning from
 the current object of the current group.  If no content has been delivered yet,
-the subscription starts with the first published or received group. Subscribers
-MUST NOT issue more than one subscription for the Latest Object of a track
-within the same session.
+the subscription starts with the first published or received group.
 
 AbsoluteStart (0x3):  Specifies an open-ended subscription beginning
 from the Object identified in the StartGroup and StartObject fields and ending

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1014,11 +1014,6 @@ GOAWAY Message {
 The subscriber specifies a filter on the subscription to allow
 the publisher to identify which objects need to be delivered.
 
-If a subscriber wants to subscribe to Objects both before and after
-the Latest Object, it can send a SUBSCRIBE for the Latest Object
-followed by a SUBSCRIBE of type AbsoluteStart.  Depending upon the
-application, one might want to send both SUBSCRIBEs at the same time
-or wait for the first to return before sending the second.
 
 There are 3 types of filters:
 
@@ -1041,6 +1036,11 @@ SUBSCRIBE_ERROR.
 
 A filter type other than the above MUST be treated as error.
 
+If a subscriber wants to subscribe to Objects both before and after
+the Latest Object, it can send a SUBSCRIBE for the Latest Object
+followed by a SUBSCRIBE of type AbsoluteStart.  Depending upon the
+application, one might want to send both SUBSCRIBEs at the same time
+or wait for the first to return before sending the second.
 
 ### SUBSCRIBE Format
 A subscriber issues a SUBSCRIBE to a publisher to request a track.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1014,23 +1014,24 @@ GOAWAY Message {
 The subscriber specifies a filter on the subscription to allow
 the publisher to identify which objects need to be delivered.
 
-There are 4 types of filters:
-
-Latest Group (0x1) : Specifies an open-ended subscription with objects
-from the beginning of the current group.  If no content has been delivered yet,
-the subscription starts with the first published or received group.
+There are 3 types of filters:
 
 Latest Object (0x2): Specifies an open-ended subscription beginning from
 the current object of the current group.  If no content has been delivered yet,
 the subscription starts with the first published or received group.
 
 AbsoluteStart (0x3):  Specifies an open-ended subscription beginning
-from the object identified in the StartGroup and StartObject fields.
+from the Object identified in the StartGroup and StartObject fields and ending
+at the Latest Object, exclusive.  If no Objects have been published after
+StartGroup and StartObject, the subscription is immediately closed with a
+SUBSCRIBE_ERROR.
 
 AbsoluteRange (0x4):  Specifies a closed subscription starting at StartObject
 in StartGroup and ending at EndObject in EndGroup.  The start and end of the
 range are inclusive.  EndGroup and EndObject MUST specify the same or a later
-object than StartGroup and StartObject.
+object than StartGroup and StartObject. If no Objects have been published
+within the range, the subscription is immediately closed with a
+SUBSCRIBE_ERROR.
 
 A filter type other than the above MUST be treated as error.
 
@@ -1069,7 +1070,9 @@ SUBSCRIBE_ERROR messages.
 * Track Alias: A session specific identifier for the track.
 Messages that reference a track, such as OBJECT ({{message-object}}),
 reference this Track Alias instead of the Track Name and Track Namespace to
-reduce overhead. If the Track Alias is already being used for a different track, the publisher MUST close the session with a Duplicate Track Alias error ({{session-termination}}).
+reduce overhead. If the Track Alias is already being used for a different track,
+the publisher MUST close the session with a
+Duplicate Track Alias error ({{session-termination}}).
 
 * Track Namespace: Identifies the namespace of the track as defined in
 ({{track-name}}).

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1233,8 +1233,9 @@ SUBSCRIBE_ERROR with code 'Invalid Range'.
 AbsoluteRange (0x4):  Specifies a closed subscription starting at StartObject
 in StartGroup and ending at EndObject in EndGroup.  The start and end of the
 range are inclusive.  EndGroup and EndObject MUST specify the same or a later
-object than StartGroup and StartObject. If the end has already been published,
-the publisher SHOULD reply with a SUBSCRIBE_ERROR with code 'Invalid Range'.
+object than StartGroup and StartObject. If the StartGroup is prior
+to the current group, the publisher SHOULD reply with a
+SUBSCRIBE_ERROR with code 'Invalid Range'.
 
 A filter type other than the above MUST be treated as error.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1226,10 +1226,9 @@ the current object of the current group.  If no content has been delivered yet,
 the subscription starts with the first published or received group.
 
 AbsoluteStart (0x3):  Specifies an open-ended subscription beginning
-from the Object identified in the StartGroup and StartObject fields and ending
-at the Latest Object, exclusive.  If no Objects have been published after
-StartGroup and StartObject, the subscription is immediately closed with a
-SUBSCRIBE_ERROR.
+from the object identified in the StartGroup and StartObject fields. If the
+StartGroup is prior to the current group, the publisher SHOULD reply with a
+SUBSCRIBE_ERROR with code 'Invalid Range'.
 
 AbsoluteRange (0x4):  Specifies a closed subscription starting at StartObject
 in StartGroup and ending at EndObject in EndGroup.  The start and end of the
@@ -1241,9 +1240,9 @@ A filter type other than the above MUST be treated as error.
 
 If a subscriber wants to subscribe to Objects both before and after
 the Latest Object, it can send a SUBSCRIBE for the Latest Object
-followed by a SUBSCRIBE of type AbsoluteStart or AbsoluteRange.
-Depending upon the application, one might want to send both SUBSCRIBEs
-at the same time or wait for the first to return before sending the second.
+followed by a FETCH. Depending upon the application, one might want to send
+both messages at the same time or wait for the first to return before sending
+the second.
 
 The format of SUBSCRIBE is as follows:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1040,9 +1040,9 @@ A filter type other than the above MUST be treated as error.
 
 If a subscriber wants to subscribe to Objects both before and after
 the Latest Object, it can send a SUBSCRIBE for the Latest Object
-followed by a SUBSCRIBE of type AbsoluteStart.  Depending upon the
-application, one might want to send both SUBSCRIBEs at the same time
-or wait for the first to return before sending the second.
+followed by a SUBSCRIBE of type AbsoluteStart or AbsoluteRange.
+Depending upon the application, one might want to send both SUBSCRIBEs
+at the same time or wait for the first to return before sending the second.
 
 ### SUBSCRIBE Format
 A subscriber issues a SUBSCRIBE to a publisher to request a track.


### PR DESCRIPTION
This is another effort at the SUBSCRIBE vs FETCH concept.

I've reduced the number of modes for SUBSCRIBE to 3, and only one of them subscribes to Objects in the future.

I removed Latest Group because the other two modes operate on the latest Object and I wasn't sure how practical it is to expect every relay to cache all of the latest group.  And if they don't, implementations get complex.

This is an opinionated approach, but it has quite a bit of flexibility now that the new priority design has landed.  In particular, it gives the subscriber lots of control over what order Objects on either side of the live head are delivered.


Fixes #368 
Could be extended to fix #350