### PR TITLE
Adding AUTHORIZATION TOKEN parameter

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1120,8 +1120,8 @@ Protocol Violation.
 Some messages include a Parameters field that encode optional message
 elements. They contain a type, length, and value.
 
-Senders MUST NOT repeat the same parameter type in a message unless the 
-parameter definition explicitly allows multiple instances of that type to 
+Senders MUST NOT repeat the same parameter type in a message unless the
+parameter definition explicitly allows multiple instances of that type to
 be sent in a single message. Receivers SHOULD check that there are no
 unauthorized duplicate parameters and close the session as a
 'Protocol Violation' if found.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -633,6 +633,8 @@ code, as defined below:
 |------|---------------------------|
 | 0x12 | Data Stream Timeout       |
 |------|---------------------------|
+| 0x13 | Max Auth Limit Exceeded   |
+|------|---------------------------|
 
 * No Error: The session is being terminated without an error.
 
@@ -668,6 +670,9 @@ code, as defined below:
   stream. If an endpoint times out waiting for a new object header on an
   open subgroup stream, it MAY send a STOP_SENDING on that stream or
   terminate the subscription.
+
+* Max Auth Limit Exceeded - the Session limit {{max-auth-size}} of all registered
+  Authorization tokens has been exceeded.
 
 An endpoint MAY choose to treat a subscription or request specific error as a
 session error under certain circumstances, closing the entire session in
@@ -1261,6 +1266,10 @@ serialization, referencing an alias which has not been registered, attempting to
 register an alias which has been previously registered, or providing a token value
 which does not match the declared Token type.
 
+Retiring an alais and token that was previously used to authorize a message has no
+retroactive effect on the original authorization, nor does it prevent that same token
+being re-registered as long as that registration is performed with a new alias.
+
 Clients SHOULD only register tokens which they intend to re-use during the session.
 Client SHOULD retire previously registered tokens once their utility has passed.
 
@@ -1268,7 +1277,7 @@ By registering a Token, the client is requiring the receiver to store the Token 
 and Token Value until they are retired, or the Session ends. The receiver can protect
 its resources by sending a SETUP parameter defining the MAX_AUTH_SIZE {{max-auth-size}}
 limit it is willing to accept. If a registration is attempted which would cause this
-limit to be exceeded, the receiver MUST reject that message with a
+limit to be exceeded, the receiver MUST termiate the Session with a
 "Max Auth Limit Exceeded" error.
 
 
@@ -1724,8 +1733,6 @@ as defined below:
 |------|---------------------------|
 | 0x7  | Invalid Auth Token        |
 |------|---------------------------|
-| 0x8  | Max Auth Limit Exceeded   |
-|------|---------------------------|
 
 * Internal Error - An implementation specific or generic error occurred.
 
@@ -1750,10 +1757,6 @@ as defined below:
   be due to invalid serialization, referencing an alias which has not been
   registered, or attempting to register an alias which has been previously
   registered.
-
-* Max Auth Limit Exceeded - the size of the Authorization token supplied
-  causes the Session limit of all registered Authorization tokens to be
-
 
 ## SUBSCRIBE_UPDATE {#message-subscribe-update}
 
@@ -2212,9 +2215,7 @@ as defined below:
 |------|---------------------------|
 | 0x7  | Invalid Auth Token        |
 |------|---------------------------|
-| 0x8  | Max Auth Limit Exceeded   |
-|------|---------------------------|
-| 0x9  | Invalid Subscribe ID      |
+| 0x8  | Invalid Subscribe ID      |
 |------|---------------------------|
 
 * Internal Error - An implementation specific or generic error occurred.
@@ -2236,10 +2237,6 @@ as defined below:
   and object for the track, or the track has not published any objects.
 
 * Invalid Auth Token - An invalid Authorization token was provided.
-
-* Max Auth Limit Exceeded - the size of the Authorization token supplied
-  causes the Session limit of all registered Authorization tokens to be
-  exceeded.
 
 * Invalid Subscribe ID - The joining Fetch referenced a Subscribe ID that did
   not belong to an active Subscription.
@@ -2429,8 +2426,6 @@ below:
 |------|---------------------------|
 | 0x7  | Invalid Auth Token        |
 |------|---------------------------|
