### PR TITLE
Remove 'Role'

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1128,33 +1128,6 @@ identified as 0xff00000D.
 
 ### Setup Parameters {#setup-params}
 
-#### ROLE {#role}
-
-The ROLE parameter (key 0x00) allows each endpoint to independently specify what
-functionality they support for the session. It has three possible values,
-which are of type varint:
-
-0x01: Publisher
-
-: The endpoint can process subscriptions and send objects, but not subscribe.
-  The endpoint MUST NOT send a SUBSCRIBE message and an ANNOUNCE MUST NOT be
-  sent to it.
-
-0x02: Subscriber
-
-: The endpoint can send subscriptions and receive objects, but not publish.
-  The endpoint MUST NOT send an ANNOUNCE message and a SUBSCRIBE MUST NOT be
-  sent to it.
-
-0x03: PubSub
-
-: The endpoint can act as a publisher or subscriber, and can send or process
-  any message type.
-
-Both endpoints MUST send a ROLE parameter with one of the three values
-specified above. Both endpoints MUST close the session if the ROLE
-parameter is missing or is not one of the three above-specified values.
-
 #### PATH {#path}
 
 The PATH parameter (key 0x01) allows the client to specify the path of


### PR DESCRIPTION
The role somewhat limited what actions were valid, but it's not clear that was important.  Also, some things can be limited by MAX_SUBSCRIBE_ID now.

Fixes #574 
Fixes #586