### PR TITLE
make syntax consistent

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1454,8 +1454,8 @@ SUBSCRIBE_OK
   Expires (i),
   Group Order (8),
   ContentExists (8),
-  [Largest Group ID (i)],
-  [Largest Object ID (i)],
+  [Largest Group ID (i),
+   Largest Object ID (i)],
   Number of Parameters (i),
   Subscribe Parameters (..) ...
 }


### PR DESCRIPTION
Since content exists applies to GroupId/ObjectId together, this PR makes syntax consistent