### PR TITLE
Joining Fetch

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1522,7 +1522,7 @@ Standalone Fetch (0x1) : A Fetch of Objects performed independently of any Subsc
 
 Joining Fetch (0x2) : A Fetch joined together with a Subscribe. A Joining Fetch
 shares the same Subscribe ID as an already-sent Subscribe. A publisher receiving a
-Joining Fetch should use properties of the associated Subscribe to determine the
+Joining Fetch uses properties of the associated Subscribe to determine the
 Track Namespace, Track, StartGroup, StartObject, EndGroup, and EndObject for the
 Joining Fetch such that it is contiguous with the associated Subscribe and begins
 Preceding Group Offset prior.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1607,7 +1607,7 @@ Fields present only for Standalone Fetch (0x1):
 * EndObject: The end Object ID, plus 1. A value of 0 means the entire group is
 requested.
 
-Field present only for Joining Fetch (0x2):
+Fields present only for Joining Fetch (0x2):
 
 * Joining Subscribe ID: The Subscribe ID of the existing subscription to be
 joined. If a publisher receives a Joining Fetch with a Subscribe ID that does

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1536,7 +1536,8 @@ The following values are used:
   * For Subscribes with Filter Type LatestObject or LatestGroup, this is equal to Largest Group ID.
   * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartGroup field of the Subscribe message
 * Resolved Subscribe Start Object:
-  * For Subscribes with Filter Type LatestObject or LatestObject, this is equal to Largest Object ID.
+  * For Subscribes with Filter Type LatestObject, this is equal to Largest Object ID.
+  * For Subscribes with Filter Type LatestGroup, this is 0
   * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartObject field of the Subscribe message
 * Preceding Group Offset: A field in the Joining Fetch message indicating the relative offset from the start of the Subscribe
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1540,7 +1540,7 @@ The following values are used:
   * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartObject field of the Subscribe message
 * Preceding Group Offset: A field in the Joining Fetch message indicating the relative offset from the start of the Subscribe
 
-Note: If a relay does not yet have LatestGroup and LatestObject for a given track, it may choose to either forward both the Subscribe and
+Note: If a relay does not yet have LatestGroup and LatestObject for a given track, it can choose to either forward both the Subscribe and
 the Joining Fetch upstream or to wait until the Joining Fetch can be resolved locally. In either case, the Resolved Subscribe Start values
 for a Joining Fetch MUST correspond to the Subscribe within the same session so the Fetch and Subscribe can be contiguous and non-overlapping.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1546,7 +1546,7 @@ The following values are used:
 The Resolved Subscribe Start values for a Joining Fetch MUST correspond to the referenced Subscribe within the same session so that the Objects delivered across the Fetch and Subscribe are contiguous and non-overlapping.
 If a relay answers the referenced Subscribe with a `SUBSCRIBE_OK` that has ContentExists set to 0, it MUST respond to the Joining Fetch with a `FETCH_ERROR`.
 
-Using that information and the following algorithm, these values are computed:
+Using the above information and the following algorithm, these values are computed:
 
 * Fetch Start Group: The StartGroup for the Fetch
 * Fetch Start Object: The StartObject for the Fetch (always 0)

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1542,7 +1542,7 @@ with the following fields dynamically determined from the corresponding Subscrib
 
 * EndGroup: StartGroup of the corresponding Subscribe minus 1 (double check minus 1)
 
-* EndObject: StartObject of the corresponding SUBSCRIBE minus 1 (double check minus 1)
+* EndObject: StartObject of the corresponding Subscribe minus 1 (double check minus 1)
 
 A Joining Fetch MUST be sent in ascending group order.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1474,7 +1474,7 @@ Fields common to all Fetch Types:
 
 * Subscribe ID: The Subscribe ID identifies a given fetch request. Subscribe ID
 is a variable length integer that MUST be unique and monotonically increasing
-within  a session. For a Standalone Fetch a new Subscribe ID MUST be used. For
+within a session. For a Standalone Fetch a new Subscribe ID MUST be used. For
 a Joining Fetch, the Subscribe ID MUST correspond to a Subscribe which has already
 been sent. If a publisher receives a Joining Fetch with a Subscribe ID that does
 not correspond to an existing Subscribe, it MUST close the session with an

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1536,7 +1536,7 @@ with the following fields dynamically determined from the corresponding Subscrib
 
 * Track Name: Same as in the corresponding Subscribe
 
-* StartGroup: LatestGroup as determined for the SUBSCRIBE minus PreviousGroups from the JOIN
+* StartGroup: LatestGroup as determined for the Subscribe minus Previous Groupe Count from the Joining Fetch
 
 * StartObject: Always 0
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1542,28 +1542,20 @@ The following values are used:
 The Resolved Subscribe Start values for a Joining Fetch MUST correspond to the referenced Subscribe within the same session so that the ranges of Objects covered by the Fetch and Subscribe are contiguous and non-overlapping.
 If a relay answers the referenced Subscribe with a `SUBSCRIBE_OK` that has ContentExists set to 0, it MUST respond to the Joining Fetch with a `FETCH_ERROR`.
 