-| 0x8  | Max Auth Limit Exceeded   |
-|------|---------------------------|
 
 * Internal Error - An implementation specific or generic error occurred.
 
@@ -2445,10 +2440,6 @@ below:
 * Uninterested - The namespace is not of interest to the endpoint.
 
 * Invalid Auth Token - An invalid Authorization token was provided.
-
-* Max Auth Limit Exceeded - the size of the Authorization token supplied
-  causes the Session limit of all registered Authorization tokens to be
-  exceeded.
 
 
 ## UNANNOUNCE {#message-unannounce}
@@ -2613,8 +2604,6 @@ as defined below:
 |------|---------------------------|
 | 0x7  | Invalid Auth Token        |
 |------|---------------------------|
-| 0x8  | Max Auth Limit Exceeded   |
-|------|---------------------------|
 
 * Internal Error - An implementation specific or generic error occurred.
 
@@ -2633,12 +2622,6 @@ as defined below:
   SUBSCRIBE_ANNOUNCES in the same session.
 
 * Invalid Auth Token - An invalid Authorization token was provided.
-
-* Max Auth Limit Exceeded - the size of the Authorization token supplied
-  causes the Session limit of all registered Authorization tokens to be
-  exceeded.
-
-
 
 ## UNSUBSCRIBE_ANNOUNCES {#message-unsub-ann}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1258,8 +1258,8 @@ TOKEN {
 
 * Token Alias - a session-specific integer identifier that references a Token
   Value. The Token Alias MUST be unique within the Session. Once a Token Alias has
-  been registered, it cannot be re-registered within the Session. Use of the Token
-  Alias is optional.
+  been registered, it cannot be re-registered within the Session without first
+  being deleted. Use of the Token Alias is optional.
 
 * Token Value - the payload of the Token. The contents and serialization of this
   payload are defined by the Token Type.
@@ -1270,9 +1270,11 @@ serialization, referencing an alias which has not been registered, attempting to
 register an alias which has been previously registered, or providing a token value
 which does not match the declared Token type.
 
-Retiring an alais and token that was previously used to authorize a message has no
-retroactive effect on the original authorization, nor does it prevent that same token
-being re-registered as long as that registration is performed with a new alias.
+Using an Alias to refer to a previously registered Token Value is for efficiency
+only and has the same effect as if the Token Value was included directly.
+Retiring an Alias that was previously used to authorize a message has no
+retroactive effect on the original authorization, nor does it prevent that same
+Token Value being re-registered.
 
 Clients SHOULD only register tokens which they intend to re-use during the session.
 Client SHOULD retire previously registered tokens once their utility has passed.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -976,9 +976,9 @@ When a relay receives an incoming ANNOUNCE for a given namespace, for
 each active upstream subscription that matches that namespace, it SHOULD send a
 SUBSCRIBE to the publisher that sent the ANNOUNCE.
 
-Object headers carry a short hop-by-hop `Track ` that maps to
+Object headers carry a short hop-by-hop `Track Alias` that maps to
 the Full Track Name (see {{message-subscribe-ok}}). Relays use the
-`Track ` of an incoming Object to identify its track and find
+`Track Alias` of an incoming Object to identify its track and find
 the active subscribers for that track. Relays MUST forward Objects to
 matching subscribers in accordance to each subscription's priority, group order,
 and delivery timeout.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1182,7 +1182,7 @@ set as if no AUTHORIZATION INFO had been included.
 
 If an AUTHORIZATION ALIAS is associated with an AUTHORIZATION INFO instance and then
 later in the same session associated with a different AUTHORIZATION INFO instance,
-the receiver SHOULD update the AUTHORIZATION ALIAS to reference the last provided
+the receiver MUST update the AUTHORIZATION ALIAS to reference the last provided
 AUTHORIZATION INFO instance.
 
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -687,7 +687,7 @@ code, as defined below:
   terminate the subscription.
 
 * Auth Token Cache Overflow - the Session limit {{max-auth-token-cache-size}} of
-  all registered Authorization tokens has been exceeded.
+  the size of all registered Authorization tokens has been exceeded.
 
 * Duplicate Auth Token Alias - Authorization Token attempted to register an
   alias that was in use (see {{authorization-token}}).

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1120,9 +1120,11 @@ Protocol Violation.
 Some messages include a Parameters field that encode optional message
 elements. They contain a type, length, and value.
 
