### PR TITLE
Fetch Objects if you can

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2183,12 +2183,7 @@ FETCH_HEADER Message {
 {: #fetch-header-format title="MOQT FETCH_HEADER Message"}
 
 
-When a publisher sends objects in response to a FETCH request, it finds the
-stream that is associated with the fetch request, or opens a new one and sends
-the `FETCH_HEADER`, and then serializes the following object fields. Each object
-sent on a fetch stream after the header has the following format:
-
-The Object Status field is only sent if the Object Payload Length is zero.
+Each object sent on a fetch stream after the FETCH_HEADER has the following format:
 
 ~~~
 {
@@ -2202,6 +2197,8 @@ The Object Status field is only sent if the Object Payload Length is zero.
 }
 ~~~
 {: #object-fetch-format title="MOQT Fetch Object Fields"}
+
+The Object Status field is only sent if the Object Payload Length is zero.
 
 
 ## Examples

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1248,7 +1248,7 @@ SUBSCRIBE Message {
   Filter Type (i),
   [StartGroup (i),
    StartObject (i)],
-  Group (i),
+  [EndGroup (i),
    EndObject (i)],
   Number of Parameters (i),
   Subscribe Parameters (..) ...

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1201,12 +1201,12 @@ GOAWAY Message {
 
 ## SUBSCRIBE {#message-subscribe-req}
 
-### Filter Types {#sub-filter}
+A subscription causes the publisher to send newly published objects for a track
+and can start at either the latest Group or latest Object. A subscriber MUST NOT
+make multiple active subscriptions for a track within a single session and
+publishers SHOULD treat this as a protocol violation.
 
-The subscriber specifies a filter on the subscription to allow
-the publisher to identify which objects need to be delivered.
-
-There are 2 types of filters:
+There are 2 types of subscriptions:
 
 Latest Group (0x1) : Specifies an open-ended subscription with objects
 from the beginning of the current group.  If no content has been delivered yet,
@@ -1216,10 +1216,8 @@ Latest Object (0x2): Specifies an open-ended subscription beginning from
 the current object of the current group.  If no content has been delivered yet,
 the subscription starts with the first published or received group.
 
-A filter type other than the above MUST be treated as error.
+A subscribe type other than the above MUST be treated as error.
 
-
-### SUBSCRIBE Format
 A subscriber issues a SUBSCRIBE to a publisher to request a track.
 
 The format of SUBSCRIBE is as follows:
@@ -1419,7 +1417,7 @@ FETCH Message {
 ~~~
 {: #moq-transport-fetch-format title="MOQT FETCH Message"}
 
-* Fetch ID: The Fetch ID identifies a given fetch request. Fetch ID is a 
+* Fetch ID: The Fetch ID identifies a given fetch request. Fetch ID is a
 variable length integer that MUST be unique and monotonically increasing
 within  a session.
 
@@ -1429,7 +1427,7 @@ within  a session.
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
 * Priority: Specifies the priority of a fetch request relative to
-other subscriptions or fetches in the same session. Lower numbers get higher 
+other subscriptions or fetches in the same session. Lower numbers get higher
 priority. See {{priorities}}.
 
 * Group Order: Allows the subscriber to request Objects be delivered in
@@ -1481,7 +1479,7 @@ FETCH_CANCEL Message {
 ~~~
 {: #moq-transport-unsubscribe-format title="MOQT FETCH_CANCEL Message"}
 
-* Fetch ID: Subscription Identifier as defined in {{message-fetch-req}}.
+* Fetch ID: Subscription Identifier as defined in {{message-fetch}}.
 
 
 ## ANNOUNCE_OK {#message-announce-ok}
@@ -2095,7 +2093,6 @@ will be dropped.
 
 ~~~
 OBJECT_DATAGRAM Message {
-  Subscribe ID (i),
   Track Alias (i),
   Group ID (i),
   Object ID (i),
@@ -2129,7 +2126,6 @@ stream header.
 
 ~~~
 STREAM_HEADER_TRACK Message {
-  Subscribe ID (i)
   Track Alias (i),
   Publisher Priority (8),
 }
@@ -2167,7 +2163,6 @@ ID` and the subgroup indicated by 'Group ID' and `Subgroup ID`.
 
 ~~~
 STREAM_HEADER_SUBGROUP Message {
-  Subscribe ID (i),
   Track Alias (i),
   Group ID (i),
   Subgroup ID (i),
@@ -2238,7 +2233,6 @@ Sending a track on one stream:
 
 ~~~
 STREAM_HEADER_TRACK {
-  Subscribe ID = 1
   Track Alias = 1
   Publisher Priority = 0
 }
@@ -2262,7 +2256,6 @@ Sending a subgroup on one stream:
 Stream = 2
 
 STREAM_HEADER_SUBGROUP {
-  Subscribe ID = 2
   Track Alias = 2
   Group ID = 0
   Subgroup ID = 0

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1268,7 +1268,6 @@ used. Values larger than 0x2 are a protocol error.
 
 * Filter Type: Identifies the type of filter, which also indicates whether
 the StartGroup/StartObject and EndGroup/EndObject fields will be present.
-See ({{sub-filter}}).
 
 * StartGroup: The start Group ID. Only present for "AbsoluteStart" and
 "AbsoluteRange" filter types.
@@ -1477,7 +1476,7 @@ FETCH_CANCEL Message {
   Fetch ID (i)
 }
 ~~~
-{: #moq-transport-unsubscribe-format title="MOQT FETCH_CANCEL Message"}
+{: #moq-transport-fetch-cancel title="MOQT FETCH_CANCEL Message"}
 
 * Fetch ID: Subscription Identifier as defined in {{message-fetch}}.
 
@@ -1732,7 +1731,7 @@ FETCH_OK
   Subscribe Parameters (..) ...
 }
 ~~~
-{: #moq-transport-subscribe-ok format title="MOQT FETCH_OK Message"}
+{: #moq-transport-fetch-ok format title="MOQT FETCH_OK Message"}
 
 * Fetch ID: Fetch Identifier as defined in {{message-fetch}}.
 
@@ -1764,7 +1763,7 @@ FETCH_ERROR
   Reason Phrase (..),
 }
 ~~~
-{: #moq-transport-subscribe-error format title="MOQT FETCH_ERROR Message"}
+{: #moq-transport-fetch-error format title="MOQT FETCH_ERROR Message"}
 
 * Fetch ID: Subscription Identifier as defined in {{message-subscribe-req}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1701,6 +1701,64 @@ SUBSCRIBE_ERROR
   ({{session-termination}}).
 
 
+## FETCH_OK {#message-fetch-ok}
+
+A publisher sends a FETCH control message for successful fetches.
+
+~~~
+FETCH_OK
+{
+  Type (i) = 0x18,
+  Length (i),
+  Fetch ID (i),
+  Group Order (8),
+  Largest Group ID (i),
+  Largest Object ID (i),
+  Number of Parameters (i),
+  Subscribe Parameters (..) ...
+}
+~~~
+{: #moq-transport-subscribe-ok format title="MOQT FETCH_OK Message"}
+
+* Fetch ID: Fetch Identifier as defined in {{message-fetch}}.
+
+* Group Order: Indicates the fetch will be delivered in
+Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
+Values of 0x0 and those larger than 0x2 are a protocol error.
+
+* Largest Group ID: The largest Group ID available for this track. This field
+is only present if ContentExists has a value of 1.
+
+* Largest Object ID: The largest Object ID available within the largest Group ID
+for this track. This field is only present if ContentExists has a value of 1.
+
+* Subscribe Parameters: The parameters are defined in {{version-specific-params}}.
+
+## FETCH_ERROR {#message-fetch-error}
+
+A publisher sends a FETCH_ERROR control message in response to a
+failed FETCH.
+
+~~~
+FETCH_ERROR
+{
+  Type (i) = 0x19,
+  Length (i),
+  Fetch ID (i),
+  Error Code (i),
+  Reason Phrase Length (i),
+  Reason Phrase (..),
+}
+~~~
+{: #moq-transport-subscribe-error format title="MOQT FETCH_ERROR Message"}
+
+* Fetch ID: Subscription Identifier as defined in {{message-subscribe-req}}.
+
+* Error Code: Identifies an integer error code for fetch failure.
+
+* Reason Phrase: Provides the reason for fetch error.
+
+
 ## SUBSCRIBE_DONE {#message-subscribe-done}
 
 A publisher sends a `SUBSCRIBE_DONE` message to indicate it is done publishing
@@ -1880,27 +1938,6 @@ SUBSCRIBE_NAMESPACE_OK
 {: #moq-transport-sub-ns-ok format title="MOQT SUBSCRIBE_NAMESPACE_OK Message"}
 
 * Track Namespace Prefix: As defined in {{message-subscribe-ns}}.
-
-
-## FETCH_ERROR {#message-fetch-error}
-
-A publisher sends a FETCH_ERROR control message in response to a
-failed FETCH;
-
-~~~
-FETCH_ERROR
-{
-  Type (i) = 0x19,
-  Length (i),
-  Fetch ID (i),
-  Error Code (i),
-  [Latest Group ID(i)],
-  [Latest Object ID(i)]
-}
-~~~
-{: #moq-transport-sub-ns-error format title="MOQT FETCH_ERROR Message"}
-
-* Fetch ID: As defined in {{message-fetch-ns}}.
 
 
 ## SUBSCRIBE_NAMESPACE_ERROR {#message-sub-ns-error}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1372,8 +1372,8 @@ UNSUBSCRIBE Message {
 A subscriber issues a FETCH to a publisher to request a range of already published
 objects within a track. The publisher responding to a FETCH is responsible for
 retrieving all available Objects, and if there are gaps between Objects, it
-indicates these Objects are not avaiable. As a result a fetch does not omit objects
-due to congestion, like a subscription can.
+indicates these Objects are not available. As a result a fetch does not omit objects
+due to congestion.
 
 A publisher responds to a FETCH request with either a FETCH_OK or a FETCH_ERROR
 message.  If it responds with FETCH_OK, the publisher creates a new unidirectional

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1457,6 +1457,10 @@ The latest available Object is indicated in the FETCH_OK, and is the last
 Object a fetch will return if the EndGroup and EndObject have not yet been
 published.
 
+A publisher MUST send fetched groups in the determined group order, either
+ascending or descending. Within each group, objects are sent in Object ID order;
+subgroup ID is not used for ordering.
+
 If StartGroup/StartObject is greater than the latest published Object group,
 the publisher MUST return FETCH_ERROR with error code 'No Objects'.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1244,6 +1244,10 @@ SUBSCRIBE Message {
   Subscriber Priority (8),
   Group Order (8),
   Filter Type (i),
+  [StartGroup (i),
+   StartObject (i)],
+  [EndGroup (i),
+   EndObject (i)],
   Number of Parameters (i),
   Subscribe Parameters (..) ...
 }

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -621,7 +621,9 @@ Given the critical nature of control messages and their relatively
 small size, the control stream SHOULD be prioritized higher than all
 subscribed Objects.
 
-TODO: Rewrite this section for Fetch without it being too awkward.
+Both SUBSCRIBE and FETCH messages indicate a subscriber priority and
+group order, so the following text applies equally to both types of
+subscriptions.
 
 The subscriber indicates the priority of a subscription via the
 Subscriber Priority field and the original publisher indicates priority
@@ -1246,7 +1248,7 @@ SUBSCRIBE Message {
   Filter Type (i),
   [StartGroup (i),
    StartObject (i)],
-  [EndGroup (i),
+  Group (i),
    EndObject (i)],
   Number of Parameters (i),
   Subscribe Parameters (..) ...
@@ -1412,8 +1414,8 @@ FETCH Message {
   Group Order (8),
   StartGroup (i),
   StartObject (i),
-  [EndGroup (i),
-   EndObject (i)],
+  EndGroup (i),
+  EndObject (i),
   Number of Parameters (i),
   Parameters (..) ...
 }
@@ -1429,7 +1431,7 @@ within  a session.
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
 
-* Priority: Specifies the priority of a fetch request relative to
+* Subscriber Priority: Specifies the priority of a fetch request relative to
 other subscriptions or fetches in the same session. Lower numbers get higher
 priority. See {{priorities}}.
 
@@ -1450,10 +1452,9 @@ requested.
 * Parameters: The parameters are defined in {{version-specific-params}}.
 
 
-Any Objects that are not yet published will not be retrieved by a FETCH.
+Objects that are not yet published will not be retrieved by a FETCH.
 The latest available Object is indicated in the FETCH_OK, and is the last
-Object a fetch will return if the 'Fetch Type is AbsoluteStart or if the
-type is AbsoluteRange and the EndGroup and EndObject have not yet been
+Object a fetch will return if the EndGroup and EndObject have not yet been
 published.
 
 If StartGroup/StartObject is greater than the latest published Object group,
@@ -1718,7 +1719,9 @@ SUBSCRIBE_ERROR
 
 ## FETCH_OK {#message-fetch-ok}
 
-A publisher sends a FETCH_OK control message for successful fetches.
+A publisher sends a FETCH_OK control message in response to successful fetches.
+A publisher MAY send Objects in response to a FETCH before the FETCH_OK message is sent,
+but the FETCH_OK MUST NOT be sent until the latest group and object are known.
 
 ~~~
 FETCH_OK
@@ -2186,7 +2189,9 @@ The Object Status field is only sent if the Object Payload Length is zero.
 ~~~
 {
   Group ID (i),
+  Subgroup ID (i),
   Object ID (i),
+  Publisher Priority (8),
   Object Payload Length (i),
   [Object Status (i)],
   Object Payload (..),

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2178,7 +2178,6 @@ track requested in the Fetch message identified by `Subscribe ID`.
 ~~~
 FETCH_HEADER Message {
   Subscribe ID (i),
-  Publisher Priority (8),
 }
 ~~~
 {: #fetch-header-format title="MOQT FETCH_HEADER Message"}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1392,7 +1392,9 @@ fetch response. All omitted objects have status Object Not Available.
 
 A publisher responds to a FETCH request with either a FETCH_OK or a FETCH_ERROR
 message.  If it responds with FETCH_OK, the publisher creates a new unidirectional
-stream that is used to send the Objects.
+stream that is used to send the Objects.  A relay MAY start sending objects immediately
+in response to a FETCH, even if sending the FETCH_OK takes longer because it requires
+going upstream to populate the latest object.
 
 The Object Forwarding Preference does not apply to fetches.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1456,10 +1456,11 @@ type is AbsoluteRange and the EndGroup and EndObject have not yet been
 published.
 
 If StartGroup/StartObject is greater than the latest published Object group,
-the publisher MUST return FETCH_ERROR with error code 'No Objects'. A publisher
-MUST send fetched objects in ascending order and MUST NOT send objects from
-outside the requested start and end.
+the publisher MUST return FETCH_ERROR with error code 'No Objects'.
 
+A publisher MUST send fetched groups in group order, either ascending or
+descending. Within each group, objects are sent in Object ID order;
+subgroup ID is not used for ordering.
 
 ## FETCH_CANCEL {#message-fetch-cancel}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1380,10 +1380,9 @@ UNSUBSCRIBE Message {
 ## FETCH {#message-fetch}
 
 A subscriber issues a FETCH to a publisher to request a range of already published
-objects within a track. The publisher responding to a FETCH is responsible for
-retrieving all available Objects, and if there are gaps between Objects, it
-indicates these Objects are not available. As a result a fetch does not omit objects
-due to congestion.
+objects within a track. The publisher responding to a FETCH is responsible for retrieving
+all available Objects. If there are gaps between Objects, the publisher omits them from the
+fetch response. All omitted objects have status Object Not Available.
 
 A publisher responds to a FETCH request with either a FETCH_OK or a FETCH_ERROR
 message.  If it responds with FETCH_OK, the publisher creates a new unidirectional

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1372,7 +1372,7 @@ UNSUBSCRIBE Message {
 A subscriber issues a FETCH to a publisher to request a range of already published
 objects within a track. The publisher responding to a FETCH is responsible for
 retrieving all available Objects, and if there are gaps between Objects, it
-indicates these Objects are not avaiable. A fetch MUST NOT omit sending objects
+indicates these Objects are not avaiable. As a result a fetch does not omit objects
 due to congestion, like a subscription can.
 
 A publisher responds to a FETCH request with either a FETCH_OK or a FETCH_ERROR

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2182,7 +2182,8 @@ FETCH_HEADER Message {
 
 When a publisher sends objects in response to a FETCH request, it finds the
 stream that is associated with the fetch request, or opens a new one and sends
-the `FETCH_HEADER`, and then serializes the following object fields.
+the `FETCH_HEADER`, and then serializes the following object fields. Each object
+sent on a fetch stream after the header has the following format:
 
 The Object Status field is only sent if the Object Payload Length is zero.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1725,6 +1725,7 @@ FETCH_OK
   Length (i),
   Fetch ID (i),
   Group Order (8),
+  End Of Track (8),
   Largest Group ID (i),
   Largest Object ID (i),
   Number of Parameters (i),
@@ -1738,6 +1739,10 @@ FETCH_OK
 * Group Order: Indicates the fetch will be delivered in
 Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
 Values of 0x0 and those larger than 0x2 are a protocol error.
+
+* End Of Track: 1 if all objects have been published on this track, so
+the Largest Group ID and Object Id indicate the last Object in the track,
+0 if not.
 
 * Largest Group ID: The largest Group ID available for this track. This field
 is only present if ContentExists has a value of 1.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1800,11 +1800,14 @@ failure.
 
 ## Fetch {#message-fetch}
 
-Subscribers issue fetch requests for prior objects while the subscriptions are 
-made for the live edge. A subscriber issues a FETCH request to a publisher to 
-request objects from a closed range of groups within a track. Publisher responds 
-to a FETCH request with either a FETCH_ERROR message or data corresponding to 
-the range requested, over a unidirectional created for the request.
+A subscriber issues a FETCH to a publisher to request a range of
+objects within a track.  Any Objects that are not yet published
+will not be retrieved in the FETCH.
+
+A publisher responds to a FETCH request with either a FETCH_OK or
+a FETCH_ERROR message.  If it responds with FETCH_OK, the publisher creates a new
+unidirectional stream that is used to send the Objects.
+
 The object forwarding preference will not apply to fetches.
 
 The format of FETCH is as follows:
@@ -2094,28 +2097,25 @@ A publisher MUST NOT send an Object on a stream if its Object ID is less than a
 previously sent Object ID within a given group in that stream.
 
 
-### Fetch Header
+### Fetch Header {#fetch-header}
 
-When a stream begins with `FETCH_HEADER`, all objects on the stream
-belong to the track requested in the Fetch message identified by `Fetch
-ID`. `Number of Objects` identifies the total count of objects that 
-satisies the fetch request.
+When a stream begins with `FETCH_HEADER`, all objects on the stream belong to the
+track requested in the Fetch message identified by `Fetch ID`.
 
 ~~~
 FETCH_HEADER Message {
-  Fetch ID (i)
-  Track Alias (i),
-  Fetch Priority (8),
-  Number of Objects (i),
+  Fetch ID (i),
+  Publisher Priority (8),
 }
 ~~~
 {: #fetch-header-format title="MOQT FETCH_HEADER Message"}
 
 
-Publisher when responding to a FETCH request shall find the stream that is 
-associated with the fetch request, or open a new one and send the 
-`FETCH_HEADER` and then serialize the following object fields. The Object Status 
-field is only sent if the Object Payload Length is zero.
+When a publisher sends objects in response to a FETCH request, it finds the
+stream that is associated with the fetch request, or opens a new one and sends
+the `FETCH_HEADER`, and then serializes the following object fields.
+
+The Object Status field is only sent if the Object Payload Length is zero.
 
 ~~~
 {
@@ -2126,7 +2126,8 @@ field is only sent if the Object Payload Length is zero.
   Object Payload (..),
 }
 ~~~
-{: #object-track-format title="MOQT Track Stream Object Fields"}
+{: #object-fetch-format title="MOQT Fetch Object Fields"}
+
 
 ## Examples
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1718,7 +1718,7 @@ SUBSCRIBE_ERROR
 
 ## FETCH_OK {#message-fetch-ok}
 
-A publisher sends a FETCH control message for successful fetches.
+A publisher sends a FETCH_OK control message for successful fetches.
 
 ~~~
 FETCH_OK


### PR DESCRIPTION
Attempt to convert the consensus from the recent hybrid interim on October 2nd/3rd into a PR with the help of @suhasHere 

There's a lot more editorial cleanup to do, such as the priorities section, because many things now need to say "subscriptions or fetches", etc.

It does not do some things we may want to do later:
 * add support for multiple ranges
 * add a FETCH_UPDATE
 * add a MAX_FETCH_ID or equivalent
 * Put fetches on their own **bidirectional** stream

Fixes #350 
Fixes #368
Fixes #476
Fixes #482
Fixes #490 
Fixes #578