### PR TITLE
Adding Absolute Joining Fetch

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1726,8 +1726,8 @@ it is contiguous with the associated Subscribe. The Joining Fetch begins the
 Preceding Group Offset prior to the associated subscription.
 
 Absolute Joining Fetch (0x3) : Identical to a Relative Joining Fetch except that the
-StartGroup is determined by an absolute Group value rather than a relative offset to the
-subscription.
+StartGroup is determined by an absolute Group value rather than a relative offset to
+the subscription.
 
 A Subscriber can use a Joining Fetch to, for example, fill a playback buffer with a
 certain number of groups prior to the live edge of a track.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -229,9 +229,7 @@ Object:
 
 Track:
 
-: An encoded bitstream. Tracks contain a sequential series of one or
-  more groups and are the subscribable entity with MOQT.
-  See ({{model-track}}).
+: A track is a collection of groups. See ({{model-track}}).
 
 
 ## Notational Conventions
@@ -398,15 +396,17 @@ active.
 
 ### Track Naming {#track-name}
 
-In MOQT, every track has a track name and a track namespace associated
-with it.  A track name identifies an individual track within the
-namespace.
+In MOQT, every track is identified by a Full Track Name, consisting of a Track
+Namespace and a Track Name.
 
-Track namespace is an ordered N-tuple of bytes where N can be between 1 and 32.
+Track Namespace is an ordered N-tuple of bytes where N can be between 1 and 32.
 The structured nature of Track Namespace allows relays and applications to
-manipulate prefixes of a namespace. Track name is a sequence of bytes.
-If an endpoint receives a Track Namespace tuple with an N of 0 or more
-than 32, it MUST close the session with a Protocol Violation.
+manipulate prefixes of a namespace. If an endpoint receives a Track Namespace
+tuple with an N of 0 or more than 32, it MUST close the session with a Protocol
+Violation.
+
+Track Name is a sequence of bytes that identifies an individual track within the
+namespace.
 
 In this specification, both the Track Namespace tuple fields and the Track Name
 are not constrained to a specific encoding. They carry a sequence of bytes and
@@ -681,8 +681,8 @@ The syntax of these messages is described in {{message}}.
 
 If the subscriber is aware of a namespace of interest, it can send
 SUBSCRIBE_ANNOUNCES to publishers/relays it has established a session with. The
-recipient of this message will send any relevant ANNOUNCE messages for that
-namespace, or subset of that namespace.
+recipient of this message will send any relevant ANNOUNCE or UNANNOUNCE messages
+for that namespace, or subset of that namespace.
 
 A publisher MUST send exactly one SUBSCRIBE_ANNOUNCES_OK or
 SUBSCRIBE_ANNOUNCES_ERROR in response to a SUBSCRIBE_ANNOUNCES. The subscriber
@@ -1966,7 +1966,6 @@ FETCH_CANCEL Message {
 
 * Subscribe ID: Subscription Identifier as defined in {{message-fetch}}.
 
-
 ## TRACK_STATUS_REQUEST {#message-track-status-req}
 
 A potential subscriber sends a 'TRACK_STATUS_REQUEST' message on the control
@@ -2387,7 +2386,8 @@ are beyond the end of a group or track.
 
 `Status` can have following values:
 
-* 0x0 := Normal object. The payload is array of bytes and can be empty.
+* 0x0 := Normal object. This status is implicit for any non-zero length object.
+         Zero-length objects explicitly encode the Normal status.
 
 * 0x1 := Indicates Object does not exist. Indicates that this object
          does not exist at any publisher and it will not be published in

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1488,7 +1488,7 @@ Track Namespace, Track, StartGroup, StartObject, EndGroup, and EndObject such th
 it is contiguous with the associated Subscribe. The Joining Fetch begins the
 Preceding Group Offset prior to the associated subscription.
 
-Absolute Joining Fetch (0x3) : identical to a Relative Joining Fetch except that the
+Absolute Joining Fetch (0x3) : Identical to a Relative Joining Fetch except that the
 StartGroup is determined by an absolute Group value rather than a relative offset to the
 subscription.
 
@@ -1552,7 +1552,8 @@ Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
 A value of 0x0 indicates the original publisher's Group Order SHOULD be
 used. Values larger than 0x2 are a protocol error.
 
-* Fetch Type: Identifies the type of Fetch, whether  or standalone.
+* Fetch Type: Identifies the type of Fetch, whether Standalone, Relative
+  Joining or Absolute Joining.
 
 * Parameters: The parameters are defined in {{version-specific-params}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1860,8 +1860,8 @@ the Fetch EndGroup if Fetch EndObject is 0.
 
 ### Calculating the Range of an Absolute Joining Fetch
 
-Identical to the Relative Joining fetch except that Fetch StartGroup is calculated
-directly as the Joining Start value.
+Identical to the Relative Joining fetch except that Fetch StartGroup is the
+Joining Start value.
 
 
 ## FETCH_OK {#message-fetch-ok}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1810,7 +1810,7 @@ Fields present only for Standalone Fetch (0x1):
 * EndObject: The end Object ID, plus 1. A value of 0 means the entire group is
 requested.
 
-Fields present only for Relative Fetch (0x2) and Absolute  Fetch (0x3):
+Fields present only for Relative Fetch (0x2) and Absolute Fetch (0x3):
 
 * Joining Subscribe ID: The Subscribe ID of the existing subscription to be
 joined. If a publisher receives a Joining Fetch with a Subscribe ID that does

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1767,7 +1767,7 @@ FETCH Message {
    EndGroup (i),
    EndObject (i),]
   [ Subscribe ID (i),
-    Start (i),]
+    Joining Start (i),]
   Number of Parameters (i),
   Parameters (..) ...
 }

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1810,8 +1810,7 @@ Fields present only for Standalone Fetch (0x1):
 * EndObject: The end Object ID, plus 1. A value of 0 means the entire group is
 requested.
 
-Fields present only for Relative  Fetch (0x2) and Absolute  Fetch
-(0x3):
+Fields present only for Relative Fetch (0x2) and Absolute  Fetch (0x3):
 
 * Joining Subscribe ID: The Subscribe ID of the existing subscription to be
 joined. If a publisher receives a Joining Fetch with a Subscribe ID that does

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1482,9 +1482,9 @@ Track Namespace, Track, StartGroup, StartObject, EndGroup, and EndObject such th
 it is contiguous with the associated Subscribe. The Joining Fetch begins the
 Preceding Group Offset prior to the associated subscription.
 
-Absolute Joining Fetch (0x3) : identical to a Relative Joining Fetch except that the 
+Absolute Joining Fetch (0x3) : identical to a Relative Joining Fetch except that the
 StartGroup is determined by an absolute Group value rather than a relative offset to the
-subscription. 
+subscription.
 
 A Subscriber can use a Joining Fetch to, for example, fill a playback buffer with a
 certain number of groups prior to the live edge of a track.


### PR DESCRIPTION
This PR adds a Absolute Joining  Fetch, in which the Start Group is defined absolutely instead of relatively as is done with the existing Relative Joining Fetch. 

An Absolute Joining Fetch assists a client in making an optimal ABR switch, as described by this [presentation](https://docs.google.com/presentation/d/1YPLTpHjrJpNUtjvw58fAvE2NhiWHjuptDwTcjaRvVcI/edit#slide=id.g331a8043eb5_0_156) delivered during the Denver Interim. 

Fixes #730 