-Senders MUST NOT repeat the same parameter type in a message. Receivers
-SHOULD check that there are no duplicate parameters and close the session
-as a 'Protocol Violation' if found.
+Senders MUST NOT repeat the same parameter type in a message unless the 
+parameter definition explicitly allows multiple instances of that type to 
+be sent in a single message. Receivers SHOULD check that there are no
+unauthorized duplicate parameters and close the session as a
+'Protocol Violation' if found.
 
 Receivers ignore unrecognized parameters.
 
@@ -1167,6 +1169,8 @@ AUTHORIZATION TOKEN parameter (Parameter Type 0x01) identifies a track's
 authorization information in a SUBSCRIBE, SUBSCRIBE_ANNOUNCES, ANNOUNCE
 or FETCH message. This parameter is populated for cases where the authorization
 is required at the track level.
+
+The AUTHORIZATION TOKEN parameter MAY be repeated within a message.
 
 The TOKEN value is a structured object containing an optional session-specific
 alias. The Alias allows the client to reference a previously transmitted TOKEN

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1177,7 +1177,7 @@ parameters sets in which only the AUTHORIZATION ALIAS is sent MUST process the
 parameter set as if the AUTHORIZATION INFO had been retransmitted.
 
 If an AUTHORIZATION ALIAS is received without first having been associated with an
-AUTHORIZATION INFO in that session, then the receiver SHALL process the parameter
+AUTHORIZATION INFO in that session, then the receiver SHOULD process the parameter
 set as if no AUTHORIZATION INFO had been included.
 
 If an AUTHORIZATION ALIAS is associated with an AUTHORIZATION INFO instance and then

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1207,8 +1207,8 @@ these parameters to appear in Setup messages.
 
 AUTHORIZATION TOKEN parameter (Parameter Type 0x01) identifies a track's
 authorization information in a SUBSCRIBE, SUBSCRIBE_ANNOUNCES, ANNOUNCE
-or FETCH message. This parameter is populated for cases where the authorization
-is required at the track level.
+TRACK_STATUS_REQUEST or FETCH message. This parameter is populated for
+cases where the authorization is required at the track level.
 
 The AUTHORIZATION TOKEN parameter MAY be repeated within a message.
 
