### PR TITLE
Clarify SUBSCRIBE now that FETCH is landed

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1207,7 +1207,7 @@ A subscription causes the publisher to send newly published objects for a track.
 A subscriber MUST NOT make multiple active subscriptions for a track within a
 single session and publishers SHOULD treat this as a protocol violation.
 The only objects prior to the current object that can be requested are those
-in the current group, via the 'Latest Group' filter.
+in the current group.
 
 **Filter Types**
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1233,7 +1233,7 @@ AbsoluteRange (0x4):  Specifies a closed subscription starting at StartObject
 in StartGroup and ending at EndObject in EndGroup.  The start and end of the
 range are inclusive.  EndGroup and EndObject MUST specify the same or a later
 object than StartGroup and StartObject. If the StartGroup is prior
-to the current group, the publisher SHOULD reply with a
+to the current group, the publisher MUST reply with a
 SUBSCRIBE_ERROR with code 'Invalid Range'.
 
 A filter type other than the above MUST be treated as error.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1206,6 +1206,8 @@ GOAWAY Message {
 A subscription causes the publisher to send newly published objects for a track.
 A subscriber MUST NOT make multiple active subscriptions for a track within a
 single session and publishers SHOULD treat this as a protocol violation.
+The only objects prior to the current object that can be requested are those
+in the current group, via the 'Latest Group' filter.
 
 **Filter Types**
 
@@ -1223,14 +1225,24 @@ the current object of the current group.  If no content has been delivered yet,
 the subscription starts with the first published or received group.
 
 AbsoluteStart (0x3):  Specifies an open-ended subscription beginning
-from the object identified in the StartGroup and StartObject fields.
+from the object identified in the StartGroup and StartObject fields. If the
+StartGroup is prior to the current group, the publisher SHOULD reply with a
+SUBSCRIBE_ERROR with code 'Invalid Range'.
 
 AbsoluteRange (0x4):  Specifies a closed subscription starting at StartObject
 in StartGroup and ending at EndObject in EndGroup.  The start and end of the
 range are inclusive.  EndGroup and EndObject MUST specify the same or a later
-object than StartGroup and StartObject.
+object than StartGroup and StartObject. If the StartGroup is prior
+to the current group, the publisher SHOULD reply with a
+SUBSCRIBE_ERROR with code 'Invalid Range'.
 
 A filter type other than the above MUST be treated as error.
+
+If a subscriber wants to subscribe to Objects both before and after
+the Latest Object, it can send a SUBSCRIBE for the Latest Object
+followed by a FETCH. Depending upon the application, one might want to send
+both messages at the same time or wait for the first to return before sending
+the second.
 
 The format of SUBSCRIBE is as follows:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1226,7 +1226,7 @@ the subscription starts with the first published or received group.
 
 AbsoluteStart (0x3):  Specifies an open-ended subscription beginning
 from the object identified in the StartGroup and StartObject fields. If the
-StartGroup is prior to the current group, the publisher SHOULD reply with a
+StartGroup is prior to the current group, the publisher MUST reply with a
 SUBSCRIBE_ERROR with code 'Invalid Range'.
 
 AbsoluteRange (0x4):  Specifies a closed subscription starting at StartObject


### PR DESCRIPTION
Changes SUBSCRIBE so you can't go back farther than the current Group with any of the filter modes.  If a SUBSCRIBE tries to go back farther, it is closed with a SUBSCRIBE_OK.

Alternatively, instead of failing the subscription, we could specify that the SUBSCRIBE will be truncated and start at the beginning of the current group.