### PR TITLE
Message flows and endpoint state management (Was: ANNOUNCE)

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -895,8 +895,8 @@ control message with a `Track Namespace` ({{model-track}}).
 The ANNOUNCE enables the relay to know which publisher to forward a
 SUBSCRIBE to.
 
-Relays MUST ensure that publishers are authorized by verifying that the
-publisher is authorized to publish the content associated with the set of
+Relays MUST verify that publishers are authorized to publish
+the content associated with the set of
 tracks whose Track Namespace matches the announced namespace. Where the
 authorization and identification of the publisher occurs depends on the way the
 relay is managed and is application specific.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -600,7 +600,11 @@ code, as defined below:
   stream. If an endpoint times out waiting for a new object header on an
   open subgroup stream, it MAY send a STOP_SENDING on that stream, terminate
   the subscription, or close the session with an error.
+<<<<<<< HEAD
 
+=======
+  
+>>>>>>> 297094f (Add session errors for control and data timeout)
 ## Migration {#session-migration}
 
 MOQT requires a long-lived and stateful session. However, a service

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -874,6 +874,48 @@ allows relays to make only a single upstream subscription for the
 track. The published content received from the upstream subscription
 request is cached and shared among the pending subscribers.
 
+The application SHOULD use a relevant error code in SUBSCRIBE_ERROR,
+as defined below:
+
+|------|---------------------------|
+| Code | Reason                    |
+|-----:|:--------------------------|
+| 0x0  | Internal Error            |
+|------|---------------------------|
+| 0x1  | Invalid Range             |
+|------|---------------------------|
+| 0x2  | Retry Track Alias         |
+|------|---------------------------|
+| 0x3  | Track Does Not Exist      |
+|------|---------------------------|
+| 0x4  | Unauthorized              |
+|------|---------------------------|
+| 0x5  | Timeout                   |
+|------|---------------------------|
+
+The application SHOULD use a relevant status code in
+SUBSCRIBE_DONE, as defined below:
+
+|------|---------------------------|
+| Code | Reason                    |
+|-----:|:--------------------------|
+| 0x0  | Unsubscribed              |
+|------|---------------------------|
+| 0x1  | Internal Error            |
+|------|---------------------------|
+| 0x2  | Unauthorized              |
+|------|---------------------------|
+| 0x3  | Track Ended               |
+|------|---------------------------|
+| 0x4  | Subscription Ended        |
+|------|---------------------------|
+| 0x5  | Going Away                |
+|------|---------------------------|
+| 0x6  | Expired                   |
+|------|---------------------------|
+| 0x7  | Too Far Behind            |
+|------|---------------------------|
+
 ### Graceful Publisher Relay Switchover
 
 This section describes behavior a subscriber MAY implement
@@ -1600,22 +1642,6 @@ message for which this response is provided.
 
 * Reason Phrase: Provides the reason for announcement error.
 
-The following error codes are defined:
-
-|------|---------------------------|
-| Code | Reason                    |
-|-----:|:--------------------------|
-| 0x0  | Internal Error            |
-|------|---------------------------|
-| 0x1  | Uninterested              |
-|------|---------------------------|
-| 0x2  | Unauthorized              |
-|------|---------------------------|
-| 0x3  | Timeout                   |
-|------|---------------------------|
-| 0x4  | Announce Not Supported    |
-|------|---------------------------|
-
 ## ANNOUNCE_CANCEL {#message-announce-cancel}
 
 The subscriber sends an `ANNOUNCE_CANCEL` control message to
@@ -1803,24 +1829,6 @@ SUBSCRIBE_ERROR
   the subscriber MUST close the connection with a Duplicate Track Alias error
   ({{session-termination}}).
 
-The following error codes are defined:
-
-|------|---------------------------|
-| Code | Reason                    |
-|-----:|:--------------------------|
-| 0x0  | Internal Error            |
-|------|---------------------------|
-| 0x1  | Invalid Range             |
-|------|---------------------------|
-| 0x2  | Retry Track Alias         |
-|------|---------------------------|
-| 0x3  | Track Does Not Exist      |
-|------|---------------------------|
-| 0x4  | Unauthorized              |
-|------|---------------------------|
-| 0x5  | Timeout                   |
-|------|---------------------------|
-
 ## FETCH_OK {#message-fetch-ok}
 
 A publisher sends a FETCH_OK control message in response to successful fetches.
@@ -1885,23 +1893,6 @@ FETCH_ERROR
 
 * Reason Phrase: Provides the reason for fetch error.
 
-The following error codes are defined:
-
-|------|---------------------------|
-| Code | Reason                    |
-|-----:|:--------------------------|
-| 0x0  | Internal Error            |
-|------|---------------------------|
-| 0x1  | Invalid Range             |
-|------|---------------------------|
-| 0x3  | Track Does Not Exist      |
-|------|---------------------------|
-| 0x4  | Unauthorized              |
-|------|---------------------------|
-| 0x5  | Timeout                   |
-|------|---------------------------|
-
-
 ## SUBSCRIBE_DONE {#message-subscribe-done}
 
 A publisher sends a `SUBSCRIBE_DONE` message to indicate it is done publishing
@@ -1962,29 +1953,6 @@ opened for this subscription.  The subscriber can remove all subscription state
 once the same number of streams have been processed.
 
 * Reason Phrase: Provides the reason for subscription error.
-
-The application SHOULD use a relevant status code in SUBSCRIBE_DONE, as defined
- below:
-
-|------|---------------------------|
-| Code | Reason                    |
-|-----:|:--------------------------|
-| 0x0  | Unsubscribed              |
-|------|---------------------------|
-| 0x1  | Internal Error            |
-|------|---------------------------|
-| 0x2  | Unauthorized              |
-|------|---------------------------|
-| 0x3  | Track Ended               |
-|------|---------------------------|
-| 0x4  | Subscription Ended        |
-|------|---------------------------|
-| 0x5  | Going Away                |
-|------|---------------------------|
-| 0x6  | Expired                   |
-|------|---------------------------|
-| 0x7  | Too Far Behind            |
-|------|---------------------------|
 
 ## MAX_SUBSCRIBE_ID {#message-max-subscribe-id}
 
@@ -2176,25 +2144,6 @@ title="MOQT SUBSCRIBE_ANNOUNCES_ERROR Message"}
 failure.
 
 * Reason Phrase: Provides the reason for the namespace subscription error.
-
-The application SHOULD use a relevant error code in a
-SUBSCRIBE_NAMESPACES_ERROR, as defined below.
-
-|------|--------------------------------|
-| Code | Reason                         |
-|-----:|:-------------------------------|
-| 0x0  | Internal Error                 |
-|------|--------------------------------|
-| 0x1  | Message Not Supported          |
-|------|--------------------------------|
-| 0x2  | Will Never Announce Namespace  |
-|------|--------------------------------|
-| 0x3  | Unauthorized                   |
-|------|------------------------------- |
-| 0x4  | Timeout                        |
-|------|--------------------------------|
-
-
 
 # Data Streams {#data-streams}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -631,14 +631,6 @@ expects more OBJECTs to be delivered. The server closes the session with a
 Discovery of MoQT servers is always done out-of-band. Namespace discovery can be
 done in the context of an established MoQT session.
 
-Throughout this section, "publishers" refer to endpoints that can deliver
-objects in response to SUBSCRIBE or FETCH messages for a particular track, and
-"subscribers" refer to endpoints that might send SUBSCRIBE or FETCH messages for
-a track. An endpoint can be both a publisher and subscriber in a session, for
-different tracks. If a relay, it can be a publisher for a track in one session
-and a subscriber for it in another session. But an endpoint cannot be publisher
-and subscriber for the same track in the same session.
-
 Given sufficient out of band information, it is valid for a subscriber
 to send a SUBSCRIBE or FETCH message to a publisher (including a relay) without
 any previous MoQT messages besides SETUP. However, SUBSCRIBE_ANNOUNCES and

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -837,7 +837,7 @@ Relays MAY cache Objects, but are not required to.
 
 ## Subscriber Interactions
 
-Subscribers subscribe to tracks by sending  a SUBSCRIBE
+Subscribers subscribe to tracks by sending a SUBSCRIBE
 ({{message-subscribe-req}}) control message for each track of
 interest. Relays MUST ensure subscribers are authorized to access the
 content associated with the track. The authorization

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -631,11 +631,19 @@ expects more OBJECTs to be delivered. The server closes the session with a
 Discovery of MoQT servers is always done out-of-band. Namespace discovery can be
 done in the context of an established MoQT session.
 
+Throughout this section, "publishers" refer to endpoints that can deliver
+objects in response to SUBSCRIBE or FETCH messages for a particular track, and
+"subscribers" refer to endpoints that might send SUBSCRIBE or FETCH messages for
+a track. An endpoint can be both a publisher and subscriber in a session, for
+different tracks. If a relay, it can be a publisher for a track in one session
+and a subscriber for it in another session. But an endpoint cannot be publisher
+and subscriber for the same track in the same session.
+
 Given sufficient out of band information, it is valid for a subscriber
 to send a SUBSCRIBE or FETCH message to a publisher (including a relay) without
 any previous MoQT messages besides SETUP. However, SUBSCRIBE_ANNOUNCES and
 ANNOUNCE messages provide an in-band means of discovery of subscribers and