@@ -1226,7 +1226,7 @@ TOKEN {
 ~~~
 {: #moq-token format title="AUTHORIZATION TOKEN value"}
 
-* Token Type  - a numeric identifier for the type of Token payload being
+* Token Type - a numeric identifier for the type of Token payload being
   transmitted. This type is defined by the IANA table "MOQT Auth Token Type". See
   {{iana}}. Type 0 is reserved to indicate that the type is not defined in the
   table and must be negotiated out-of-band between client and receiver.
@@ -1234,25 +1234,29 @@ TOKEN {
 * Alias Type - an integer defining both the serialization and the processing
   behavior of the receiver. This Alias type has the following code points:
 
-|------|-------------------------------------------------------------------------|
-| Code | Serialization and behavior                                              |
-|-----:|:------------------------------------------------------------------------|
-| 0x0  | There is an Alias but no Value. This Alias and the Token Value it was   |
-|      | previously associated with MUST be retired. Retiring removes them from  |
-|      | the pool of actively registered tokens.                                 |
-|------|-------------------------------------------------------------------------|
-| 0x1  | There is an Alias and a Value. This Alias MUST be associated  with the  |
-|      | Token Value for the duration of the Session. This action is termed      |
-|      | "registering" the Token.                                                |
-|------|-------------------------------------------------------------------------|
-| 0x2  | There is an Alias and no Value. Use the Token Value previously          |
-|      | registered with this Alias.                                             |
-|------|-------------------------------------------------------------------------|
-| 0x3  | There is no Alias and there is a Value. Use the Token Value as provided.|
-|      | The Token Value may be discarded after processing.                      |
-|------|-------------------------------------------------------------------------|
+|------|------------|------------------------------------------------------|
+| Code | Name       | Serialization and behavior                           |
+|-----:|:-----------|------------------------------------------------------|
+| 0x0  | DELETE     | There is an Alias but no Value. This Alias and the   |
+|      |            | Token Value it was previously associated with MUST be|
+|      |            | retired. Retiring removes them from the pool of      |
+|      |            | actively registered tokens.                          |
+|------|------------|------------------------------------------------------|
+| 0x1  | REGISTER   | There is an Alias and a Value. This Alias MUST be    |
+|      |            | associated with the Token Value for the duration of  |
+|      |            | the Session. This action is termed "registering" the |
+|      |            | Token.                                               |
+|------|------------|------------------------------------------------------|
+| 0x2  | USE_ALIAS  | There is an Alias and no Value. Use the Token Value  |
+|      |            | previously registered with this Alias.               |
+|------|------------|------------------------------------------------------|
+| 0x3  | USE_VALUE  | There is no Alias and there is a Value. Use the Token|
+|      |            | Value as provided. The Token Value may be discarded  |
+|      |            | after processing.                                    |
+|------|------------|------------------------------------------------------|
 
-* Token Alias  - a session-specific integer identifier that references a Token
+
+* Token Alias - a session-specific integer identifier that references a Token
   Value. The Token Alias MUST be unique within the Session. Once a Token Alias has
   been registered, it cannot be re-registered within the Session. Use of the Token
   Alias is optional.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1168,17 +1168,17 @@ a relay that handles a subscription that includes those Objects re-requests them
 
 #### AUTHORIZATION ALIAS {#authorization-alias}
 
-AUTHORIZATION ALIAS parameter (Parameter Type 0x05) identifies an alias by which
-AUTHORIZATION INFO (Parameter Type 0x02) can be referenced within the current
-session. Transmission of both AUTHORIZATION ALIAS and AUTHORIZATION INFO parameters
-in the same parameter set is an instruction to the receiver to associate the
-AUTHORIZATION ALIAS with the AUTHORIZATION INFO. Receivers processing future
+AUTHORIZATION ALIAS parameter (Parameter Type 0x06) identifies a varint alias by
+which an AUTHORIZATION INFO (Parameter Type 0x02) can be referenced within the
+current session. Transmission of both AUTHORIZATION ALIAS and AUTHORIZATION INFO
+parameters in the same parameter set is an instruction to the receiver to associate
+the AUTHORIZATION ALIAS with the AUTHORIZATION INFO. Receivers processing future
 parameters sets in which only the AUTHORIZATION ALIAS is sent MUST process the
 parameter set as if the AUTHORIZATION INFO had been retransmitted.
 
-If an AUTHORIZATION ALIAS is received without first having been associated with an
-AUTHORIZATION INFO in that session, then the receiver SHOULD process the parameter
-set as if no AUTHORIZATION INFO had been included.
+If an AUTHORIZATION ALIAS is received in a message without that alias first having been
+associated with an AUTHORIZATION INFO in that session, then the receiver MUST reject
+that message with an "Invalid Auth alias" error.
 
 If an AUTHORIZATION ALIAS is associated with an AUTHORIZATION INFO instance and then
 later in the same session associated with a different AUTHORIZATION INFO instance,
@@ -1554,6 +1554,8 @@ as defined below:
 | 0x5  | Invalid Range             |
 |------|---------------------------|
 | 0x6  | Retry Track Alias         |
+|------|---------------------------|
+| 0x7  | Invalid Auth alias        |
 |------|---------------------------|
 
 ## SUBSCRIBE_UPDATE {#message-subscribe-update}
@@ -1953,6 +1955,8 @@ as defined below:
 |------|---------------------------|
 | 0x6  | No Objects                |
 |------|---------------------------|
+| 0x7  | Invalid Auth alias        |
+|------|---------------------------|
 
 ## FETCH_CANCEL {#message-fetch-cancel}
 
@@ -2124,6 +2128,8 @@ below:
 |------|---------------------------|
 | 0x4  | Uninterested              |
 |------|---------------------------|
+| 0x5  | Invalid Auth alias        |
+|------|---------------------------|
 
 ## UNANNOUNCE {#message-unannounce}
 
@@ -2277,6 +2283,8 @@ as defined below:
 | 0x3  | Not Supported             |
 |------|---------------------------|
 | 0x4  | Namespace Prefix Unknown  |
+|------|---------------------------|
+| 0x5  | Invalid Auth alias        |
 |------|---------------------------|
 
 ## UNSUBSCRIBE_ANNOUNCES {#message-unsub-ann}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1198,7 +1198,7 @@ TOKEN {
 |      | the pool of actively registered tokens.                                 |
 |------|-------------------------------------------------------------------------|
 | 0x1  | There is an Alias and a Value. This Alias MUST be associated  with the  |
-|      | Token Value for the duration of the Session. This action is termed      |     
+|      | Token Value for the duration of the Session. This action is termed      |
 |      | "registering" the Token.                                                |
 |------|-------------------------------------------------------------------------|
 | 0x2  | There is an Alias and no Value. Use the Token Value previously          |

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1182,7 +1182,7 @@ set as if no AUTHORIZATION INFO had been included.
 
 If an AUTHORIZATION ALIAS is associated with an AUTHORIZATION INFO instance and then
 later in the same session associated with a different AUTHORIZATION INFO instance,
-the receiver SHALL update the AUTHORIZATION ALIAS to reference the last provided
+the receiver SHOULD update the AUTHORIZATION ALIAS to reference the last provided
 AUTHORIZATION INFO instance.
 
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1120,7 +1120,7 @@ these parameters to appear in Setup messages.
 AUTHORIZATION INFO parameter (Parameter Type 0x02) identifies a track's
 authorization information in a SUBSCRIBE, SUBSCRIBE_ANNOUNCES, ANNOUNCE
 or FETCH message. This parameter is populated for cases where the authorization
-is required at the track level. The value is an ASCII string.
+is required at the track level.
 
 #### DELIVERY TIMEOUT Parameter {#delivery-timeout}
 
@@ -1165,6 +1165,25 @@ milliseconds has elapsed since the beginning of the Object was received.  This
 means Objects earlier in a multi-object stream will expire earlier than Objects
 later in the stream. Once Objects have expired, their state becomes unknown, and
 a relay that handles a subscription that includes those Objects re-requests them.
+
+#### AUTHORIZATION ALIAS {#authorization-alias}
+
+AUTHORIZATION ALIAS parameter (Parameter Type 0x05) identifies an alias by which
+AUTHORIZATION INFO (Parameter Type 0x02) can be referenced within the current
+session. Transmission of both AUTHORIZATION ALIAS and AUTHORIZATION INFO parameters
+in the same parameter set is an instruction to the receiver to associate the
+AUTHORIZATION ALIAS with the AUTHORIZATION INFO. Receivers processing future
+parameters sets in which only the AUTHORIZATION ALIAS is sent MUST process the
+parameter set as if the AUTHORIZATION INFO had been retransmitted.
+
+If an AUTHORIZATION ALIAS is received without first having been associated with an
+AUTHORIZATION INFO in that session, then the receiver SHALL process the parameter
+set as if no AUTHORIZATION INFO had been included.
+
+If an AUTHORIZATION ALIAS is associated with an AUTHORIZATION INFO instance and then
+later in the same session associated with a different AUTHORIZATION INFO instance,
+the receiver SHALL update the AUTHORIZATION ALIAS to reference the last provided
+AUTHORIZATION INFO instance.
 
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1364,10 +1364,14 @@ value is 0, so if not specified, the peer MUST NOT create subscriptions.
 
 The MAX_AUTH_SIZE parameter (Parameter Type 0x04) communicates the maximum
 size in bytes of all actively registered Authorization tokens that the server
-is willing to store per Session. This parameter is optional. The total size is
-calculated as the sum of the size of all registered tokens (Alias Type value of
-0x01 - see {{moq-token}})  minus the size for all deregistered tokens
-(Alias Type value of 0x00), since Session initiation.
+is willing to store per Session. This parameter is optional. The default value
+is 0 which prohibits the use of token aliases.
+
+The token size is calculated as 8 bytes + the size of the Token value
+(see {{moq-token}}). The total size as restricted by the MAX_AUTH_SIZE parameter
+is calculated as the sum of the token sizes for all registered tokens (Alias Type
+value of 0x01) minus the sum of the token sizes for all deregistered tokens (Alias
+Type value of 0x00), since Session initiation.
 
 ## GOAWAY {#message-goaway}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1845,7 +1845,7 @@ as defined below:
 * Malformed Auth Token - Invalid Auth Token serialization during registration
   (see {{authorization-token}}).
 
-* Unknown Auth Token Alias - Authroization Token refers to an alias that is
+* Unknown Auth Token Alias - Authorization Token refers to an alias that is
   not registered (see {{authorization-token}}).
 
 * Expired Auth Token - Authorization token has expired {{authorization-token}}).
@@ -2341,7 +2341,7 @@ as defined below:
 * Malformed Auth Token - Invalid Auth Token serialization during registration
   (see {{authorization-token}}).
 
-* Unknown Auth Token Alias - Authroization Token refers to an alias that is
+* Unknown Auth Token Alias - Authorization Token refers to an alias that is
   not registered (see {{authorization-token}}).
 
 * Expired Auth Token - Authorization token has expired {{authorization-token}}).
@@ -2557,7 +2557,7 @@ below:
 * Malformed Auth Token - Invalid Auth Token serialization during registration
   (see {{authorization-token}}).
 
-* Unknown Auth Token Alias - Authroization Token refers to an alias that is
+* Unknown Auth Token Alias - Authorization Token refers to an alias that is
   not registered (see {{authorization-token}}).
 
 * Expired Auth Token - Authorization token has expired {{authorization-token}}).
