### PR TITLE
Remove EndObject from SUBSCRIBE_UPDATE description

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1353,7 +1353,7 @@ if the SUBSCRIBE_UPDATE violates either rule or if the subscriber specifies a
 Subscribe ID that does not exist within the Session.
 
 Unlike a new subscription, SUBSCRIBE_UPDATE can not cause an Object to be
-delivered multiple times.  Like SUBSCRIBE, EndGroup and EndObject MUST specify the
+delivered multiple times.  Like SUBSCRIBE, EndGroup MUST specify the
 same or a later object than StartGroup and StartObject.
 
 The format of SUBSCRIBE_UPDATE is as follows:


### PR DESCRIPTION
The description of the field was removed previously, but this mention was leftover.