-publishers, respectively.
+publishers for a namespace.
 
 The syntax of these messages is described in {{message}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -600,11 +600,7 @@ code, as defined below:
   stream. If an endpoint times out waiting for a new object header on an
   open subgroup stream, it MAY send a STOP_SENDING on that stream, terminate
   the subscription, or close the session with an error.
-<<<<<<< HEAD
 
-=======
-  
->>>>>>> 297094f (Add session errors for control and data timeout)
 ## Migration {#session-migration}
 
 MOQT requires a long-lived and stateful session. However, a service

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -679,8 +679,7 @@ application to inform the search for additional subscribers for a namespace,
 or abandoning the attempt to publish under this namespace. This might be
 especially useful in upload or chat applications. A subscriber MUST send exactly
 one ANNOUNCE_OK or ANNOUNCE_ERROR in response to an ANNOUNCE. The publisher
-SHOULD close the session with a protocol error if it detects receiving more than
-one.
+SHOULD close the session with a protocol error if it receives more than one.
 
 An UNANNOUNCE message withdraws a previous ANNOUNCE, although it is not a
 protocol error for the subscriber to send a SUBSCRIBE or FETCH message after

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -838,8 +838,8 @@ Relays MAY cache Objects, but are not required to.
 
 ## Subscriber Interactions
 
-Subscribers interact with the Relays by sending a SUBSCRIBE
-({{message-subscribe-req}}) control message for the tracks of
+Subscribers subscribe to tracks by sending  a SUBSCRIBE
+({{message-subscribe-req}}) control message for each track of
 interest. Relays MUST ensure subscribers are authorized to access the
 content associated with the track. The authorization
 information can be part of subscription request itself or part of the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -888,20 +888,21 @@ to the old relay can be stopped with an UNSUBSCRIBE.
 
 Publishing through the relay starts with publisher sending ANNOUNCE
 control message with a `Track Namespace` ({{model-track}}).
-The ANNOUNCE enables the relay to know which publisher to forward a
-SUBSCRIBE to, if the track name belongs to the namespace indicated in
-the ANNOUNCE.
+The announce enables the relay to know which publisher to forward a
+SUBSCRIBE to.
 
-Relays MUST ensure that publishers are authorized by verifying that the
-publisher is authorized to publish the content associated with the set of
-tracks whose Track Namespace matches the announced namespace. Where the
-authorization and identification of the publisher occurs depends on the way the
-relay is managed and is application specific.
+Relays MUST ensure that publishers are authorized by:
+
+- Verifying that the publisher is authorized to publish the content
+  associated with the set of tracks whose Track Namespace matches the
+  announced namespace. Where the authorization and identification of
+  the publisher occurs depends on the way the relay is managed and
+  is application specific.
 
 A Relay can receive announcements from multiple publishers for the same
 Track Namespace and it SHOULD respond with the same response to each of the
 publishers, as though it was responding to an ANNOUNCE
-from a single publisher for a given track namespace.
+from a single publisher for a given tracknamespace.
 
 When a publisher wants to stop
 new subscriptions for an announced namespace it sends an UNANNOUNCE.
@@ -918,7 +919,7 @@ publisher that has announced the subscription's namespace, unless it
 already has an active subscription for the Objects requested by the
 incoming SUBSCRIBE request from all available publishers.
 
-When a relay receives an incoming ANNOUNCE for a given namespace, for
+When a relay receives an incoming ANNOUCE for a given namespace, for
 each active upstream subscription that matches that namespace, it SHOULD send a
 SUBSCRIBE to the publisher that sent the ANNOUNCE.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -720,7 +720,7 @@ with FETCH_CANCEL, but MUST send FETCH_CANCEL.
 The Publisher can destroy subscription or fetch state as soon as it has received
 UNSUBSCRIBE or FETCH_CANCEL, respectively. It MUST reset any open streams
 associated with the SUBSCRIBE or FETCH. It can also destroy state after closing
-on the FETCH data stream.
+the FETCH data stream.
 
 The publisher can immediately delete SUBSCRIBE state after sending
 SUBSCRIBE_DONE, but MUST NOT send it until it has closed all related streams. It

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -646,9 +646,10 @@ SUBSCRIBE_ANNOUNCES to publishers/relays it has discovered. The recipient of
 this message will send any relevant ANNOUNCE messages for that namespace, or
 subset of that namespace.
 
-A publisher MUST send exactly one SUBSCRIBE_NAMESPACES_OK or
-SUBSCRIBE_NAMESPACES_ERROR. The subscriber SHOULD close the session with a
-protocol error if it detects receiving more than one.
+A publisher MUST send exactly one SUBSCRIBE_ANNOUNCES_OK or
+SUBSCRIBE_ANNOUNCES_ERROR  in response to a SUBSCRIBE_ANNOUNCES.
+The subscriber SHOULD close the session with a protocol error if it detects receiving
+more than one.
 
 An UNSUBSCRIBE_NAMESPACES withdraws a previous SUBSCRIBE_NAMESPACES. It does
 not prohibit the receiver (publisher) from sending further ANNOUNCE messages.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -712,8 +712,8 @@ of a SUBSCRIBE_DONE or SUBSCRIBE_ERROR. Note that SUBSCRIBE_DONE does not
 usually indicate that state can immediately be destroyed, see
 {{message-subscribe-done}}.
 
-A subscriber keeps FETCH state until it sends FETCH_CANCEL; receives
-FETCH_ERROR; or receives a FIN or RESET_STREAM for the FETCH data stream. If the
+A subscriber keeps FETCH state until it sends FETCH_CANCEL, receives
+FETCH_ERROR, or receives a FIN or RESET_STREAM for the FETCH data stream. If the
 data stream is already open, it MAY send STOP_SENDING for the data stream along
 with FETCH_CANCEL, but MUST send FETCH_CANCEL.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -911,7 +911,10 @@ namespace it previously responded ANNOUNCE_OK to by sending an
 ANNOUNCE_CANCEL.
 
 A relay manages sessions from multiple publishers and subscribers,
-connecting them based on the track namespace.
+connecting them based on the track namespace. This MUST use an exact
+match on track namespace unless otherwise negotiated by the application.
+For example, a SUBSCRIBE namespace=foobar message will be forwarded to
+the session that sent ANNOUNCE namespace=foobar.
 
 When a relay receives an incoming SUBSCRIBE request that triggers an
 upstream subscription, it SHOULD send a SUBSCRIBE request to each

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -653,7 +653,7 @@ more than one.
 
 An UNSUBSCRIBE_NAMESPACES withdraws a previous SUBSCRIBE_NAMESPACES. It does
 not prohibit the receiver (publisher) from sending further ANNOUNCE messages.
-The receiver of a SUBSCRIBE_NAMESPACES_OK or SUBSCRIBE_NAMESPACES_ERROR should
+The receiver of a SUBSCRIBE_NAMESPACES_OK or SUBSCRIBE_NAMESPACES_ERROR ought to
 forward the result to the application, so that it can make decisions about
 further publishers to contact.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -657,10 +657,13 @@ protocol error if it detects receiving more than one.
 
 ## ANNOUNCE
 
-A publisher MAY send ANNOUNCE messages to any subscriber. It SHOULD send them
-if it has received a SUBSCRIBE_ANNOUNCES for that namespace, or a superset of
-that namespace. An ANNOUNCE increases the likelihood of a subsequent successful
-SUBSCRIBE or FETCH.
+A publisher MAY send ANNOUNCE messages to any subscriber. An ANNOUNCE increases
+the likelihood of a subsequent successful SUBSCRIBE or FETCH. It SHOULD send
+an ANNOUNCE if it has received a SUBSCRIBE_ANNOUNCES for that namespace, or a
+superset of that namespace. However, a publisher SHOULD NOT send an ANNOUNCE
+advertising a namespace equal to, or a subset of, a namespace for which the
+receiver sent an earlier ANNOUNCE (i.e. an ANNOUNCE ought not to be echoed back
+to its sender).
 
 An UNANNOUNCE message negates the meaning of an ANNOUNCE, although it is not a
 protocol error for the subscriber to send a SUBSCRIBE or FETCH message anyway.
@@ -710,48 +713,6 @@ A publisher MUST send exactly one SUBSCRIBE_OK or SUBSCRIBE_ERROR in response to
 a SUBSCRIBE. It MUST send exactly one FETCH_OK or FETCH_ERROR in response to a
 FETCH. The subscriber SHOULD close the session with a protocol error if it
 detects receiving more than one.
-
-The application SHOULD use a relevant error code in SUBSCRIBE_ERROR or
-FETCH_ERROR, as defined below:
-
-|------|---------------------------|
-| Code | Reason                    |
-|-----:|:--------------------------|
-| 0x0  | Internal Error            |
-|------|---------------------------|
-| 0x1  | Invalid Range             |
-|------|---------------------------|
-| 0x2  | Retry Track Alias         |
-|------|---------------------------|
-| 0x3  | Track Does Not Exist      |
-|------|---------------------------|
-| 0x4  | Unauthorized              |
-|------|---------------------------|
-| 0x5  | Timeout                   |
-|------|---------------------------|
-
-The application SHOULD use a relevant status code in
-SUBSCRIBE_DONE or a FETCH RESET_STREAM, as defined below:
-
-|------|---------------------------|
-| Code | Reason                    |
-|-----:|:--------------------------|
-| 0x0  | Unsubscribed              |
-|------|---------------------------|
-| 0x1  | Internal Error            |
-|------|---------------------------|
-| 0x2  | Unauthorized              |
-|------|---------------------------|
-| 0x3  | Track Ended               |
-|------|---------------------------|
-| 0x4  | Subscription Ended        |
-|------|---------------------------|
-| 0x5  | Going Away                |
-|------|---------------------------|
-| 0x6  | Expired                   |
-|------|---------------------------|
-| 0x7  | Too Far Behind            |
-|------|---------------------------|
 
 # Priorities {#priorities}
 
@@ -1623,6 +1584,23 @@ message for which this response is provided.
 
 * Reason Phrase: Provides the reason for announcement error.
 
+The application SHOULD use a relevant error code in an ANNOUNCE_ERROR, as
+defined below.
+
+|------|---------------------------|
+| Code | Reason                    |
+|-----:|:--------------------------|
+| 0x0  | Internal Error            |
+|------|---------------------------|
+| 0x1  | Uninterested              |
+|------|---------------------------|
+| 0x2  | Unauthorized              |
+|------|---------------------------|
+| 0x3  | Timeout                   |
+|------|---------------------------|
+| 0x4  | Announce Not Supported    |
+|------|---------------------------|
+
 ## ANNOUNCE_CANCEL {#message-announce-cancel}
 
 The subscriber sends an `ANNOUNCE_CANCEL` control message to
@@ -1810,6 +1788,23 @@ SUBSCRIBE_ERROR
   the subscriber MUST close the connection with a Duplicate Track Alias error
   ({{session-termination}}).
 
+The application SHOULD use a relevant error code in SUBSCRIBE_ERROR, as defined below:
+
+|------|---------------------------|
+| Code | Reason                    |
+|-----:|:--------------------------|
+| 0x0  | Internal Error            |
+|------|---------------------------|
+| 0x1  | Invalid Range             |
+|------|---------------------------|
+| 0x2  | Retry Track Alias         |
+|------|---------------------------|
+| 0x3  | Track Does Not Exist      |
+|------|---------------------------|
+| 0x4  | Unauthorized              |
+|------|---------------------------|
+| 0x5  | Timeout                   |
+|------|---------------------------|
 
 ## FETCH_OK {#message-fetch-ok}
 
@@ -1875,6 +1870,22 @@ FETCH_ERROR
 
 * Reason Phrase: Provides the reason for fetch error.
 
+The application SHOULD use a relevant error code in FETCH_ERROR, as defined below:
+
+|------|---------------------------|
+| Code | Reason                    |
+|-----:|:--------------------------|
+| 0x0  | Internal Error            |
+|------|---------------------------|
+| 0x1  | Invalid Range             |
+|------|---------------------------|
+| 0x3  | Track Does Not Exist      |
+|------|---------------------------|
+| 0x4  | Unauthorized              |
+|------|---------------------------|
+| 0x5  | Timeout                   |
+|------|---------------------------|
+
 
 ## SUBSCRIBE_DONE {#message-subscribe-done}
 
@@ -1936,6 +1947,29 @@ opened for this subscription.  The subscriber can remove all subscription state
 once the same number of streams have been processed.
 
 * Reason Phrase: Provides the reason for subscription error.
+
+The application SHOULD use a relevant status code in SUBSCRIBE_DONE, as defined
+ below:
+
+|------|---------------------------|
+| Code | Reason                    |
+|-----:|:--------------------------|
+| 0x0  | Unsubscribed              |
+|------|---------------------------|
+| 0x1  | Internal Error            |
+|------|---------------------------|
+| 0x2  | Unauthorized              |
+|------|---------------------------|
+| 0x3  | Track Ended               |
+|------|---------------------------|
+| 0x4  | Subscription Ended        |
+|------|---------------------------|
+| 0x5  | Going Away                |
+|------|---------------------------|
+| 0x6  | Expired                   |
+|------|---------------------------|
+| 0x7  | Too Far Behind            |
+|------|---------------------------|
 
 ## MAX_SUBSCRIBE_ID {#message-max-subscribe-id}
 
@@ -2127,6 +2161,23 @@ title="MOQT SUBSCRIBE_ANNOUNCES_ERROR Message"}
 failure.
 
 * Reason Phrase: Provides the reason for the namespace subscription error.
