### PR TITLE
Reduce use of x(b) notation

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -899,7 +899,8 @@ formatted as follows:
 ~~~
 MOQT Control Message {
   Message Type (i),
-  Message Payload (b),
+  Message Length (i),
+  Message Payload (..),
 }
 ~~~
 {: #moq-transport-message-format title="MOQT Message"}
@@ -1060,6 +1061,7 @@ The wire format of the Setup messages are as follows:
 
 ~~~
 CLIENT_SETUP Message Payload {
+  Length (i),
   Number of Supported Versions (i),
   Supported Version (i) ...,
   Number of Parameters (i) ...,
@@ -1067,6 +1069,7 @@ CLIENT_SETUP Message Payload {
 }
 
 SERVER_SETUP Message Payload {
+  Length (i),
   Selected Version (i),
   Number of Parameters (i) ...,
   Setup Parameters (..) ...,
@@ -1158,7 +1161,9 @@ receives multiple GOAWAY messages.
 
 ~~~
 GOAWAY Message {
-  New Session URI (b)
+  Length (i),
+  New Session URI Length (i),
+  New Session URI (..),
 }
 ~~~
 {: #moq-transport-goaway-format title="MOQT GOAWAY Message"}
@@ -1205,10 +1210,12 @@ The format of SUBSCRIBE is as follows:
 
 ~~~
 SUBSCRIBE Message {
+  Length (i),
   Subscribe ID (i),
   Track Alias (i),
   Track Namespace (tuple),
-  Track Name (b),
+  Track Name Length (i),
+  Track Name (..),
   Subscriber Priority (8),
   Group Order (8),
   Filter Type (i),
@@ -1295,6 +1302,7 @@ The format of SUBSCRIBE_UPDATE is as follows:
 
 ~~~
 SUBSCRIBE_UPDATE Message {
+  Length (i),
   Subscribe ID (i),
   StartGroup (i),
   StartObject (i),
@@ -1338,6 +1346,7 @@ The format of `UNSUBSCRIBE` is as follows:
 
 ~~~
 UNSUBSCRIBE Message {
+  Length (i),
   Subscribe ID (i)
 }
 ~~~
@@ -1353,6 +1362,7 @@ successful authorization and acceptance of an ANNOUNCE message.
 ~~~
 ANNOUNCE_OK
 {
+  Length (i),
   Track Namespace (tuple),
 }
 ~~~
@@ -1369,9 +1379,11 @@ failed authorization.
 ~~~
 ANNOUNCE_ERROR
 {
+  Length (i),
   Track Namespace (tuple),
   Error Code (i),
-  Reason Phrase (b),
+  Reason Phrase Length (i),
+  Reason Phrase (..),
 }
 ~~~
 {: #moq-transport-announce-error format title="MOQT ANNOUNCE_ERROR Message"}
@@ -1395,9 +1407,11 @@ receiving an ANNOUNCE_CANCEL, it SHOULD close the session as a
 
 ~~~
 ANNOUNCE_CANCEL Message {
+  Length (i),
   Track Namespace (tuple),
   Error Code (i),
-  Reason Phrase (b),
+  Reason Phrase Length (i),
+  Reason Phrase Length (..),
 }
 ~~~
 {: #moq-transport-announce-cancel-format title="MOQT ANNOUNCE_CANCEL Message"}
@@ -1419,8 +1433,10 @@ A TRACK_STATUS message MUST be sent in response to each TRACK_STATUS_REQUEST.
 
 ~~~
 TRACK_STATUS_REQUEST Message {
+  Length (i),
   Track Namespace (tuple),
-  Track Name (b),
+  Track Name Length (i),
+  Track Name (..),
 }
 ~~~
 {: #moq-track-status-request-format title="MOQT TRACK_STATUS_REQUEST Message"}
@@ -1433,6 +1449,7 @@ the set.
 
 ~~~
 SUBSCRIBE_NAMESPACE Message {
+  Length (i),
   Track Namespace Prefix (tuple),
   Number of Parameters (i),
   Parameters (..) ...,
@@ -1479,6 +1496,7 @@ The format of `UNSUBSCRIBE_NAMESPACE` is as follows:
 
 ~~~
 UNSUBSCRIBE_NAMESPACE Message {
+  Length (i),
   Track Namespace Prefix (tuple)
 }
 ~~~
@@ -1494,6 +1512,7 @@ subscriptions.
 ~~~
 SUBSCRIBE_OK
 {
+  Length (i),
   Subscribe ID (i),
   Expires (i),
   Group Order (8),
@@ -1537,9 +1556,11 @@ failed SUBSCRIBE.
 ~~~
 SUBSCRIBE_ERROR
 {
+  Length (i),
   Subscribe ID (i),
   Error Code (i),
-  Reason Phrase (b),
+  Reason Phrase Length (i),
+  Reason Phrase (..),
   Track Alias (i),
 }
 ~~~
@@ -1567,9 +1588,11 @@ The format of `SUBSCRIBE_DONE` is as follows:
 
 ~~~
 SUBSCRIBE_DONE Message {
+  Length (i),
   Subscribe ID (i),
   Status Code (i),
-  Reason Phrase (b),
+  Reason Phrase Length (i),
+  Reason Phrase (..),
   ContentExists (f),
   [Final Group (i)],
   [Final Object (i)],
@@ -1604,6 +1627,7 @@ value is a 'Protocol Violation'.
 ~~~
 MAX_SUBSCRIBE_ID
 {
+  Length (i),
   Subscribe ID (i),
 }
 ~~~
@@ -1624,6 +1648,7 @@ publish tracks under this namespace.
 
 ~~~
 ANNOUNCE Message {
+  Length (i),
   Track Namespace (tuple),
   Number of Parameters (i),
   Parameters (..) ...,
@@ -1645,6 +1670,7 @@ within the provided Track Namespace.
 
 ~~~
 UNANNOUNCE Message {
+  Length (i),
   Track Namespace (tuple),
 }
 ~~~
@@ -1661,8 +1687,10 @@ to a TRACK_STATUS_REQUEST message.
 
 ~~~
 TRACK_STATUS Message {
+  Length (i),
   Track Namespace (tuple),
-  Track Name (b),
+  Track Name Length(i),
+  Track Name (..),
   Status Code (i),
   Last Group ID (i),
   Last Object ID (i),
@@ -1714,6 +1742,7 @@ namespace subscriptions.
 ~~~
 SUBSCRIBE_NAMESPACE_OK
 {
+  Length (i),
   Track Namespace Prefix (tuple),
 }
 ~~~
@@ -1729,9 +1758,11 @@ failed SUBSCRIBE_NAMESPACE.
 ~~~
 SUBSCRIBE_NAMESPACE_ERROR
 {
+  Length (i),
   Track Namespace Prefix (tuple),
   Error Code (i),
-  Reason Phrase (b),
+  Reason Phrase Length (i),
+  Reason Phrase (..),
 }
 ~~~
 {: #moq-transport-sub-ns-error format title="MOQT SUBSCRIBE_NAMESPACE_ERROR Message"}


### PR DESCRIPTION
This is a proposal to illustrate the changes needed to address one aspect of https://github.com/moq-wg/moq-transport/issues/536 .

In creating this, I realised that the [recent change](https://github.com/moq-wg/moq-transport/commit/b5ad15c1f4320271cd515b20e55275efe573256a) to add a length to control messages used the `x(b)` notation. This makes it awkward to then fully expand the full message structure as is done in RFC 9000 and RFC 9114 (and proposed for the `Type` field here on https://github.com/moq-wg/moq-transport/pull/541). Its also arguable if the "followed by that many bytes  of binary data" description for the `x (b)` notation is really supposed to apply to fields that are also formally defined but I think that debate is a distraction.

This PR reduces usage of `x (b)` by adding an explicit length field before the respective value. This reveals that some control message types have a redundant length field, which is rather pointless in some cases. For example, with this change we have

```
GOAWAY Message {
  Length (i),
  New Session URI Length (i),
  New Session URI (..),
}
```

this could be simplified to just 

```
GOAWAY Message {
  Length (i),
  New Session URI (..),
}
```

However, I avoided doing that in this PR because it is a breaking wire format change. 

I'd suggest we do the editorial changes in this PR first, and then survey the control types for opportunities to remove redundant lengths. We could even go so far as rearranging the order of fields so that the variable length ones go at the end, for example HTTP/3 does this with [HEADERS](https://datatracker.ietf.org/doc/html/rfc9114#name-headers) and [PUSH_PROMISE](https://datatracker.ietf.org/doc/html/rfc9114#section-7.2.5)

The last remaining usage of `x (b)` after this change relates to `x (tuple)`. I left that one since I didn't want to conflate things.