-Using the above information and the following algorithm, these values are computed:
-
-* Fetch Start Group: The StartGroup for the Fetch
-* Fetch Start Object: The StartObject for the Fetch (always 0)
-* Fetch End Group: The EndGroup for the Fetch
-* Fetch End Object: The EndObject for the Fetch (represented as 1 more than the end Object ID
-  or a value of 0 indicating that the entire group is requested)
-
 The publisher receiving a Joining Fetch computes the fetch range as follows:
 
-* Fetch Start Group: Resolved Subscribe Start Group - Preceding Group Offset
-* Fetch Start Object: 0
+* Fetch StartGroup: Resolved Subscribe Start Group - Preceding Group Offset
+* Fetch StartObject: 0
 
 If Resolved Subscribe Start Object is 0:
-* Fetch End Group: Resolved Subscribe Start Group - 1
-* Fetch End Object: 0 (all objects in the group)
+* Fetch EndGroup: Resolved Subscribe Start Group - 1
+* Fetch EndObject: 0 (all objects in the group)
 
 Else, if Resolved Subscribe Start Object is 1 or more:
-* Fetch End Group: Resolved Subscribe Start Group
-* Fetch End Object: Resolved Subscribe Start Object
+* Fetch EndGroup: Resolved Subscribe Start Group
+* Fetch EndObject: Resolved Subscribe Start Object
 
-If Fetch End Group < Fetch Start Group respond with a Fetch Error.
+If Fetch EndGroup < Fetch StartGroup respond with a `FETCH_ERROR`.
 
 ## FETCH_CANCEL {#message-fetch-cancel}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1430,7 +1430,7 @@ Joining Fetch (0x2) : A Fetch joined together with a Subscribe. A Joining Fetch
 shares the same Subscribe ID as an already-sent Subscribe. A publisher receiving a Joining
 Fetch should use properties of the associated Subscribe to determine the Track Namespace,
 Track, StartGroup, StartObject, EndGroup, and EndObject for the Joining Fetch such that it is
-contiguous with the associated Subscribe and begins Previous Group Count prior.
+contiguous with the associated Subscribe and begins Preceding Group Offset prior.
 
 A Fetch Type other than the above MUST be treated as an error.
 
@@ -1463,7 +1463,7 @@ FETCH Message {
    StartObject (i),
    EndGroup (i),
    EndObject (i),]
-  [Previous Group Count (i),]
+  [Preceding Group Offset (i),]
   Number of Parameters (i),
   Parameters (..) ...
 }
@@ -1511,7 +1511,7 @@ requested.
 
 Field present only for Joining Fetch (0x2):
 
-* Previous Group Count: The number of groups to Fetch prior to the StartGroup of the corresponding Subscribe
+* Preceding Group Offset: The group offset for the Fetch prior and relative to the StartGroup of the corresponding Subscribe
 
 Objects that are not yet published will not be retrieved by a FETCH.
 The latest available Object is indicated in the FETCH_OK, and is the last
@@ -1532,7 +1532,7 @@ subgroup ID is not used for ordering.
 ### Calculating the Range of a Joining Fetch
 
 A publisher which receives a Fetch message with a Fetch Type of 0x2 must treat it as a Fetch
-with a range dynamically determined by the Previous Group Count (PGC) field and values derived
+with a range dynamically determined by the Preceding Group Offset (PGO) field and values derived
 from to the corresponding Subscribe message (hereafter "the Subscribe").
 
 The following values are used:
@@ -1544,7 +1544,7 @@ The following values are used:
 * Resolved Subscribe Start Object:
   * For Subscribes with Filter Type LatestObject or LatestObject, this is equal to Largest Object ID.
   * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartObject field of the Subscribe message
-* Previous Group Count: A field in the Joining Fetch message indicating how many prior groups to include
+* Preceding Group Offset: A field in the Joining Fetch message indicating the relative offset from the start of the Subscribe
 
 Using that information and the following algorithm, these values are computed:
 
@@ -1559,7 +1559,7 @@ The publisher receiving a Joining Fetch computes the fetch range as follows:
 If ContentExists is not 1 and Largest Group ID and Largest Object ID are not available, a relay SHOULD
 forward the Fetch with the 0x2 Fetch Type upstream.
 
-* Fetch Start Group: Resolved Subscribe Start Group - Previous Group Count
+* Fetch Start Group: Resolved Subscribe Start Group - Preceding Group Offset
 * Fetch Start Object: 0
 
 If Resolved Subscribe Start Object is 0:

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1597,7 +1597,8 @@ The Largest Group ID and Largest Object ID values from the corresponding
 subscription are used to calculate the end of a Joining Fetch so the Objects
 retrieved by the FETCH and SUBSCRIBE are contiguous and non-overlapping.
 If no Objects have been published for the track, and the SUBSCRIBE_OK has a
-ContentExists value of 0, the publisher responds with a FETCH_ERROR.
+ContentExists value of 0, the publisher responds with a FETCH_ERROR with
+error code 'No Objects'.
 
 The publisher receiving a Joining Fetch computes the range as follows:
 
@@ -1605,6 +1606,10 @@ The publisher receiving a Joining Fetch computes the range as follows:
 * Fetch StartObject: 0
 * Fetch EndGroup: Subscribe Largest Group
 * Fetch EndObject: Subscribe Largest Object