+
+The application SHOULD use a relevant error code in a
+SUBSCRIBE_NAMESPACES_ERROR, as defined below.
+
+|------|--------------------------------|
+| Code | Reason                         |
+|-----:|:-------------------------------|
+| 0x0  | Internal Error                 |
+|------|--------------------------------|
+| 0x1  | Message Not Supported          |
+|------|--------------------------------|
+| 0x2  | Will Never Announce Namespace  |
+|------|--------------------------------|
+| 0x3  | Unauthorized                   |
+|------|------------------------------- |
+| 0x4  | Timeout                        |
+|------|--------------------------------|
 
 
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -866,8 +866,9 @@ cache need to protect against cache poisoning.
 A relay MUST NOT reorder or drop objects received on a multi-object stream when
 forwarding to subscribers, unless it has application specific information.
 
-Relays MAY aggregate authorized subscriptions for a given track when
-multiple subscribers request the same track. Subscription aggregation
+Relays SHOULD aggregate authorized subscriptions for a given track when
+multiple subscribers request the same track, using SUBSCRIBE_UPDATE when new
+subscriptions change the aggregate properties. Subscription aggregation
 allows relays to make only a single upstream subscription for the
 track. The published content received from the upstream subscription
 request is cached and shared among the pending subscribers.
@@ -888,21 +889,19 @@ to the old relay can be stopped with an UNSUBSCRIBE.
 
 Publishing through the relay starts with publisher sending ANNOUNCE
 control message with a `Track Namespace` ({{model-track}}).
-The announce enables the relay to know which publisher to forward a
+The ANNOUNCE enables the relay to know which publisher to forward a
 SUBSCRIBE to.
 
-Relays MUST ensure that publishers are authorized by:
-
-- Verifying that the publisher is authorized to publish the content
-  associated with the set of tracks whose Track Namespace matches the
-  announced namespace. Where the authorization and identification of
-  the publisher occurs depends on the way the relay is managed and
-  is application specific.
+Relays MUST ensure that publishers are authorized by verifying that the
+publisher is authorized to publish the content associated with the set of
+tracks whose Track Namespace matches the announced namespace. Where the
+authorization and identification of the publisher occurs depends on the way the
+relay is managed and is application specific.
 
 A Relay can receive announcements from multiple publishers for the same
 Track Namespace and it SHOULD respond with the same response to each of the
 publishers, as though it was responding to an ANNOUNCE
-from a single publisher for a given tracknamespace.
+from a single publisher for a given track namespace.
 
 When a publisher wants to stop
 new subscriptions for an announced namespace it sends an UNANNOUNCE.
@@ -911,10 +910,7 @@ namespace it previously responded ANNOUNCE_OK to by sending an
 ANNOUNCE_CANCEL.
 
 A relay manages sessions from multiple publishers and subscribers,
-connecting them based on the track namespace. This MUST use an exact
-match on track namespace unless otherwise negotiated by the application.
-For example, a SUBSCRIBE namespace=foobar message will be forwarded to
-the session that sent ANNOUNCE namespace=foobar.
+connecting them based on the track namespace.
 
 When a relay receives an incoming SUBSCRIBE request that triggers an
 upstream subscription, it SHOULD send a SUBSCRIBE request to each
@@ -922,7 +918,7 @@ publisher that has announced the subscription's namespace, unless it
 already has an active subscription for the Objects requested by the
 incoming SUBSCRIBE request from all available publishers.
 
-When a relay receives an incoming ANNOUCE for a given namespace, for
+When a relay receives an incoming ANNOUNCE for a given namespace, for
 each active upstream subscription that matches that namespace, it SHOULD send a
 SUBSCRIBE to the publisher that sent the ANNOUNCE.
 
@@ -1433,8 +1429,8 @@ See {{priorities}}.
 ## UNSUBSCRIBE {#message-unsubscribe}
 
 A subscriber issues a `UNSUBSCRIBE` message to a publisher indicating it is no
-longer interested in receiving media for the specified track and requests that
-objects stop being sent as soon as possible.
+longer interested in receiving media for the specified track and Objects
+should stop being sent as soon as possible.
 
 The format of `UNSUBSCRIBE` is as follows:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -626,6 +626,132 @@ and announcements. The client can choose to delay closing the session if it
 expects more OBJECTs to be delivered. The server closes the session with a
 'GOAWAY Timeout' if the client doesn't close the session quickly enough.
 
