### PR TITLE
Remove Latest Group from SUBSCRIBE

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1288,11 +1288,7 @@ in the current group.
 The subscriber specifies a filter on the subscription to allow
 the publisher to identify which objects need to be delivered.
 
-There are 4 types of filters:
-
-Latest Group (0x1) : Specifies an open-ended subscription with objects
-from the beginning of the current group.  If no content has been delivered yet,
-the subscription starts with the first published or received group.
+There are 3 types of filters:
 
 Latest Object (0x2): Specifies an open-ended subscription beginning from
 the current object of the current group.  If no content has been delivered yet,

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1280,8 +1280,6 @@ GOAWAY Message {
 A subscription causes the publisher to send newly published objects for a track.
 A subscriber MUST NOT make multiple active subscriptions for a track within a
 single session and publishers SHOULD treat this as a protocol violation.
-The only objects prior to the current object that can be requested are those
-in the current group.
 
 **Filter Types**
 


### PR DESCRIPTION
Fixes #598 

May address #679 

Now that Joining Fetch is in the draft, we don't need this.