+
+A Fetch EndObject of 0 requests the entire group, but Fetch will not
+retrieve Objects that have not yet been published, so 1 is subtracted from
+the Fetch EndGroup if Fetch EndObject is 0.
 
 ## FETCH_CANCEL {#message-fetch-cancel}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1661,9 +1661,6 @@ Else, if Resolved Subscribe Start Object is 1 or more:
 * Fetch EndGroup: Resolved Subscribe Start Group
 * Fetch EndObject: Resolved Subscribe Start Object
 
-If Fetch EndGroup < Fetch StartGroup, there are no Objects to retrieve,
-so respond with a `FETCH_ERROR`.
-
 ## FETCH_CANCEL {#message-fetch-cancel}
 
 A subscriber issues a `FETCH_CANCEL` message to a publisher indicating it is no

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1520,12 +1520,12 @@ There are two types of Fetch messages:
 
 Standalone Fetch (0x1) : A Fetch of Objects performed independently of any Subscribe.
 
-Joining Fetch (0x2) : A Fetch joined together with a Subscribe. A Joining Fetch
-shares the same Subscribe ID as an already-sent Subscribe. A publisher receiving a
+Joining Fetch (0x2) : A Fetch joined together with a Subscribe by specifying
+the Subscribe ID of an active subscription. A publisher receiving a
 Joining Fetch uses properties of the associated Subscribe to determine the
-Track Namespace, Track, StartGroup, StartObject, EndGroup, and EndObject for the
-Joining Fetch such that it is contiguous with the associated Subscribe and begins
-Preceding Group Offset prior.
+Track Namespace, Track, StartGroup, StartObject, EndGroup, and EndObject such that
+it is contiguous with the associated Subscribe. The Joining Fetch begins the
+Preceding Group Offset prior to the associated subscription.
 
 A Subscriber can use a Joining Fetch to, for example, fill a playback buffer with a
 certain number of groups prior to the live edge of a track.
@@ -1533,7 +1533,7 @@ certain number of groups prior to the live edge of a track.
 A Joining Fetch is only permitted when the associated Subscribe has the Filter
 Type Latest Object.
 
-A Fetch Type other than the above MUST be treated as an error.
+A Fetch Type other than 0x1 or 0x2 MUST be treated as an error.
 
 A publisher responds to a FETCH request with either a FETCH_OK or a FETCH_ERROR
 message.  If it responds with FETCH_OK, the publisher creates a new unidirectional
@@ -1564,7 +1564,8 @@ FETCH Message {
    StartObject (i),
    EndGroup (i),
    EndObject (i),]
-  [Preceding Group Offset (i),]
+  [Joining Subscribe ID (i),
+   Preceding Group Offset (i),]
   Number of Parameters (i),
   Parameters (..) ...
 }
@@ -1575,12 +1576,7 @@ Fields common to all Fetch Types:
 
 * Subscribe ID: The Subscribe ID identifies a given fetch request. Subscribe ID
 is a variable length integer that MUST be unique and monotonically increasing
-within a session. For a Standalone Fetch a new Subscribe ID MUST be used. For
-a Joining Fetch, the Subscribe ID MUST correspond to a Subscribe which has already
-been sent. If a publisher receives a Joining Fetch with a Subscribe ID that does
-not correspond to an existing Subscribe, it MUST respond with a Fetch Error.
-Though they share an ID, cancelling or updating the subscription has no impact
-on the Fetch and vice versa.
+within a session.
 
 * Subscriber Priority: Specifies the priority of a fetch request relative to
 other subscriptions or fetches in the same session. Lower numbers get higher
@@ -1612,6 +1608,10 @@ Fields present only for Standalone Fetch (0x1):
 requested.
 
 Field present only for Joining Fetch (0x2):
+
+* Joining Subscribe ID: The Subscribe ID of the existing subscription to be
+joined. If a publisher receives a Joining Fetch with a Subscribe ID that does
+not correspond to an existing Subscribe, it MUST respond with a Fetch Error.
 
 * Preceding Group Offset: The group offset for the Fetch prior and relative
 to the StartGroup of the corresponding Subscribe. A value of 0 indicates

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1636,30 +1636,18 @@ as a Fetch with a range dynamically determined by the Preceding Group Offset
 field and field values derived from the corresponding SUBSCRIBE message
 (hereafter "the Subscribe").
 
-The following values are used:
-
-* Resolved Subscribe Start Group: the Largest Group ID of the associated Subscribe.
-* Resolved Subscribe Start Object: the Largest Object ID of the associated Subscribe.
-
-The Resolved Subscribe Start values for a Joining Fetch MUST correspond to the
-referenced Subscribe within the same session so that the ranges of Objects covered
-by the Fetch and Subscribe are contiguous and non-overlapping.
+The Largest Group ID and Largest Object ID values from the corresponding
+subscription are used to calculate the end of a Joining Fetch so the Objects
+retrieved by the Fetch and Subscribe are contiguous and non-overlapping.
 If no Objects have been published for the track, so the SUBSCRIBE_OK has a
-ContentExists value of 0, the publisher MUST respond to the Joining Fetch with a
-FETCH_ERROR.
+ContentExists value of 0, the publisher responds with a FETCH_ERROR.
 
 The publisher receiving a Joining Fetch computes the fetch range as follows:
 