+# Track Discovery and Retrieval (#track-discovery}
+
+Discovery of MoQT servers is always done out-of-band. Track discovery is done in
+the context of an established MoQT session. The session client might be a
+subscriber, publisher, or both.
+
+Given sufficient out of band information, it is valid for a subscriber
+to send a SUBSCRIBE or FETCH message to a publisher (including a relay) without
+any previous MoQT messages besides SETUP. However, SUBSCRIBE_NAMESPACES and
+ANNOUNCE messages provide an in-band means of discovery of subscribers and
+publishers.
+
+The syntax of these messages is described in {{messages}}.
+
+## SUBSCRIBE_ANNOUNCES
+
+If the subscriber is aware of a namespace of interest, it can send
+SUBSCRIBE_ANNOUNCES to publishers/relays it has discovered. This message
+increases the likelihood that publishers will send relevant ANNOUNCE messages
+for that namespace.
+
+An UNSUBSCRIBE_NAMESPACES negates the effect of a SUBSCRIBE_NAMESPACES. It does
+not prohibit the receiver from sending further ANNOUNCE messages. The receiver
+of a SUBSCRIBE_NAMESPACES_OK or SUBSCRIBE_NAMESPACES_ERROR should forward the
+result to the application, so that it can make decisions about further
+publishers to contact. A publisher MUST send exactly one SUBSCRIBE_NAMESPACES_OK
+or SUBSCRIBE_NAMESPACES_ERROR. The subscriber SHOULD close the session with a
+protocol error if it detects receiving more than one.
+
+## ANNOUNCE
+
+A publisher MAY send ANNOUNCE messages to any subscriber. It SHOULD send them
+if it has received a SUBSCRIBE_ANNOUNCES for that namespace, or a superset of
+that namespace. An ANNOUNCE increases the likelihood of a subsequent successful
+SUBSCRIBE or FETCH.
+
+An UNANNOUNCE message negates the meaning of an ANNOUNCE, although it is not a
+protocol error for the subscriber to send a SUBSCRIBE or FETCH message anyway.
+A subscriber can send ANNOUNCE_CANCEL, meaning it is no longer interested in a
+namespace, which also negates the ANNOUNCE: the publisher need not send
+UNANNOUNCE. A publisher and subscriber might seek alternate subscribers and
+publishers, respectively, for potential SUBSCRIBE and FETCH interactions.
+
+The receiver of an ANNOUNCE_OK or ANNOUNCE_ERROR SHOULD report this to the
+application to inform the search for additional subscribers for a namespace,
+or abandoning the attempt to publish a track. This might be especially useful
+in upload or chat applications. A subscriber MUST send exactly one ANNOUNCE_OK
+or ANNOUNCE_ERROR. The publisher SHOULD close the session with a protocol error
+if it detects receiving more than one.
+
+## SUBSCRIBE/FETCH
+
+A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If has
+received an ANNOUNCE with a namespace that includes that track, it SHOULD only
+request it from the senders of those ANNOUNCE messages.
+
+The central interaction with a publisher is to send SUBSCRIBE and/or FETCH for
+a particular track in a namespace. The subscriber expects to receive a
+SUBSCRIBE_OK/FETCH_OK and objects from the track.
+
+A subscriber keeps SUBSCRIBE state until it sends UNSUBSCRIBE, or after receipt
+of a SUBSCRIBE_DONE.  Note that SUBSCRIBE_DONE does not usually indicate that
+state can immediately be destroyed, see {{message-subscribe-done}}.
+
+A subscriber keeps FETCH state until it sends FETCH_CANCEL, or a FIN or
+RESET_STREAM for the FETCH data stream. If the data stream is already open, it
+MAY send STOP_SENDING for the data stream, but MUST send FETCH_CANCEL.
+
+The Publisher can destroy subscription or fetch state as soon as it has received
+UNSUBSCRIBE or FETCH_CANCEL, respectively. It MUST reset any open streams for
+that operation.
+
+The publisher can immediate delete SUBSCRIBE state after sending
+SUBSCRIBE_DONE, but MUST NOT send it until it has closed all related streams. It
+can destroy all FETCH state after closing the data stream.
+
+A SUBSCRIBE_ERROR or FETCH_ERROR indicates no objects will be delivered, and
+both endpoints can immediately destroy relevant state. Objects MUST NOT be sent
+for requests that end with an error.
+
+A publisher MUST send exactly one SUBSCRIBE_OK or SUBSCRIBE_ERROR in response to
+a SUBSCRIBE. It MUST send exactly one FETCH_OK or FETCH_ERROR in response to a
+FETCH. The subscriber SHOULD close the session with a protocol error if it
+detects receiving more than one.
+
+The application SHOULD use a relevant error code in SUBSCRIBE_ERROR or
+FETCH_ERROR, as defined below:
+
+|------|---------------------------|
+| Code | Reason                    |
+|-----:|:--------------------------|
+| 0x0  | Internal Error            |
+|------|---------------------------|
+| 0x1  | Invalid Range             |
+|------|---------------------------|
+| 0x2  | Retry Track Alias         |
+|------|---------------------------|
+| 0x3  | Track Does Not Exist      |
+|------|---------------------------|
+| 0x4  | Unauthorized              |
+|------|---------------------------|
+| 0x5  | Timeout                   |
+|------|---------------------------|
+
+The application SHOULD use a relevant status code in
+SUBSCRIBE_DONE or a FETCH RESET_STREAM, as defined below:
+
+|------|---------------------------|
+| Code | Reason                    |
+|-----:|:--------------------------|
+| 0x0  | Unsubscribed              |
+|------|---------------------------|
+| 0x1  | Internal Error            |
+|------|---------------------------|
+| 0x2  | Unauthorized              |
+|------|---------------------------|
+| 0x3  | Track Ended               |
+|------|---------------------------|
+| 0x4  | Subscription Ended        |
+|------|---------------------------|
+| 0x5  | Going Away                |
+|------|---------------------------|
+| 0x6  | Expired                   |
+|------|---------------------------|
+| 0x7  | Too Far Behind            |
+|------|---------------------------|
 
 # Priorities {#priorities}
 
@@ -739,13 +865,8 @@ Subscribers interact with the Relays by sending a SUBSCRIBE or FETCH
 control message for the tracks of interest. Relays MUST ensure subscribers are
 authorized to access the content associated with the track. The authorization
 information can be part of subscription request itself or part of the
-encompassing session. The specifics of how a relay authorizes a user are
-outside the scope of this specification. The subscriber is notified
-of the result of the subscription via a
-SUBSCRIBE_OK ({{message-subscribe-ok}}) or SUBSCRIBE_ERROR
-{{message-subscribe-error}} control message. The entity receiving the
-SUBSCRIBE MUST send only a single response to a given SUBSCRIBE of
-either SUBSCRIBE_OK or SUBSCRIBE_ERROR.
+encompassing session. The specifics of how a relay authorizes a user are outside
+the scope of this specification.
 
 The relay will have to send an upstream SUBSCRIBE and/or FETCH if it does not
 have all the objects in the FETCH, or is not currently subscribed to the full
@@ -756,9 +877,7 @@ one from upstream.
 For successful subscriptions, the publisher maintains a list of
 subscribers for each track. Each new OBJECT belonging to the
 track within the subscription range is forwarded to each active
-subscriber, dependent on the congestion response. A subscription
-remains active until soon after the publisher of the track terminates the
-subscription with a SUBSCRIBE_DONE (see {{message-subscribe-done}}).
+subscriber, dependent on the congestion response.
 
 A caching relay saves Objects to its cache identified by the Object's
 Full Track Name, Group ID and Object ID. Relays MUST be able to
@@ -769,62 +888,17 @@ Group ID and Object ID, Relays MAY ignore subsequently received Objects
 or MAY use them to update the cache. Implementations that update the
 cache need to protect against cache poisoning.
 
-Caching can also reduce the number of upstream FETCH requests.
-
-Objects MUST NOT be sent for unsuccessful subscriptions, and if a subscriber
-receives a SUBSCRIBE_ERROR after receiving objects, it MUST close the session
-with a 'Protocol Violation'.
+Caching can reduce the number of upstream FETCH requests.
 
 A relay MUST NOT reorder or drop objects received on a multi-object stream when
 forwarding to subscribers, unless it has application specific information.
 
-Relays MAY aggregate authorized subscriptions for a given track when
-multiple subscribers request the same track. Subscription aggregation
+Relays SHOULD aggregate authorized subscriptions for a given track when
+multiple subscribers request the same track, using SUBSCRIBE_UPDATE when new
+subscriptions change the aggregate properties. Subscription aggregation
 allows relays to make only a single upstream subscription for the
 track. The published content received from the upstream subscription
 request is cached and shared among the pending subscribers.
-
-The application SHOULD use a relevant error code in SUBSCRIBE_ERROR,
-as defined below:
-
-|------|---------------------------|
-| Code | Reason                    |
-|-----:|:--------------------------|
-| 0x0  | Internal Error            |
-|------|---------------------------|
-| 0x1  | Invalid Range             |
-|------|---------------------------|
-| 0x2  | Retry Track Alias         |
-|------|---------------------------|
-| 0x3  | Track Does Not Exist      |
-|------|---------------------------|
-| 0x4  | Unauthorized              |
-|------|---------------------------|
-| 0x5  | Timeout                   |
-|------|---------------------------|
-
-The application SHOULD use a relevant status code in
-SUBSCRIBE_DONE, as defined below:
-
-|------|---------------------------|
-| Code | Reason                    |
-|-----:|:--------------------------|
-| 0x0  | Unsubscribed              |
-|------|---------------------------|
-| 0x1  | Internal Error            |
-|------|---------------------------|
-| 0x2  | Unauthorized              |
-|------|---------------------------|
-| 0x3  | Track Ended               |
-|------|---------------------------|
-| 0x4  | Subscription Ended        |
-|------|---------------------------|
-| 0x5  | Going Away                |
-|------|---------------------------|
-| 0x6  | Expired                   |
-|------|---------------------------|
-| 0x7  | Too Far Behind            |
-|------|---------------------------|
 
 ### Graceful Publisher Relay Switchover
 