@@ -2754,7 +2754,7 @@ as defined below:
 * Malformed Auth Token - Invalid Auth Token serialization during registration
   (see {{authorization-token}}).
 
-* Unknown Auth Token Alias - Authroization Token refers to an alias that is
+* Unknown Auth Token Alias - Authorization Token refers to an alias that is
   not registered (see {{authorization-token}}).
 
 * Expired Auth Token - Authorization token has expired {{authorization-token}}).

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -642,6 +642,8 @@ code, as defined below:
 |------|---------------------------|
 | 0x13 | Auth Token Cache Overflow |
 |------|---------------------------|
+| 0x14 | Duplicate Auth Token Alias|
+|------|---------------------------|
 
 * No Error: The session is being terminated without an error.
 
@@ -686,6 +688,9 @@ code, as defined below:
 
 * Auth Token Cache Overflow - the Session limit {{max-auth-token-cache-size}} of
   all registered Authorization tokens has been exceeded.
+
+* Duplicate Auth Token Alias - Authorization Token attempted to register an
+  alias that was in use (see {{authorization-token}}).
 
 An endpoint MAY choose to treat a subscription or request specific error as a
 session error under certain circumstances, closing the entire session in
@@ -1318,13 +1323,12 @@ to invalid serialization or providing a token value which does not match the
 declared Token Type.  The receiver of a message referencing an alias that is
 not currently registered MUST reject the message with `Unknown Auth Token
 Alias`. The receiver of a message attempting to register an alias which is
