### PR TITLE
Fix a typo in a section ref in the Intro

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -99,7 +99,7 @@ discovery and subscription.
 
 * {{message}} covers how control messages are encoded on the wire.
 
-* {{data-streams}}} covers how data messages are encoded on the wire.
+* {{data-streams}} covers how data messages are encoded on the wire.
 
 
 ## Motivation


### PR DESCRIPTION
There is an extra `}` that leads to rendering artifact:
```
*  Section 7} covers how data messages are encoded on the wire.
```