@@ -843,18 +917,13 @@ to the old relay can be stopped with an UNSUBSCRIBE.
 Publishing through the relay starts with publisher sending ANNOUNCE
 control message with a `Track Namespace` ({{model-track}}).
 The ANNOUNCE enables the relay to know which publisher to forward a
-SUBSCRIBE to if the track belongs to the namespace in the ANNOUNCE.
+SUBSCRIBE to.
 
-Relays MUST verify that publishers are authorized to publish
-the content associated with the set of
+Relays MUST ensure that publishers are authorized by verifying that the
+publisher is authorized to publish the content associated with the set of
 tracks whose Track Namespace matches the announced namespace. Where the
 authorization and identification of the publisher occurs depends on the way the
 relay is managed and is application specific.
-
-Relays respond with an ANNOUNCE_OK or ANNOUNCE_ERROR control message
-providing the result of announcement. The entity receiving the
-ANNOUNCE MUST send only a single response to a given ANNOUNCE of
-either ANNOUNCE_OK or ANNOUNCE_ERROR.
 
 A Relay can receive announcements from multiple publishers for the same
 Track Namespace and it SHOULD respond with the same response to each of the
@@ -868,10 +937,7 @@ namespace it previously responded ANNOUNCE_OK to by sending an
 ANNOUNCE_CANCEL.
 
 A relay manages sessions from multiple publishers and subscribers,
-connecting them based on the track namespace. This MUST use an exact
-match on track namespace unless otherwise negotiated by the application.
-For example, a SUBSCRIBE namespace=foobar message will be forwarded to
-the session that sent ANNOUNCE namespace=foobar.
+connecting them based on the track namespace.
 
 When a relay receives an incoming SUBSCRIBE request that triggers an
 upstream subscription, it SHOULD send a SUBSCRIBE request to each
@@ -1391,8 +1457,7 @@ See {{priorities}}.
 
 A subscriber issues a `UNSUBSCRIBE` message to a publisher indicating it is no
 longer interested in receiving media for the specified track and Objects
-should stop being sent as soon as possible.  The publisher sends a
-SUBSCRIBE_DONE to acknowledge the unsubscribe was successful.
+should stop being sent as soon as possible.
 
 The format of `UNSUBSCRIBE` is as follows:
 
@@ -1563,10 +1628,6 @@ message for which this response is provided.
 The subscriber sends an `ANNOUNCE_CANCEL` control message to
 indicate it will stop sending new subscriptions for tracks
 within the provided Track Namespace.