-already registered MUST reject the message with `Duplicate Auth Token Alias`.
+already registered MUST close the session with `Duplicate Auth Token Alias`.
 
 Any message carrying an AUTHORIZATION TOKEN with Alias Type REGISTER that does
-not result in `Malformed Auth Token` or `Duplicate Auth Token Alias` MUST
-effect the token registration, even if the message fails for other reasons,
-including `Unauthorized`.  This allows senders to pipeline messages that refer
-to previously registered tokens.
+not result in `Malformed Auth Token` MUST effect the token registration, even
+if the message fails for other reasons, including `Unauthorized`.  This allows
+senders to pipeline messages that refer to previously registered tokens.
 
 If a receiver detects that an authorization token has expired, it MUST retain
 the registered alias until it is deleted by the sender, though it MAY discard
@@ -1490,7 +1494,7 @@ maximum size in bytes of all actively registered Authorization tokens that the
 server is willing to store per Session. This parameter is optional. The default
 value is 0 which prohibits the use of token aliases.
 
-The token size is calculated as 8 bytes + the size of the Token value (see 
+The token size is calculated as 8 bytes + the size of the Token value (see
 {{moq-token}}). The total size as restricted by the MAX_AUTH_TOKEN_CACHE_SIZE
 parameter is calculated as the sum of the token sizes for all registered tokens
 (Alias Type value of 0x01) minus the sum of the token sizes for all deregistered
@@ -1816,9 +1820,7 @@ as defined below:
 |------|---------------------------|
 | 0x11 | Unknown Auth Token Alias  |
 |------|---------------------------|
-| 0x12 | Duplicate Auth Token Alias|
-|------|---------------------------|
-| 0x13 | Expired Auth Token        |
+| 0x12 | Expired Auth Token        |
 |------|---------------------------|
 
 * Internal Error - An implementation specific or generic error occurred.
@@ -1842,13 +1844,10 @@ as defined below:
 
 * Malformed Auth Token - Invalid Auth Token serialization during registration
   (see {{authorization-token}}).
-  
+
 * Unknown Auth Token Alias - Authroization Token refers to an alias that is
   not registered (see {{authorization-token}}).
-  
-* Duplicate Auth Token Alias - Authorization Token attempted to register an
-  alias that was in use (see {{authorization-token}}).
-  
+
 * Expired Auth Token - Authorization token has expired {{authorization-token}}).
 
 