-* Fetch StartGroup: Resolved Subscribe Start Group - Preceding Group Offset
+* Fetch StartGroup: Subscribe Largest Group - Preceding Group Offset
 * Fetch StartObject: 0
-
-If Resolved Subscribe Start Object is 0:
-* Fetch EndGroup: Resolved Subscribe Start Group - 1
-* Fetch EndObject: 0 (all objects in the group)
-
-Else, if Resolved Subscribe Start Object is 1 or more:
-* Fetch EndGroup: Resolved Subscribe Start Group
-* Fetch EndObject: Resolved Subscribe Start Object
+* Fetch EndGroup: Subscribe Largest Group
+* Fetch EndObject: Subscribe Largest Object
 
 ## FETCH_CANCEL {#message-fetch-cancel}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1626,15 +1626,14 @@ field and field values derived from the corresponding SUBSCRIBE message
 The following values are used:
 
 * Resolved Subscribe Start Group:
-  * For Subscribes with Filter Type Latest Object or Latest Group,
-    this is equal to Largest Group ID.
-  * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange,
-    this is equal to the StartGroup field of the Subscribe message
+  * For Latest Object or Latest Group filter types, this is Largest Group ID.
+  * For AbsoluteStart or AbsoluteRange filter types, this is the StartGroup field
+    of the SUBSCRIBE message
 * Resolved Subscribe Start Object:
-  * For Subscribes with Filter Type Latest Object, this is equal to Largest Object ID.
-  * For Subscribes with Filter Type Latest Group, this is 0
-  * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange,
-    this is equal to the StartObject field of the Subscribe message
+  * For the Latest Object filter type, this is the Largest Object ID.
+  * For the Latest Group filter type, this is 0
+  * For AbsoluteStart or AbsoluteRange filter types, this is the StartObject field
+    of the SUBSCRIBE message
 * Preceding Group Offset: A field in the Joining Fetch message indicating the
   relative offset from the start of the Subscribe
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1540,7 +1540,7 @@ with the following fields dynamically determined from the corresponding Subscrib
 
 * StartObject: Always 0
 
