### PR TITLE
Remove End Of Subgroup status

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2211,7 +2211,7 @@ Group boundaries to avoid doing so.
 An MoQT implementation that processes a stream FIN is assured it has received
 all objects in a subgroup from the start of the subscription. If a relay, it
 can forward stream FINs to its own subscribers once those objects have been
-sent. A relay MAY treat receipt of EndOfGroup, EndOfSubgroup, GroupDoesNotExist, or
+sent. A relay MAY treat receipt of EndOfGroup, GroupDoesNotExist, or
 EndOfTrack objects as a signal to close corresponding streams even if the FIN
 has not arrived, as further objects on the stream would be a protocol violation.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2096,9 +2096,6 @@ are beyond the end of a group or track.
          group. This is sent right after the last object in the
          track. This SHOULD be cached.
 
-* 0x5 := Indicates end of Subgroup. Object ID is one greater than the largest
-         normal object ID in the Subgroup.
-
 Any other value SHOULD be treated as a protocol error and terminate the
 session with a Protocol Violation ({{session-termination}}).
 Any object with a status code other than zero MUST have an empty payload.


### PR DESCRIPTION
We don't discuss how to use it anyway.

This was suggested in #589 