@@ -2315,9 +2314,7 @@ as defined below:
 |------|---------------------------|
 | 0x11 | Unknown Auth Token Alias  |
 |------|---------------------------|
-| 0x12 | Duplicate Auth Token Alias|
-|------|---------------------------|
-| 0x13 | Expired Auth Token        |
+| 0x12 | Expired Auth Token        |
 |------|---------------------------|
 
 * Internal Error - An implementation specific or generic error occurred.
@@ -2343,13 +2340,10 @@ as defined below:
 
 * Malformed Auth Token - Invalid Auth Token serialization during registration
   (see {{authorization-token}}).
-  
+
 * Unknown Auth Token Alias - Authroization Token refers to an alias that is
   not registered (see {{authorization-token}}).
-  
-* Duplicate Auth Token Alias - Authorization Token attempted to register an
-  alias that was in use (see {{authorization-token}}).
-  
+
 * Expired Auth Token - Authorization token has expired {{authorization-token}}).
 
 
@@ -2545,9 +2539,7 @@ below:
 |------|---------------------------|
 | 0x11 | Unknown Auth Token Alias  |
 |------|---------------------------|
-| 0x12 | Duplicate Auth Token Alias|
-|------|---------------------------|
-| 0x13 | Expired Auth Token        |
+| 0x12 | Expired Auth Token        |
 |------|---------------------------|
 
 * Internal Error - An implementation specific or generic error occurred.
@@ -2564,13 +2556,10 @@ below:
 
 * Malformed Auth Token - Invalid Auth Token serialization during registration
   (see {{authorization-token}}).
-  
+
 * Unknown Auth Token Alias - Authroization Token refers to an alias that is
   not registered (see {{authorization-token}}).
-  
-* Duplicate Auth Token Alias - Authorization Token attempted to register an
-  alias that was in use (see {{authorization-token}}).
-  
+
 * Expired Auth Token - Authorization token has expired {{authorization-token}}).
 
 
@@ -2743,9 +2732,7 @@ as defined below:
 |------|---------------------------|
 | 0x11 | Unknown Auth Token Alias  |
 |------|---------------------------|
-| 0x12 | Duplicate Auth Token Alias|
-|------|---------------------------|
-| 0x13 | Expired Auth Token        |
+| 0x12 | Expired Auth Token        |
 |------|---------------------------|
 
 * Internal Error - An implementation specific or generic error occurred.
@@ -2766,13 +2753,10 @@ as defined below:
 
 * Malformed Auth Token - Invalid Auth Token serialization during registration
   (see {{authorization-token}}).
-  
+
 * Unknown Auth Token Alias - Authroization Token refers to an alias that is
   not registered (see {{authorization-token}}).
-  
-* Duplicate Auth Token Alias - Authorization Token attempted to register an
-  alias that was in use (see {{authorization-token}}).
-  
+
 * Expired Auth Token - Authorization token has expired {{authorization-token}}).
 
 


### PR DESCRIPTION
The AUTHORIZATION ALIAS parameter allows a small alias to be associated with a larger AUTHORIZATION INFO payload, such as a token. This reduces message wireline size and token processing time (decryption etc) when future operations (such as rapid subscriptions and fetches) wish to reapply the same token.

Also removes the restriction that AUTHORIZATION INFO is an ASCII string.

This PR replaces PR #756 (same changes, cleaner base)

Fixes https://github.com/moq-wg/moq-transport/issues/906
Fixes: #513 
Fixes: #722
Fixes: #724 