### PR TITLE
Clean up confusing all caps text that seems false 

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -161,6 +161,8 @@ remains opaque and private.
 
 {::boilerplate bcp14-tagged}
 
+The following terms are used with the first letter capitalized.
+
 Client:
 
 : The party initiating a Transport Session.


### PR DESCRIPTION
add bit in terms defined after avoid confusion of if the "all capitals, as shown here" applies to the following text 