### PR TITLE
Remove a TODO and obsolete example

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2314,16 +2314,13 @@ OBJECT_DATAGRAM_STATUS Message {
 
 ## Streams
 
-When objects are sent on streams, the stream begins with a stream header
-message and is followed by one or more sets of serialized object fields.
-If a stream ends gracefully in the middle of a serialized Object, terminate the
-session with a Protocol Violation.
+When objects are sent on streams, the stream begins with a Stream Header
+Subgroup message and is followed by one or more sets of serialized object fields.
+If a stream ends gracefully in the middle of a serialized Object, the session
+SHOULD be terminated with a Protocol Violation.
 
-A publisher SHOULD NOT open more than one stream at a time with the same stream
-header message type and fields.
-
-
-TODO: figure out how a relay closes these streams
+A publisher SHOULD NOT open more than one stream at a time with the same Stream
+Header Subgroup field values.
 
 
 ### Stream Header Subgroup
@@ -2470,27 +2467,6 @@ The Subgroup ID field of an object with a Forwarding Preference of "Datagram"
 (see {{object-fields}}) is set to the Object ID.
 
 ## Examples
-
-Sending a track on one stream:
-
-~~~
-STREAM_HEADER_TRACK {
-  Track Alias = 1
-  Publisher Priority = 0
-}
-{
-  Group ID = 0
-  Object ID = 0
-  Object Payload Length = 4
-  Payload = "abcd"
-}
-{
-  Group ID = 1
-  Object ID = 0
-  Object Payload Length = 4
-  Payload = "efgh"
-}
-~~~
 
 Sending a subgroup on one stream:
 


### PR DESCRIPTION
We now have text on how to close subgroup streams, so removing the TODO.

Also updating some language now that we only send subgroups on streams, not tracks/etc.