-* EndGroup: StartGroup of the corresponding SUBSCRIBE minus 1 (double check minus 1)
+* EndGroup: StartGroup of the corresponding Subscribe minus 1 (double check minus 1)
 
 * EndObject: StartObject of the corresponding SUBSCRIBE minus 1 (double check minus 1)
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1452,11 +1452,11 @@ FETCH Message {
   Length (i),
   Subscribe ID (i),
   Subscriber Priority (8),
+  Group Order (8),
   Fetch Type (i),
   [Track Namespace (tuple),
    Track Name Length (i),
    Track Name (..),
-   Group Order (8),
    StartGroup (i),
    StartObject (i),
    EndGroup (i),
@@ -1481,6 +1481,11 @@ not correspond to an existing Subscribe, it MUST respond with a Fetch Error.
 other subscriptions or fetches in the same session. Lower numbers get higher
 priority. See {{priorities}}.
 
+* Group Order: Allows the subscriber to request Objects be delivered in
+Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
+A value of 0x0 indicates the original publisher's Group Order SHOULD be
+used. Values larger than 0x2 are a protocol error.
+
 * Fetch Type: Identifies the type of Fetch, whether joining or standalone.
 
 * Parameters: The parameters are defined in {{version-specific-params}}.
@@ -1491,11 +1496,6 @@ Fields present only for Standalone Fetch (0x1):
 ({{track-name}}).
 
 * Track Name: Identifies the track name as defined in ({{track-name}}).
-
-* Group Order: Allows the subscriber to request Objects be delivered in
-Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
-A value of 0x0 indicates the original publisher's Group Order SHOULD be
-used. Values larger than 0x2 are a protocol error.
 
 * StartGroup: The start Group ID.
 
@@ -1564,8 +1564,6 @@ Else, if Resolved Subscribe Start Object is 1 or more:
 * Fetch End Object: Resolved Subscribe Start Object
 
 If Fetch End Group < Fetch Start Group respond with a Fetch Error.
-
-A Joining Fetch MUST be sent in ascending group order.
 
 ## FETCH_CANCEL {#message-fetch-cancel}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1531,7 +1531,6 @@ from to the corresponding Subscribe message (hereafter "the Subscribe").
 
 The following values are used:
 
-* ContentExists: whether we have any objects and therefore a Largest Group ID and Largest Object ID for the track
 * Resolved Subscribe Start Group:
   * For Subscribes with Filter Type LatestObject or LatestGroup, this is equal to Largest Group ID.
   * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartGroup field of the Subscribe message
@@ -1540,6 +1539,10 @@ The following values are used:
   * For Subscribes with Filter Type LatestGroup, this is 0
   * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartObject field of the Subscribe message
 * Preceding Group Offset: A field in the Joining Fetch message indicating the relative offset from the start of the Subscribe
+
+Note: If a relay does not yet have LatestGroup and LatestObject for a given track, it may choose to either forward both the Subscribe and
+the Joining Fetch upstream or to watch until the Joining Fetch can be resolved locally. However it is handled, the Resolved Subscribe Start values
+for a Joining Fetch MUST correspond to the Subscribe within the same session so the Fetch and Subscribe can be contiguous and non-overlapping.
 
 Using that information and the following algorithm, these values are computed:
 
@@ -1550,9 +1553,6 @@ Using that information and the following algorithm, these values are computed:
   or a value of 0 indicating that the entire group is requested)
 
 The publisher receiving a Joining Fetch computes the fetch range as follows:
-
-If ContentExists is not 1 and Largest Group ID and Largest Object ID are not available, a relay SHOULD
-forward the Fetch with the 0x2 Fetch Type upstream.
 
 * Fetch Start Group: Resolved Subscribe Start Group - Preceding Group Offset
 * Fetch Start Object: 0

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1540,9 +1540,8 @@ The following values are used:
   * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartObject field of the Subscribe message
 * Preceding Group Offset: A field in the Joining Fetch message indicating the relative offset from the start of the Subscribe
 
-Note: If a relay does not yet have LatestGroup and LatestObject for a given track, it can choose to either forward both the Subscribe and
-the Joining Fetch upstream or to wait until the Joining Fetch can be resolved locally. In either case, the Resolved Subscribe Start values
-for a Joining Fetch MUST correspond to the Subscribe within the same session so the Fetch and Subscribe can be contiguous and non-overlapping.
+The Resolved Subscribe Start values for a Joining Fetch MUST correspond to the referenced Subscribe within the same session so that the Objects delivered across the Fetch and Subscribe are contiguous and non-overlapping.
+If a relay answers the referenced Subscribe with a `SUBSCRIBE_OK` that has ContentExists set to 0, it MUST respond to the Joining Fetch with a `FETCH_ERROR`.
 
 Using that information and the following algorithm, these values are computed:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1522,10 +1522,6 @@ subgroup ID is not used for ordering.
 If StartGroup/StartObject is greater than the latest published Object group,
 the publisher MUST return FETCH_ERROR with error code 'No Objects'.
 
-A publisher MUST send fetched groups in group order, either ascending or
-descending. Within each group, objects are sent in Object ID order;
-subgroup ID is not used for ordering.
-
 ### Calculating the Range of a Joining Fetch
 
 A publisher which receives a Fetch message with a Fetch Type of 0x2 must treat it as a Fetch

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1539,7 +1539,7 @@ The following values are used:
   * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartObject field of the Subscribe message
 * Preceding Group Offset: A field in the Joining Fetch message indicating the relative offset from the start of the Subscribe
 
-The Resolved Subscribe Start values for a Joining Fetch MUST correspond to the referenced Subscribe within the same session so that the Objects delivered across the Fetch and Subscribe are contiguous and non-overlapping.
+The Resolved Subscribe Start values for a Joining Fetch MUST correspond to the referenced Subscribe within the same session so that the ranges of Objects covered by the Fetch and Subscribe are contiguous and non-overlapping.
 If a relay answers the referenced Subscribe with a `SUBSCRIBE_OK` that has ContentExists set to 0, it MUST respond to the Joining Fetch with a `FETCH_ERROR`.
 
 Using the above information and the following algorithm, these values are computed:

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1534,7 +1534,7 @@ with the following fields dynamically determined from the corresponding Subscrib
 
 * Track Namespace: Same as in the corresponding Subscribe
 
-* Track Name: Same as in the corresponding SUBSCRIBE
+* Track Name: Same as in the corresponding Subscribe
 
 * StartGroup: LatestGroup as determined for the SUBSCRIBE minus PreviousGroups from the JOIN
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1631,18 +1631,17 @@ the publisher MUST return FETCH_ERROR with error code 'No Objects'.
 
 ### Calculating the Range of a Joining Fetch
 
-A publisher which receives a Fetch message with a Fetch Type of 0x2 treats it
+A publisher that receives a Fetch of type Type 0x2 treats it
 as a Fetch with a range dynamically determined by the Preceding Group Offset
-field and field values derived from the corresponding SUBSCRIBE message
-(hereafter "the Subscribe").
+and field values derived from the corresponding subscription.
 
 The Largest Group ID and Largest Object ID values from the corresponding
 subscription are used to calculate the end of a Joining Fetch so the Objects
-retrieved by the Fetch and Subscribe are contiguous and non-overlapping.
-If no Objects have been published for the track, so the SUBSCRIBE_OK has a
+retrieved by the FETCH and SUBSCRIBE are contiguous and non-overlapping.
+If no Objects have been published for the track, and the SUBSCRIBE_OK has a
 ContentExists value of 0, the publisher responds with a FETCH_ERROR.
 
-The publisher receiving a Joining Fetch computes the fetch range as follows:
+The publisher receiving a Joining Fetch computes the range as follows:
 
 * Fetch StartGroup: Subscribe Largest Group - Preceding Group Offset
 * Fetch StartObject: 0

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1621,7 +1621,7 @@ the publisher MUST return FETCH_ERROR with error code 'No Objects'.
 ### Calculating the Range of a Joining Fetch
 
 A publisher which receives a Fetch message with a Fetch Type of 0x2 treats it
-as a Fetch with a range dynamically determined by the Preceding Group Offset (PGO)
+as a Fetch with a range dynamically determined by the Preceding Group Offset
 field and field values derived from the corresponding SUBSCRIBE message
 (hereafter "the Subscribe").
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1541,7 +1541,7 @@ The following values are used:
 * Preceding Group Offset: A field in the Joining Fetch message indicating the relative offset from the start of the Subscribe
 
 Note: If a relay does not yet have LatestGroup and LatestObject for a given track, it may choose to either forward both the Subscribe and
-the Joining Fetch upstream or to watch until the Joining Fetch can be resolved locally. However it is handled, the Resolved Subscribe Start values
+the Joining Fetch upstream or to wait until the Joining Fetch can be resolved locally. In either case, the Resolved Subscribe Start values
 for a Joining Fetch MUST correspond to the Subscribe within the same session so the Fetch and Subscribe can be contiguous and non-overlapping.
 
 Using that information and the following algorithm, these values are computed:

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1565,8 +1565,7 @@ Else, if Resolved Subscribe Start Object is 1 or more:
 * Fetch End Group: Resolved Subscribe Start Group
 * Fetch End Object: Resolved Subscribe Start Object
 
-If Fetch End Group < Fetch Start Group no Fetch will be generated.
-(TODO: How can we signal this?)
+If Fetch End Group < Fetch Start Group respond with a Fetch Error.
 
 A Joining Fetch MUST be sent in ascending group order.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1614,7 +1614,7 @@ joined. If a publisher receives a Joining Fetch with a Subscribe ID that does
 not correspond to an existing Subscribe, it MUST respond with a Fetch Error.
 
 * Preceding Group Offset: The group offset for the Fetch prior and relative
-to the StartGroup of the corresponding Subscribe. A value of 0 indicates
+to the Current Group of the corresponding Subscribe. A value of 0 indicates
 the current Group.
 
 Objects that are not yet published will not be retrieved by a FETCH.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1615,7 +1615,7 @@ not correspond to an existing Subscribe, it MUST respond with a Fetch Error.
 
 * Preceding Group Offset: The group offset for the Fetch prior and relative
 to the Current Group of the corresponding Subscribe. A value of 0 indicates
-the current Group.
+the Fetch starts at the beginning of the Current Group.
 
 Objects that are not yet published will not be retrieved by a FETCH.
 The latest available Object is indicated in the FETCH_OK, and is the last

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1579,6 +1579,8 @@ within a session. For a Standalone Fetch a new Subscribe ID MUST be used. For
 a Joining Fetch, the Subscribe ID MUST correspond to a Subscribe which has already
 been sent. If a publisher receives a Joining Fetch with a Subscribe ID that does
 not correspond to an existing Subscribe, it MUST respond with a Fetch Error.
+Though they share an ID, cancelling or updating the subscription has no impact
+on the Fetch and vice versa.
 
 * Subscriber Priority: Specifies the priority of a fetch request relative to
 other subscriptions or fetches in the same session. Lower numbers get higher

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1427,6 +1427,9 @@ Fetch should use properties of the associated Subscribe to determine the Track N
 Track, StartGroup, StartObject, EndGroup, and EndObject for the Joining Fetch such that it is
 contiguous with the associated Subscribe and begins Preceding Group Offset prior.
 
+A Subscriber can use a Joining Fetch to, for example, fill a playback buffer with a certain
+number of groups prior to the live edge of a track.
+
 A Fetch Type other than the above MUST be treated as an error.
 
 A publisher responds to a FETCH request with either a FETCH_OK or a FETCH_ERROR

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1536,7 +1536,7 @@ with the following fields dynamically determined from the corresponding Subscrib
 
 * Track Name: Same as in the corresponding Subscribe
 
-* StartGroup: LatestGroup as determined for the Subscribe minus Previous Groupe Count from the Joining Fetch
+* StartGroup: LatestGroup as determined for the Subscribe minus Previous Group Count from the Joining Fetch
 
 * StartObject: Always 0
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1600,7 +1600,9 @@ requested.
 
 Field present only for Joining Fetch (0x2):
 
-* Preceding Group Offset: The group offset for the Fetch prior and relative to the StartGroup of the corresponding Subscribe
+* Preceding Group Offset: The group offset for the Fetch prior and relative
+to the StartGroup of the corresponding Subscribe. A value of 0 indicates
+the current Group.
 
 Objects that are not yet published will not be retrieved by a FETCH.
 The latest available Object is indicated in the FETCH_OK, and is the last
@@ -1616,23 +1618,32 @@ the publisher MUST return FETCH_ERROR with error code 'No Objects'.
 
 ### Calculating the Range of a Joining Fetch
 
-A publisher which receives a Fetch message with a Fetch Type of 0x2 must treat it as a Fetch
-with a range dynamically determined by the Preceding Group Offset (PGO) field and values derived
-from to the corresponding Subscribe message (hereafter "the Subscribe").
+A publisher which receives a Fetch message with a Fetch Type of 0x2 treats it
+as a Fetch with a range dynamically determined by the Preceding Group Offset (PGO)
+field and field values derived from the corresponding SUBSCRIBE message
+(hereafter "the Subscribe").
 
 The following values are used:
 
 * Resolved Subscribe Start Group:
-  * For Subscribes with Filter Type Latest Object or Latest Group, this is equal to Largest Group ID.
-  * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartGroup field of the Subscribe message
+  * For Subscribes with Filter Type Latest Object or Latest Group,
+    this is equal to Largest Group ID.
+  * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange,
+    this is equal to the StartGroup field of the Subscribe message
 * Resolved Subscribe Start Object:
   * For Subscribes with Filter Type Latest Object, this is equal to Largest Object ID.
   * For Subscribes with Filter Type Latest Group, this is 0
-  * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartObject field of the Subscribe message
-* Preceding Group Offset: A field in the Joining Fetch message indicating the relative offset from the start of the Subscribe
+  * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange,
+    this is equal to the StartObject field of the Subscribe message
+* Preceding Group Offset: A field in the Joining Fetch message indicating the
+  relative offset from the start of the Subscribe
 
-The Resolved Subscribe Start values for a Joining Fetch MUST correspond to the referenced Subscribe within the same session so that the ranges of Objects covered by the Fetch and Subscribe are contiguous and non-overlapping.
-If a relay answers the referenced Subscribe with a `SUBSCRIBE_OK` that has ContentExists set to 0, it MUST respond to the Joining Fetch with a `FETCH_ERROR`.
+The Resolved Subscribe Start values for a Joining Fetch MUST correspond to the
+referenced Subscribe within the same session so that the ranges of Objects covered
+by the Fetch and Subscribe are contiguous and non-overlapping.
+If no Objects have been published for the track, so the SUBSCRIBE_OK has a
+ContentExists value of 0, the publisher MUST respond to the Joining Fetch with a
+FETCH_ERROR.
 
 The publisher receiving a Joining Fetch computes the fetch range as follows:
 
@@ -1647,7 +1658,8 @@ Else, if Resolved Subscribe Start Object is 1 or more:
 * Fetch EndGroup: Resolved Subscribe Start Group
 * Fetch EndObject: Resolved Subscribe Start Object
 
-If Fetch EndGroup < Fetch StartGroup respond with a `FETCH_ERROR`.
+If Fetch EndGroup < Fetch StartGroup, there are no Objects to retrieve,
+so respond with a `FETCH_ERROR`.
 
 ## FETCH_CANCEL {#message-fetch-cancel}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1500,10 +1500,11 @@ UNSUBSCRIBE Message {
 
 ## FETCH {#message-fetch}
 
-A subscriber issues a FETCH to a publisher to request a range of already published
-objects within a track. The publisher responding to a FETCH is responsible for retrieving
-all available Objects. If there are gaps between Objects, the publisher omits them from the
-fetch response. All omitted objects have status Object Not Available.
+A subscriber issues a FETCH to a publisher to request a range of already
+published objects within a track. The publisher responding to a FETCH is
+responsible for retrieving all available Objects. If there are gaps between Objects,
+the publisher omits them from the fetch response. All omitted objects have status
+Object Not Available.
 
 **Fetch Types**
 
@@ -1512,13 +1513,14 @@ There are two types of Fetch messages:
 Standalone Fetch (0x1) : A Fetch of Objects performed independently of any Subscribe.
 
 Joining Fetch (0x2) : A Fetch joined together with a Subscribe. A Joining Fetch
-shares the same Subscribe ID as an already-sent Subscribe. A publisher receiving a Joining
-Fetch should use properties of the associated Subscribe to determine the Track Namespace,
-Track, StartGroup, StartObject, EndGroup, and EndObject for the Joining Fetch such that it is
-contiguous with the associated Subscribe and begins Preceding Group Offset prior.
+shares the same Subscribe ID as an already-sent Subscribe. A publisher receiving a
+Joining Fetch should use properties of the associated Subscribe to determine the
+Track Namespace, Track, StartGroup, StartObject, EndGroup, and EndObject for the
+Joining Fetch such that it is contiguous with the associated Subscribe and begins
+Preceding Group Offset prior.
 
-A Subscriber can use a Joining Fetch to, for example, fill a playback buffer with a certain
-number of groups prior to the live edge of a track.
+A Subscriber can use a Joining Fetch to, for example, fill a playback buffer with a
+certain number of groups prior to the live edge of a track.
 
 A Fetch Type other than the above MUST be treated as an error.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -564,8 +564,6 @@ code, as defined below:
 |------|---------------------------|
 | 0x6  | Too Many Subscribes       |
 |------|---------------------------|
-| 0x7  | Invalid Subscribe ID      |
-|------|---------------------------|
 | 0x10 | GOAWAY Timeout            |
 |------|---------------------------|
 | 0x11 | Control Message Timeout   |
@@ -588,9 +586,6 @@ code, as defined below:
 
 * Too Many Subscribes: The session was closed because the subscriber used
   a Subscribe ID equal or larger than the current Maximum Subscribe ID.
-
-* Invalid Subscribe ID: The session was closed because the subscriber sent
-  a Joining Fetch with a Subscribe ID that does not exist.
 
 * GOAWAY Timeout: The session was closed because the peer took too long to
   close the session in response to a GOAWAY ({{message-goaway}}) message.
@@ -1477,8 +1472,7 @@ is a variable length integer that MUST be unique and monotonically increasing
 within a session. For a Standalone Fetch a new Subscribe ID MUST be used. For
 a Joining Fetch, the Subscribe ID MUST correspond to a Subscribe which has already
 been sent. If a publisher receives a Joining Fetch with a Subscribe ID that does
-not correspond to an existing Subscribe, it MUST close the session with an
-Invalid Subscribe ID error.
+not correspond to an existing Subscribe, it MUST respond with a Fetch Error.
 
 * Subscriber Priority: Specifies the priority of a fetch request relative to
 other subscriptions or fetches in the same session. Lower numbers get higher

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1535,11 +1535,11 @@ from to the corresponding Subscribe message (hereafter "the Subscribe").
 The following values are used:
 
 * Resolved Subscribe Start Group:
-  * For Subscribes with Filter Type LatestObject or LatestGroup, this is equal to Largest Group ID.
+  * For Subscribes with Filter Type Latest Object or Latest Group, this is equal to Largest Group ID.
   * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartGroup field of the Subscribe message
 * Resolved Subscribe Start Object:
-  * For Subscribes with Filter Type LatestObject, this is equal to Largest Object ID.
-  * For Subscribes with Filter Type LatestGroup, this is 0
+  * For Subscribes with Filter Type Latest Object, this is equal to Largest Object ID.
+  * For Subscribes with Filter Type Latest Group, this is 0
   * For Subscribes with Filter Type AbsoluteStart or AbsoluteRange, this is equal to the StartObject field of the Subscribe message
 * Preceding Group Offset: A field in the Joining Fetch message indicating the relative offset from the start of the Subscribe
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1530,6 +1530,9 @@ Preceding Group Offset prior.
 A Subscriber can use a Joining Fetch to, for example, fill a playback buffer with a
 certain number of groups prior to the live edge of a track.
 
+A Joining Fetch is only permitted when the associated Subscribe has the Filter
+Type Latest Object.
+
 A Fetch Type other than the above MUST be treated as an error.
 
 A publisher responds to a FETCH request with either a FETCH_OK or a FETCH_ERROR
@@ -1633,17 +1636,8 @@ field and field values derived from the corresponding SUBSCRIBE message
 
 The following values are used:
 
-* Resolved Subscribe Start Group:
-  * For Latest Object or Latest Group filter types, this is Largest Group ID.
-  * For AbsoluteStart or AbsoluteRange filter types, this is the StartGroup field
-    of the SUBSCRIBE message
-* Resolved Subscribe Start Object:
-  * For the Latest Object filter type, this is the Largest Object ID.
-  * For the Latest Group filter type, this is 0
-  * For AbsoluteStart or AbsoluteRange filter types, this is the StartObject field
-    of the SUBSCRIBE message
-* Preceding Group Offset: A field in the Joining Fetch message indicating the
-  relative offset from the start of the Subscribe
+* Resolved Subscribe Start Group: the Largest Group ID of the associated Subscribe.
+* Resolved Subscribe Start Object: the Largest Object ID of the associated Subscribe.
 
 The Resolved Subscribe Start values for a Joining Fetch MUST correspond to the
 referenced Subscribe within the same session so that the ranges of Objects covered

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -592,7 +592,7 @@ code, as defined below:
 * Invalid Subscribe ID: The session was closed because the subscriber sent
   a Joining Fetch with a Subscribe ID that does not exist.
 
-* GOAWAY Timeout: The session was closed because the client took too long to
+* GOAWAY Timeout: The session was closed because the peer took too long to
   close the session in response to a GOAWAY ({{message-goaway}}) message.
   See session migration ({{session-migration}}).
 


### PR DESCRIPTION
This PR adds the desired "Join" functionality as [discussed](https://meetecho-player.ietf.org/playout/?session=IETF121-MOQ-20241104-1730) [at IETF 121 in Dublin](https://datatracker.ietf.org/meeting/121/session/moq)[^1]

Adding this functionality to Fetch unblocks further simplifications of Subscribe, allowing us to more clearly delineate between "past" (Fetch) and "future" (Subscribe). (see https://github.com/moq-wg/moq-transport/issues/598, https://github.com/moq-wg/moq-transport/pull/510#pullrequestreview-2260597641, etc.)

There are several ways we could allow a publisher to "atomically" join a Fetch and a Subscribe.
At IETF 121, @wilaw presented [slides](https://datatracker.ietf.org/meeting/121/materials/slides-121-moq-join-api-proposal-00) showing API options:
1. a new macro-like singular JOIN message that is decomposed at the publisher into both a SUBSCRIBE and a FETCH
2. a modified form of FETCH that can be joined together with an existing Subscribe 

The consensus of the discussion seemed to heavily favor the latter design, so, as was requested, this PR is written as a modified form of Fetch: **Joining Fetch**.

This PR:
- Adds "**Fetch Type**" field to Fetch messages
- Redefines pre-existing behavior as a Fetch Type: "**Standalone Fetch**"
- Defines new Fetch Type: "**Joining Fetch**"
- Defines new error code: "**Invalid Subscribe ID**"

[^1]: [21:18 ](https://youtu.be/zs5Y424tASE?feature=shared&t=1278) in the recording. Note: the [Meetecho page](https://meetecho-player.ietf.org/playout/?session=IETF121-MOQ-20241104-1730) includes the chat, synced to the video.