-
-If a publisher receives new subscriptions for that namespace after
-receiving an ANNOUNCE_CANCEL, it SHOULD close the session as a
-'Protocol Violation'.
 
 ~~~
 ANNOUNCE_CANCEL Message {

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -635,7 +635,7 @@ Given sufficient out of band information, it is valid for a subscriber
 to send a SUBSCRIBE or FETCH message to a publisher (including a relay) without
 any previous MoQT messages besides SETUP. However, SUBSCRIBE_ANNOUNCES and
 ANNOUNCE messages provide an in-band means of discovery of subscribers and
-publishers.
+publishers, respectively.
 
 The syntax of these messages is described in {{message}}.
 
@@ -654,7 +654,6 @@ not prohibit the receiver (publisher) from sending further ANNOUNCE messages.
 The receiver of a SUBSCRIBE_NAMESPACES_OK or SUBSCRIBE_NAMESPACES_ERROR should
 forward the result to the application, so that it can make decisions about
 further publishers to contact.
-
 
 ## ANNOUNCE
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1489,8 +1489,8 @@ See {{priorities}}.
 ## UNSUBSCRIBE {#message-unsubscribe}
 
 A subscriber issues a `UNSUBSCRIBE` message to a publisher indicating it is no
-longer interested in receiving media for the specified track and Objects
-should stop being sent as soon as possible.
+longer interested in receiving media for the specified track and requesting that
+the publisher stop sending Objects as soon as possible.
 
 The format of `UNSUBSCRIBE` is as follows:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -657,21 +657,25 @@ close the session with a protocol error if it detects receiving more than one.
 
 ## ANNOUNCE
 
-A publisher MAY send ANNOUNCE messages to any subscriber. An ANNOUNCE increases
-the likelihood of a subsequent successful SUBSCRIBE or FETCH.
+A publisher MAY send ANNOUNCE messages to any subscriber. An ANNOUNCE indicates
+to the subscriber where to route a SUBSCRIBE or FETCH for that namespace. A
+subscriber MAY send SUBSCRIBE or FETCH for a namespace without having received
+an ANNOUNCE for it.
 
-If a publisher is authoritative for a given namespace, or has received an
-ANNOUNCE for that namespace from an upstream publisher, it MUST send an ANNOUNCE
-to any subscriber that has subscribed to ANNOUNCE for that namespace, a
-superset of that namespace, or a subset of that namespace. A publisher MAY send
-the ANNOUNCE to any other subscriber.
+If a publisher is authoritative for a given namespace, or is a relay that has
+received an ANNOUNCE for that namespace from an upstream publisher, it MUST send
+an ANNOUNCE to any subscriber that has subscribed to ANNOUNCE for that
+namespace, a superset of that namespace, or a subset of that namespace. A
+publisher MAY send the ANNOUNCE to any other subscriber.
 
-However, a publisher SHOULD NOT send an ANNOUNCE advertising a namespace equal
-to, or a subset of, a namespace for which the subscriber sent an earlier ANNOUNCE
+However, a publisher SHOULD NOT send an ANNOUNCE advertising a namespace that
+exactly matches a namespace for which the subscriber sent an earlier ANNOUNCE
 (i.e. an ANNOUNCE ought not to be echoed back to its sender).
 
 An UNANNOUNCE message negates the meaning of an ANNOUNCE, although it is not a
-protocol error for the subscriber to send a SUBSCRIBE or FETCH message anyway.
+protocol error for the subscriber to send a SUBSCRIBE or FETCH message after
+receiving an UNANNOUNCE.
+
 A subscriber can send ANNOUNCE_CANCEL, meaning it is no longer interested in a
 namespace, which also negates the ANNOUNCE: the publisher need not send
 UNANNOUNCE. A publisher and subscriber might seek alternate subscribers and
@@ -695,16 +699,19 @@ a particular track in a namespace. The subscriber expects to receive a
 SUBSCRIBE_OK/FETCH_OK and objects from the track.
 
 A subscriber keeps SUBSCRIBE state until it sends UNSUBSCRIBE, or after receipt
-of a SUBSCRIBE_DONE.  Note that SUBSCRIBE_DONE does not usually indicate that
-state can immediately be destroyed, see {{message-subscribe-done}}.
+of a SUBSCRIBE_DONE or SUBSCRIBE_ERROR. Note that SUBSCRIBE_DONE does not
+usually indicate that state can immediately be destroyed, see
+{{message-subscribe-done}}.
 
-A subscriber keeps FETCH state until it sends FETCH_CANCEL, or a FIN or
-RESET_STREAM for the FETCH data stream. If the data stream is already open, it
-MAY send STOP_SENDING for the data stream, but MUST send FETCH_CANCEL.
+A subscriber keeps FETCH state until it sends FETCH_CANCEL; receives
+FETCH_ERROR; or receives a FIN or RESET_STREAM for the FETCH data stream. If the
+data stream is already open, it MAY send STOP_SENDING for the data stream along
+with FETCH_CANCEL, but MUST send FETCH_CANCEL.
 
 The Publisher can destroy subscription or fetch state as soon as it has received
 UNSUBSCRIBE or FETCH_CANCEL, respectively. It MUST reset any open streams
-associated with the SUBSCRIBE or FETCH.
+associated with the SUBSCRIBE or FETCH. It can also destroy state after closing
+on the FETCH data stream.
 
 The publisher can immediately delete SUBSCRIBE state after sending
 SUBSCRIBE_DONE, but MUST NOT send it until it has closed all related streams. It
@@ -883,7 +890,8 @@ to the old relay can be stopped with an UNSUBSCRIBE.
 Publishing through the relay starts with publisher sending ANNOUNCE
 control message with a `Track Namespace` ({{model-track}}).
 The ANNOUNCE enables the relay to know which publisher to forward a
-SUBSCRIBE to.
+SUBSCRIBE to, if the track name belongs to the namespace indicated in
+the ANNOUNCE.
 
 Relays MUST ensure that publishers are authorized by verifying that the
 publisher is authorized to publish the content associated with the set of
@@ -1422,8 +1430,8 @@ See {{priorities}}.
 ## UNSUBSCRIBE {#message-unsubscribe}
 
 A subscriber issues a `UNSUBSCRIBE` message to a publisher indicating it is no
-longer interested in receiving media for the specified track and Objects
-should stop being sent as soon as possible.
+longer interested in receiving media for the specified track and requests that
+objects stop being sent as soon as possible.
 
 The format of `UNSUBSCRIBE` is as follows:
 
@@ -1589,8 +1597,7 @@ message for which this response is provided.
 
 * Reason Phrase: Provides the reason for announcement error.
 
-The application SHOULD use a relevant error code in an ANNOUNCE_ERROR, as
-defined below.
+The following error codes are defined:
 
 |------|---------------------------|
 | Code | Reason                    |
@@ -1793,7 +1800,7 @@ SUBSCRIBE_ERROR
   the subscriber MUST close the connection with a Duplicate Track Alias error
   ({{session-termination}}).
 
-The application SHOULD use a relevant error code in SUBSCRIBE_ERROR, as defined below:
+The following error codes are defined:
 
 |------|---------------------------|
 | Code | Reason                    |
@@ -1875,7 +1882,7 @@ FETCH_ERROR
 
 * Reason Phrase: Provides the reason for fetch error.
 
-The application SHOULD use a relevant error code in FETCH_ERROR, as defined below:
+The following error codes are defined:
 
 |------|---------------------------|
 | Code | Reason                    |

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -628,13 +628,12 @@ expects more OBJECTs to be delivered. The server closes the session with a
 
 # Track Discovery and Retrieval (#track-discovery}
 
-Discovery of MoQT servers is always done out-of-band. Track discovery is done in
-the context of an established MoQT session. The session client might be a
-subscriber, publisher, or both.
+Discovery of MoQT servers is always done out-of-band. Track discovery can be
+done in the context of an established MoQT session.
 
 Given sufficient out of band information, it is valid for a subscriber
 to send a SUBSCRIBE or FETCH message to a publisher (including a relay) without
-any previous MoQT messages besides SETUP. However, SUBSCRIBE_NAMESPACES and
+any previous MoQT messages besides SETUP. However, SUBSCRIBE_ANNOUNCES and
 ANNOUNCE messages provide an in-band means of discovery of subscribers and
 publishers.
 
@@ -643,17 +642,19 @@ The syntax of these messages is described in {{message}}.
 ## SUBSCRIBE_ANNOUNCES
 
 If the subscriber is aware of a namespace of interest, it can send
-SUBSCRIBE_ANNOUNCES to publishers/relays it has discovered. This message
-increases the likelihood that publishers will send relevant ANNOUNCE messages
-for that namespace.
+SUBSCRIBE_ANNOUNCES to publishers/relays it has discovered. The recipient of
+this message will send any relevant ANNOUNCE messages for that namespace.
 
-An UNSUBSCRIBE_NAMESPACES negates the effect of a SUBSCRIBE_NAMESPACES. It does
+A publisher MUST send exactly one SUBSCRIBE_NAMESPACES_OK or
+SUBSCRIBE_NAMESPACES_ERROR. The subscriber SHOULD close the session with a
+protocol error if it detects receiving more than one.
+
+An UNSUBSCRIBE_NAMESPACES withdraws a previous SUBSCRIBE_NAMESPACES. It does
 not prohibit the receiver (publisher) from sending further ANNOUNCE messages.
 The receiver of a SUBSCRIBE_NAMESPACES_OK or SUBSCRIBE_NAMESPACES_ERROR should
 forward the result to the application, so that it can make decisions about
-further publishers to contact. A publisher MUST send exactly one
-SUBSCRIBE_NAMESPACES_OK or SUBSCRIBE_NAMESPACES_ERROR. The subscriber SHOULD
-close the session with a protocol error if it detects receiving more than one.
+further publishers to contact.
+
 
 ## ANNOUNCE
 
@@ -663,40 +664,46 @@ subscriber MAY send SUBSCRIBE or FETCH for a namespace without having received
 an ANNOUNCE for it.
 
 If a publisher is authoritative for a given namespace, or is a relay that has
-received an ANNOUNCE for that namespace from an upstream publisher, it MUST send
-an ANNOUNCE to any subscriber that has subscribed to ANNOUNCE for that
-namespace, a superset of that namespace, or a subset of that namespace. A
+received an authorized ANNOUNCE for that namespace from an upstream publisher,
+it MUST send an ANNOUNCE to any subscriber that has subscribed to ANNOUNCE for
+that namespace, a superset of that namespace, or a subset of that namespace. A
 publisher MAY send the ANNOUNCE to any other subscriber.
 
-However, a publisher SHOULD NOT send an ANNOUNCE advertising a namespace that
+A publisher SHOULD NOT, however, send an ANNOUNCE advertising a namespace that
 exactly matches a namespace for which the subscriber sent an earlier ANNOUNCE
 (i.e. an ANNOUNCE ought not to be echoed back to its sender).
 
-An UNANNOUNCE message negates the meaning of an ANNOUNCE, although it is not a
+The receiver of an ANNOUNCE_OK or ANNOUNCE_ERROR SHOULD report this to the
+application to inform the search for additional subscribers for a namespace,
+or abandoning the attempt to publish under this namespace. This might be
+especially useful in upload or chat applications. A subscriber MUST send exactly
+one ANNOUNCE_OK or ANNOUNCE_ERROR in response to an ANNOUNCE. The publisher
+SHOULD close the session with a protocol error if it detects receiving more than
+one.
+
+An UNANNOUNCE message withdraws a previous of an ANNOUNCE, although it is not a
 protocol error for the subscriber to send a SUBSCRIBE or FETCH message after
 receiving an UNANNOUNCE.
 
-A subscriber can send ANNOUNCE_CANCEL, meaning it is no longer interested in a
-namespace, which also negates the ANNOUNCE: the publisher need not send
-UNANNOUNCE. A publisher and subscriber might seek alternate subscribers and
-publishers, respectively, for potential SUBSCRIBE and FETCH interactions.
-
-The receiver of an ANNOUNCE_OK or ANNOUNCE_ERROR SHOULD report this to the
-application to inform the search for additional subscribers for a namespace,
-or abandoning the attempt to publish a track. This might be especially useful
-in upload or chat applications. A subscriber MUST send exactly one ANNOUNCE_OK
-or ANNOUNCE_ERROR in response to an ANNOUNCE. The publisher SHOULD close the
-session with a protocol error if it detects receiving more than one.
+A subscriber can send ANNOUNCE_CANCEL to revoke acceptance of an ANNOUNCE, for
+example due to expiration of authorization credentials. The message enables the
+publisher to ANNOUNCE again with refreshed authorization, or discard associated
+state. After receiving an ANNOUNCE_CANCEL, the publisher does not send UNANNOUNCE.
 
 ## SUBSCRIBE/FETCH
+
+The central interaction with a publisher is to send SUBSCRIBE and/or FETCH for
+a particular track in a namespace. The subscriber expects to receive a
+SUBSCRIBE_OK/FETCH_OK and objects from the track.
 
 A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If it
 has received an ANNOUNCE with a namespace that includes that track, it SHOULD
 only request it from the senders of those ANNOUNCE messages.
 
-The central interaction with a publisher is to send SUBSCRIBE and/or FETCH for
-a particular track in a namespace. The subscriber expects to receive a
-SUBSCRIBE_OK/FETCH_OK and objects from the track.
+A publisher MUST send exactly one SUBSCRIBE_OK or SUBSCRIBE_ERROR in response to
+a SUBSCRIBE. It MUST send exactly one FETCH_OK or FETCH_ERROR in response to a
+FETCH. The subscriber SHOULD close the session with a protocol error if it
+detects receiving more than one.
 
 A subscriber keeps SUBSCRIBE state until it sends UNSUBSCRIBE, or after receipt
 of a SUBSCRIBE_DONE or SUBSCRIBE_ERROR. Note that SUBSCRIBE_DONE does not
@@ -720,11 +727,6 @@ can destroy all FETCH state after closing the data stream.
 A SUBSCRIBE_ERROR or FETCH_ERROR indicates no objects will be delivered, and
 both endpoints can immediately destroy relevant state. Objects MUST NOT be sent
 for requests that end with an error.
-
-A publisher MUST send exactly one SUBSCRIBE_OK or SUBSCRIBE_ERROR in response to
-a SUBSCRIBE. It MUST send exactly one FETCH_OK or FETCH_ERROR in response to a
-FETCH. The subscriber SHOULD close the session with a protocol error if it
-detects receiving more than one.
 
 # Priorities {#priorities}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -870,8 +870,7 @@ A relay MUST NOT reorder or drop objects received on a multi-object stream when
 forwarding to subscribers, unless it has application specific information.
 
 Relays SHOULD aggregate authorized subscriptions for a given track when
-multiple subscribers request the same track, using SUBSCRIBE_UPDATE when new
-subscriptions change the aggregate properties. Subscription aggregation
+multiple subscribers request the same track. Subscription aggregation
 allows relays to make only a single upstream subscription for the
 track. The published content received from the upstream subscription
 request is cached and shared among the pending subscribers.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -834,9 +834,10 @@ Relays MAY cache Objects, but are not required to.
 
 ## Subscriber Interactions
 
-Subscribers interact with the Relays by sending a SUBSCRIBE or FETCH
-control message for the tracks of interest. Relays MUST ensure subscribers are
-authorized to access the content associated with the track. The authorization
+Subscribers interact with the Relays by sending a SUBSCRIBE
+({{message-subscribe-req}}) control message for the tracks of
+interest. Relays MUST ensure subscribers are authorized to access the
+content associated with the track. The authorization
 information can be part of subscription request itself or part of the
 encompassing session. The specifics of how a relay authorizes a user are outside
 the scope of this specification.
@@ -859,9 +860,7 @@ publishers and forward objects to active matching subscriptions.
 If multiple objects are received with the same Full Track Name,
 Group ID and Object ID, Relays MAY ignore subsequently received Objects
 or MAY use them to update the cache. Implementations that update the
-cache need to protect against cache poisoning.
-
-Caching can reduce the number of upstream FETCH requests.
+cache need to be protect against cache poisoning.
 
 A relay MUST NOT reorder or drop objects received on a multi-object stream when
 forwarding to subscribers, unless it has application specific information.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -694,7 +694,7 @@ state. After receiving an ANNOUNCE_CANCEL, the publisher does not send UNANNOUNC
 ## SUBSCRIBE/FETCH
 
 The central interaction with a publisher is to send SUBSCRIBE and/or FETCH for
-a particular track in a namespace. The subscriber expects to receive a
+a particular track. The subscriber expects to receive a
 SUBSCRIBE_OK/FETCH_OK and objects from the track.
 
 A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If it

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -705,7 +705,7 @@ messages.
 A publisher MUST send exactly one SUBSCRIBE_OK or SUBSCRIBE_ERROR in response to
 a SUBSCRIBE. It MUST send exactly one FETCH_OK or FETCH_ERROR in response to a
 FETCH. The subscriber SHOULD close the session with a protocol error if it
-detects receiving more than one.
+receives more than one.
 
 A subscriber keeps SUBSCRIBE state until it sends UNSUBSCRIBE, or after receipt
 of a SUBSCRIBE_DONE or SUBSCRIBE_ERROR. Note that SUBSCRIBE_DONE does not

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -648,22 +648,32 @@ increases the likelihood that publishers will send relevant ANNOUNCE messages
 for that namespace.
 
 An UNSUBSCRIBE_NAMESPACES negates the effect of a SUBSCRIBE_NAMESPACES. It does
-not prohibit the receiver from sending further ANNOUNCE messages. The receiver
-of a SUBSCRIBE_NAMESPACES_OK or SUBSCRIBE_NAMESPACES_ERROR should forward the
-result to the application, so that it can make decisions about further
-publishers to contact. A publisher MUST send exactly one SUBSCRIBE_NAMESPACES_OK
-or SUBSCRIBE_NAMESPACES_ERROR. The subscriber SHOULD close the session with a
-protocol error if it detects receiving more than one.
+not prohibit the receiver (publisher) from sending further ANNOUNCE messages.
+The receiver of a SUBSCRIBE_NAMESPACES_OK or SUBSCRIBE_NAMESPACES_ERROR should
+forward the result to the application, so that it can make decisions about
+further publishers to contact. A publisher MUST send exactly one
+SUBSCRIBE_NAMESPACES_OK or SUBSCRIBE_NAMESPACES_ERROR. The subscriber SHOULD
+close the session with a protocol error if it detects receiving more than one.
 
 ## ANNOUNCE
 
 A publisher MAY send ANNOUNCE messages to any subscriber. An ANNOUNCE increases
-the likelihood of a subsequent successful SUBSCRIBE or FETCH. It SHOULD send
-an ANNOUNCE if it has received a SUBSCRIBE_ANNOUNCES for that namespace, or a
-superset of that namespace. However, a publisher SHOULD NOT send an ANNOUNCE
-advertising a namespace equal to, or a subset of, a namespace for which the
-receiver sent an earlier ANNOUNCE (i.e. an ANNOUNCE ought not to be echoed back
-to its sender).
+the likelihood of a subsequent successful SUBSCRIBE or FETCH.
+
+If a publisher is authoritative for a given namespace, or has received an
+ANNOUNCE for that namespace from an upstream publisher, it MUST send an ANNOUNCE
+to any subscriber that has subscribed to ANNOUNCE for that namespace or a
+superset of that namespace.
+
+If a subscriber is subscribed to ANNOUNCE for a subset of that namespace, the
+publisher MUST send an ANNOUNCE for the specific subset.
+
+A publisher MAY send the ANNOUNCE to subscribers that have not subscribed to
+ANNOUNCE for the namespace, or a subset or superset thereof.
+
+However, a publisher SHOULD NOT send an ANNOUNCE advertising a namespace equal
+to, or a subset of, a namespace for which the subscriber sent an earlier ANNOUNCE
+(i.e. an ANNOUNCE ought not to be echoed back to its sender).
 
 An UNANNOUNCE message negates the meaning of an ANNOUNCE, although it is not a
 protocol error for the subscriber to send a SUBSCRIBE or FETCH message anyway.
@@ -676,14 +686,14 @@ The receiver of an ANNOUNCE_OK or ANNOUNCE_ERROR SHOULD report this to the
 application to inform the search for additional subscribers for a namespace,
 or abandoning the attempt to publish a track. This might be especially useful
 in upload or chat applications. A subscriber MUST send exactly one ANNOUNCE_OK
-or ANNOUNCE_ERROR. The publisher SHOULD close the session with a protocol error
-if it detects receiving more than one.
+or ANNOUNCE_ERROR in response to an ANNOUNCE. The publisher SHOULD close the
+session with a protocol error if it detects receiving more than one.
 
 ## SUBSCRIBE/FETCH
 
-A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If has
-received an ANNOUNCE with a namespace that includes that track, it SHOULD only
-request it from the senders of those ANNOUNCE messages.
+A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If it
+has received an ANNOUNCE with a namespace that includes that track, it SHOULD
+only request it from the senders of those ANNOUNCE messages.
 
 The central interaction with a publisher is to send SUBSCRIBE and/or FETCH for
 a particular track in a namespace. The subscriber expects to receive a
@@ -698,8 +708,8 @@ RESET_STREAM for the FETCH data stream. If the data stream is already open, it
 MAY send STOP_SENDING for the data stream, but MUST send FETCH_CANCEL.
 
 The Publisher can destroy subscription or fetch state as soon as it has received
-UNSUBSCRIBE or FETCH_CANCEL, respectively. It MUST reset any open streams for
-that operation.
+UNSUBSCRIBE or FETCH_CANCEL, respectively. It MUST reset any open streams
+associated with the SUBSCRIBE or FETCH.
 
 The publisher can immediate delete SUBSCRIBE state after sending
 SUBSCRIBE_DONE, but MUST NOT send it until it has closed all related streams. It

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -912,7 +912,10 @@ namespace it previously responded ANNOUNCE_OK to by sending an
 ANNOUNCE_CANCEL.
 
 A relay manages sessions from multiple publishers and subscribers,
-connecting them based on the track namespace.
+connecting them based on the track namespace. This MUST use an exact
+match on track namespace unless otherwise negotiated by the application.
+For example, a SUBSCRIBE namespace=foobar message will be forwarded to
+the session that sent ANNOUNCE namespace=foobar.
 
 When a relay receives an incoming SUBSCRIBE request that triggers an
 upstream subscription, it SHOULD send a SUBSCRIBE request to each

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -650,20 +650,21 @@ The syntax of these messages is described in {{message}}.
 ## SUBSCRIBE_ANNOUNCES
 
 If the subscriber is aware of a namespace of interest, it can send
-SUBSCRIBE_ANNOUNCES to publishers/relays it has discovered. The recipient of
-this message will send any relevant ANNOUNCE messages for that namespace, or
-subset of that namespace.
+SUBSCRIBE_ANNOUNCES to publishers/relays it has established a session with. The
+recipient of this message will send any relevant ANNOUNCE messages for that
+namespace, or subset of that namespace.
 
 A publisher MUST send exactly one SUBSCRIBE_ANNOUNCES_OK or
-SUBSCRIBE_ANNOUNCES_ERROR  in response to a SUBSCRIBE_ANNOUNCES.
-The subscriber SHOULD close the session with a protocol error if it detects
-receiving more than one.
+SUBSCRIBE_ANNOUNCES_ERROR in response to a SUBSCRIBE_ANNOUNCES. The subscriber
+SHOULD close the session with a protocol error if it detects receiving more than
+one.
 
-An UNSUBSCRIBE_NAMESPACES withdraws a previous SUBSCRIBE_NAMESPACES. It does
-not prohibit the receiver (publisher) from sending further ANNOUNCE messages.
 The receiver of a SUBSCRIBE_NAMESPACES_OK or SUBSCRIBE_NAMESPACES_ERROR ought to
 forward the result to the application, so that it can make decisions about
 further publishers to contact.
+
+An UNSUBSCRIBE_NAMESPACES withdraws a previous SUBSCRIBE_NAMESPACES. It does
+not prohibit the receiver (publisher) from sending further ANNOUNCE messages.
 
 ## ANNOUNCE
 
@@ -678,8 +679,8 @@ it MUST send an ANNOUNCE to any subscriber that has subscribed to ANNOUNCE for
 that namespace, or a subset of that namespace. A publisher MAY send the ANNOUNCE
 to any other subscriber.
 
-A publisher SHOULD NOT, however, send an ANNOUNCE advertising a namespace that
-exactly matches a namespace for which the subscriber sent an earlier ANNOUNCE
+An endpoint SHOULD NOT, however, send an ANNOUNCE advertising a namespace that
+exactly matches a namespace for which the peer sent an earlier ANNOUNCE
 (i.e. an ANNOUNCE ought not to be echoed back to its sender).
 
 The receiver of an ANNOUNCE_OK or ANNOUNCE_ERROR SHOULD report this to the
@@ -697,6 +698,11 @@ A subscriber can send ANNOUNCE_CANCEL to revoke acceptance of an ANNOUNCE, for
 example due to expiration of authorization credentials. The message enables the
 publisher to ANNOUNCE again with refreshed authorization, or discard associated
 state. After receiving an ANNOUNCE_CANCEL, the publisher does not send UNANNOUNCE.
+
+While ANNOUNCE does provide hints on where to route a SUBSCRIBE or FETCH, it is
+not a full-fledged routing protocol and does not protect against loops and other
+phenomena. In particular, ANNOUNCE SHOULD NOT be used to find paths through
+richly connected networks of relays.
 
 ## SUBSCRIBE/FETCH
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -643,7 +643,8 @@ The syntax of these messages is described in {{message}}.
 
 If the subscriber is aware of a namespace of interest, it can send
 SUBSCRIBE_ANNOUNCES to publishers/relays it has discovered. The recipient of
-this message will send any relevant ANNOUNCE messages for that namespace.
+this message will send any relevant ANNOUNCE messages for that namespace, or
+subset of that namespace.
 
 A publisher MUST send exactly one SUBSCRIBE_NAMESPACES_OK or
 SUBSCRIBE_NAMESPACES_ERROR. The subscriber SHOULD close the session with a
@@ -665,8 +666,8 @@ an ANNOUNCE for it.
 If a publisher is authoritative for a given namespace, or is a relay that has
 received an authorized ANNOUNCE for that namespace from an upstream publisher,
 it MUST send an ANNOUNCE to any subscriber that has subscribed to ANNOUNCE for
-that namespace, a superset of that namespace, or a subset of that namespace. A
-publisher MAY send the ANNOUNCE to any other subscriber.
+that namespace, or a subset of that namespace. A publisher MAY send the ANNOUNCE
+to any other subscriber.
 
 A publisher SHOULD NOT, however, send an ANNOUNCE advertising a namespace that
 exactly matches a namespace for which the subscriber sent an earlier ANNOUNCE
@@ -680,7 +681,7 @@ one ANNOUNCE_OK or ANNOUNCE_ERROR in response to an ANNOUNCE. The publisher
 SHOULD close the session with a protocol error if it detects receiving more than
 one.
 
-An UNANNOUNCE message withdraws a previous of an ANNOUNCE, although it is not a
+An UNANNOUNCE message withdraws a previous ANNOUNCE, although it is not a
 protocol error for the subscriber to send a SUBSCRIBE or FETCH message after
 receiving an UNANNOUNCE.
 
@@ -696,8 +697,9 @@ a particular track in a namespace. The subscriber expects to receive a
 SUBSCRIBE_OK/FETCH_OK and objects from the track.
 
 A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If it
-has received an ANNOUNCE with a namespace that includes that track, it SHOULD
-only request it from the senders of those ANNOUNCE messages.
+has received an ANNOUNCE with a namespace that exactly matches the namespace for
+that track, it SHOULD only request it from the senders of those ANNOUNCE
+messages.
 
 A publisher MUST send exactly one SUBSCRIBE_OK or SUBSCRIBE_ERROR in response to
 a SUBSCRIBE. It MUST send exactly one FETCH_OK or FETCH_ERROR in response to a

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -638,7 +638,7 @@ any previous MoQT messages besides SETUP. However, SUBSCRIBE_NAMESPACES and
 ANNOUNCE messages provide an in-band means of discovery of subscribers and
 publishers.
 
-The syntax of these messages is described in {{messages}}.
+The syntax of these messages is described in {{message}}.
 
 ## SUBSCRIBE_ANNOUNCES
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -628,7 +628,7 @@ expects more OBJECTs to be delivered. The server closes the session with a
 
 # Track Discovery and Retrieval (#track-discovery}
 
-Discovery of MoQT servers is always done out-of-band. Track discovery can be
+Discovery of MoQT servers is always done out-of-band. Namespace discovery can be
 done in the context of an established MoQT session.
 
 Given sufficient out of band information, it is valid for a subscriber

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -662,14 +662,9 @@ the likelihood of a subsequent successful SUBSCRIBE or FETCH.
 
 If a publisher is authoritative for a given namespace, or has received an
 ANNOUNCE for that namespace from an upstream publisher, it MUST send an ANNOUNCE
-to any subscriber that has subscribed to ANNOUNCE for that namespace or a
-superset of that namespace.
-
-If a subscriber is subscribed to ANNOUNCE for a subset of that namespace, the
-publisher MUST send an ANNOUNCE for the specific subset.
-
-A publisher MAY send the ANNOUNCE to subscribers that have not subscribed to
-ANNOUNCE for the namespace, or a subset or superset thereof.
+to any subscriber that has subscribed to ANNOUNCE for that namespace, a
+superset of that namespace, or a subset of that namespace. A publisher MAY send
+the ANNOUNCE to any other subscriber.
 
 However, a publisher SHOULD NOT send an ANNOUNCE advertising a namespace equal
 to, or a subset of, a namespace for which the subscriber sent an earlier ANNOUNCE
@@ -711,7 +706,7 @@ The Publisher can destroy subscription or fetch state as soon as it has received
 UNSUBSCRIBE or FETCH_CANCEL, respectively. It MUST reset any open streams
 associated with the SUBSCRIBE or FETCH.
 
-The publisher can immediate delete SUBSCRIBE state after sending
+The publisher can immediately delete SUBSCRIBE state after sending
 SUBSCRIBE_DONE, but MUST NOT send it until it has closed all related streams. It
 can destroy all FETCH state after closing the data stream.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -865,9 +865,8 @@ cache need to be protect against cache poisoning.
 A relay MUST NOT reorder or drop objects received on a multi-object stream when
 forwarding to subscribers, unless it has application specific information.
 
-Relays SHOULD aggregate authorized subscriptions for a given track when
-multiple subscribers request the same track, using SUBSCRIBE_UPDATE when new
-subscriptions change the aggregate properties. Subscription aggregation
+Relays MAY aggregate authorized subscriptions for a given track when
+multiple subscribers request the same track. Subscription aggregation
 allows relays to make only a single upstream subscription for the
 track. The published content received from the upstream subscription
 request is cached and shared among the pending subscribers.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -836,9 +836,10 @@ Relays MAY cache Objects, but are not required to.
 
 ## Subscriber Interactions
 
-Subscribers interact with the Relays by sending a SUBSCRIBE or FETCH
-control message for the tracks of interest. Relays MUST ensure subscribers are
-authorized to access the content associated with the track. The authorization
+Subscribers interact with the Relays by sending a SUBSCRIBE
+({{message-subscribe-req}}) control message for the tracks of
+interest. Relays MUST ensure subscribers are authorized to access the
+content associated with the track. The authorization
 information can be part of subscription request itself or part of the
 encompassing session. The specifics of how a relay authorizes a user are outside
 the scope of this specification.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -868,7 +868,7 @@ cache need to protect against cache poisoning.
 A relay MUST NOT reorder or drop objects received on a multi-object stream when
 forwarding to subscribers, unless it has application specific information.
 
-Relays SHOULD aggregate authorized subscriptions for a given track when
+Relays MAY aggregate authorized subscriptions for a given track when
 multiple subscribers request the same track. Subscription aggregation
 allows relays to make only a single upstream subscription for the
 track. The published content received from the upstream subscription

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -698,7 +698,7 @@ a particular track. The subscriber expects to receive a
 SUBSCRIBE_OK/FETCH_OK and objects from the track.
 
 A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If it
-has received an ANNOUNCE with a namespace that exactly matches the namespace for
+has accepted an ANNOUNCE with a namespace that exactly matches the namespace for
 that track, it SHOULD only request it from the senders of those ANNOUNCE
 messages.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -648,8 +648,8 @@ subset of that namespace.
 
 A publisher MUST send exactly one SUBSCRIBE_ANNOUNCES_OK or
 SUBSCRIBE_ANNOUNCES_ERROR  in response to a SUBSCRIBE_ANNOUNCES.
-The subscriber SHOULD close the session with a protocol error if it detects receiving
-more than one.
+The subscriber SHOULD close the session with a protocol error if it detects
+receiving more than one.
 
 An UNSUBSCRIBE_NAMESPACES withdraws a previous SUBSCRIBE_NAMESPACES. It does
 not prohibit the receiver (publisher) from sending further ANNOUNCE messages.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -836,10 +836,9 @@ Relays MAY cache Objects, but are not required to.
 
 ## Subscriber Interactions
 
-Subscribers interact with the Relays by sending a SUBSCRIBE
-({{message-subscribe-req}}) control message for the tracks of
-interest. Relays MUST ensure subscribers are authorized to access the
-content associated with the track. The authorization
+Subscribers interact with the Relays by sending a SUBSCRIBE or FETCH
+control message for the tracks of interest. Relays MUST ensure subscribers are
+authorized to access the content associated with the track. The authorization
 information can be part of subscription request itself or part of the
 encompassing session. The specifics of how a relay authorizes a user are outside
 the scope of this specification.
@@ -862,7 +861,7 @@ publishers and forward objects to active matching subscriptions.
 If multiple objects are received with the same Full Track Name,
 Group ID and Object ID, Relays MAY ignore subsequently received Objects
 or MAY use them to update the cache. Implementations that update the
-cache need to be protect against cache poisoning.
+cache need to protect against cache poisoning.
 
 A relay MUST NOT reorder or drop objects received on a multi-object stream when
 forwarding to subscribers, unless it has application specific information.


### PR DESCRIPTION
Fixes #556
Fixes #557 
Fixes #583 
Fixes #584 

Also eliminates text from the relay section that is redundant, because it applies to endpoints whether or not they are relays.