### PR TITLE
Do something useful with SUBSCRIBE_DONE

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1797,8 +1797,8 @@ stream state may persist until delivery completes.
 A subscriber that receives SUBSCRIBE_DONE SHOULD set a timer of at least 2 seconds
 in case some datagrams or unopened streams are still inbound due to
 prioritization or packet loss. Once the timer has expired, the receiver destroys
-subscription state once all open streams for the subscription have closed. Ai
-receiver MAY destroy subscription state earlier, at the cost of potentially not
+subscription state once all open streams for the subscription have closed. A
+subscriber MAY discard subscription state earlier, at the cost of potentially not
 delivering some late objects to the application.
 
 The format of `SUBSCRIBE_DONE` is as follows:

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1780,12 +1780,15 @@ FETCH_ERROR
 
 ## SUBSCRIBE_DONE {#message-subscribe-done}
 
-A publisher sends a `SUBSCRIBE_DONE` message to indicate it will not open any
-additional streams or send any more datagrams for a subscription. When all
-streams for the subscription are fully closed, each endpoint can destroy its
-subscription state.
+A publisher sends a `SUBSCRIBE_DONE` message when it is not going to send
+additional objects for a subscription. Because SUBSCRIBE_DONE is sent on the
+control stream, it is likely to arrive at the receiver before late-arriving
+objects, and often even late-opening streams. However, the receiver uses it
+as an indication that it should receive any late-opening streams in a relatively
+short time. When all streams for the subscription are fully closed, each
+endpoint can destroy its subscription state.
 
-Note that some objects in the subscribed groups might never be delivered,
+Note that some objects in the subscribed track might never be delivered,
 because a stream was reset, or never opened in the first place, due to the
 delivery timeout.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1770,13 +1770,13 @@ A publisher sends a `SUBSCRIBE_DONE` message to indicate it will not open any
 additional streams for a subscription. When all streams for the subscription are
 fully closed, each endpoint can destroy its subscription state.
 
-Note that some objects in the subscribed groups might not have been delivered,
+Note that some objects in the subscribed groups might never be delivered,
 because a stream was reset, or never opened in the first place, due to the
 delivery timeout.
 
 A sender MUST NOT send SUBSCRIBE_DONE until it has closed all streams it will
 ever open for a subscription. After sending SUBSCRIBE_DONE, MoQT can immediately
-destroy subscription state. The QUIC implementation might still be resolving the
+destroy subscription state. The QUIC layer might still be resolving the
 closing of the stream on the wire.
 
 A receiver that receives SUBSCRIBE_DONE SHOULD set a timer of at least 2 seconds

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1767,24 +1767,25 @@ FETCH_ERROR
 ## SUBSCRIBE_DONE {#message-subscribe-done}
 
 A publisher sends a `SUBSCRIBE_DONE` message to indicate it will not open any
-additional streams for a subscription. When all streams for the subscription are
-fully closed, each endpoint can destroy its subscription state.
+additional streams or send any more datagrams for a subscription. When all
+streams for the subscription are fully closed, each endpoint can destroy its
+subscription state.
 
 Note that some objects in the subscribed groups might never be delivered,
 because a stream was reset, or never opened in the first place, due to the
 delivery timeout.
 
 A sender MUST NOT send SUBSCRIBE_DONE until it has closed all streams it will
-ever open for a subscription. After sending SUBSCRIBE_DONE, MoQT can immediately
-destroy subscription state. The QUIC layer might still be resolving the
-closing of the stream on the wire.
+ever open, and has no pending datagrams, for a subscription. After sending
+SUBSCRIBE_DONE, the sender  can immediately destroy subscription state, although
+stream state may persist until delivery completes.
 
 A receiver that receives SUBSCRIBE_DONE SHOULD set a timer of at least 2 seconds
-in case some unopened streams are still inbound due to prioritization or packet
-loss. Once the timer has expired, the receiver destroys subscription state once
-all open streams for the subscription have closed. A receiver MAY destroy
-subscription state earlier, at the cost of potentially not delivering some late
-objects to the application.
+in case some datagrams or unopened streams are still inbound due to
+prioritization or packet loss. Once the timer has expired, the receiver destroys
+subscription state once all open streams for the subscription have closed. Ai
+receiver MAY destroy subscription state earlier, at the cost of potentially not
+delivering some late objects to the application.
 
 The format of `SUBSCRIBE_DONE` is as follows:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1791,7 +1791,7 @@ delivery timeout.
 
 A sender MUST NOT send SUBSCRIBE_DONE until it has closed all streams it will
 ever open, and has no pending datagrams, for a subscription. After sending
-SUBSCRIBE_DONE, the sender  can immediately destroy subscription state, although
+SUBSCRIBE_DONE, the sender can immediately destroy subscription state, although
 stream state may persist until delivery completes.
 
 A receiver that receives SUBSCRIBE_DONE SHOULD set a timer of at least 2 seconds

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1794,7 +1794,7 @@ ever open, and has no pending datagrams, for a subscription. After sending
 SUBSCRIBE_DONE, the sender can immediately destroy subscription state, although
 stream state may persist until delivery completes.
 
-A receiver that receives SUBSCRIBE_DONE SHOULD set a timer of at least 2 seconds
+A subscriber that receives SUBSCRIBE_DONE SHOULD set a timer of at least 2 seconds
 in case some datagrams or unopened streams are still inbound due to
 prioritization or packet loss. Once the timer has expired, the receiver destroys
 subscription state once all open streams for the subscription have closed. Ai


### PR DESCRIPTION
Fixes #424
Fixes #456
Fixes #465

Comes up with some rules on when to send SUBSCRIBE_DONE, and what to do with it.

Deletes the ContentExists and Final Group/Object fields, because there is nothing the receiver does with it.