### PR TITLE
Groups might not be published in ascending order

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -388,9 +388,8 @@ Order is Descending.  Due to network reordering and the partial reliability
 features of MoQT, Groups can always be received out of order.
 
 As a result, subscribers cannot infer the existence of a Group until an object in
-the Group is received.
-This can create gaps in the MoQ cache that MUST be filled by
-doing a Fetch upstream if a Fetch is received that requests those Groups.
+the Group is received. This can create gaps in the MoQ cache that MUST be filled
+by doing a Fetch upstream if a Fetch is received that requests those Groups.
 
 Subscribers to tracks which do not follow this requirement SHOULD NOT
 use range filters which span multiple groups in FETCH or SUBSCRIBE. SUBSCRIBE and

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -389,8 +389,8 @@ Group Order.
 
 As a result, Subscribers will not know the status of a Group within a SUBSCRIBE's
 Group range, even if there is no Delivery Timeout for the Subscription, until
-either the Group is received or a 'Group Does Not Exist' status is received
-for the Group.  This can create gaps in the MoQ cache that MUST be filled by
+either the Group is received or a 'Group Does Not Exist' status is received.
+This can create gaps in the MoQ cache that MUST be filled by
 doing a Fetch upstream if a Fetch is received that requests those Groups.
 
 Subscribers to tracks which do not follow this requirement SHOULD NOT

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -407,8 +407,8 @@ Order is Descending.  Due to network reordering and the partial reliability
 features of MoQT, Groups can always be received out of order.
 
 As a result, subscribers cannot infer the existence of a Group until an object in
-the Group is received. This can create gaps in the MoQ cache that MUST be filled
-by doing a Fetch upstream if a Fetch is received that requests those Groups.
+the Group is received. This can create gaps in a cache that can be filled
+by doing a Fetch upstream, if necessary.
 
 Subscribers to tracks which do not follow this requirement SHOULD NOT
 use range filters which span multiple groups in FETCH or SUBSCRIBE. SUBSCRIBE and

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -382,10 +382,10 @@ their group membership.  Groups can contain any number of objects.
 ### Group Ordering
 
 Within a track, the original publisher SHOULD publish Group IDs which increase
-with time. There are cases when even if the Groups are produced in increasing order,
-they might not be sent to the MoQ network or various Subscribers in the network
-in that order. One example is if the original publisher is publishing in descending
-Group Order.
+with time. In some cases, Groups will be produced in increasing order, but sent
+to subscribers in a different order, for example when the subscription's Group
+Order is Descending.  Due to network reordering and the partial reliability
+features of MoQT, Groups can always be received out of order.
 
 As a result, Subscribers will not know the status of a Group within a SUBSCRIBE's
 Group range, even if there is no Delivery Timeout for the Subscription, until

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -399,6 +399,10 @@ FETCH delivery use Group Order, so a FETCH cannot deliver Groups out of order
 and a subscription could have unexpected delivery order if Group IDs do not increase
 with time.
 
+Applications that cannot produce Group IDs that increase with time are limited
+to the subset of MoQT that does not compare group IDs. Subscribers to these Tracks
+SHOULD NOT use range filters which span multiple Groups in FETCH or SUBSCRIBE.
+
 ## Track {#model-track}
 
 A track is a sequence of groups ({{model-group}}). It is the entity

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -410,15 +410,12 @@ As a result, subscribers cannot infer the existence of a Group until an object i
 the Group is received. This can create gaps in a cache that can be filled
 by doing a Fetch upstream, if necessary.
 
-Subscribers to tracks which do not follow this requirement SHOULD NOT
-use range filters which span multiple groups in FETCH or SUBSCRIBE. SUBSCRIBE and
-FETCH delivery use Group Order, so a FETCH cannot deliver Groups out of order
-and a subscription could have unexpected delivery order if Group IDs do not increase
-with time.
-
 Applications that cannot produce Group IDs that increase with time are limited
 to the subset of MoQT that does not compare group IDs. Subscribers to these Tracks
 SHOULD NOT use range filters which span multiple Groups in FETCH or SUBSCRIBE.
+SUBSCRIBE and FETCH delivery use Group Order, so a FETCH cannot deliver Groups
+out of order and a subscription could have unexpected delivery order if Group IDs
+do not increase with time.
 
 ## Track {#model-track}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -379,8 +379,21 @@ subscriber that does not want to receive the entire track can opt to receive onl
 the latest group(s).  The publisher then selectively transmits objects based on
 their group membership.  Groups can contain any number of objects.
 
-Within a track, the original publisher SHOULD produce Group IDs which increase
-with time. Subscribers to tracks which do not follow this requirement SHOULD NOT
+### Group Ordering
+
+Within a track, the original publisher SHOULD publish Group IDs which increase
+with time. There are cases when even if the Groups are produced in increasing order,
+they might not be sent to the MoQ network or various Subscribers in the network
+in that order. One example is if the original publisher is publishing in descending
+Group Order.
+
+As a result, Subscribers will not know the status of a Group within a SUBSCRIBE's
+Group range, even if there is no Delivery Timeout for the Subscription, until
+either the Group is received or a 'Group Does Not Exist' status is received
+for the Group.  This can create gaps in the MoQ cache that MUST be filled by
+doing a Fetch upstream if a Fetch is received that requests those Groups.
+
+Subscribers to tracks which do not follow this requirement SHOULD NOT
 use range filters which span multiple groups in FETCH or SUBSCRIBE. SUBSCRIBE and
 FETCH delivery use Group Order, so a FETCH cannot deliver Groups out of order
 and a subscription could have unexpected delivery order if Group IDs do not increase

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -387,9 +387,8 @@ to subscribers in a different order, for example when the subscription's Group
 Order is Descending.  Due to network reordering and the partial reliability
 features of MoQT, Groups can always be received out of order.
 
-As a result, Subscribers will not know the status of a Group within a SUBSCRIBE's
-Group range, even if there is no Delivery Timeout for the Subscription, until
-either the Group is received or a 'Group Does Not Exist' status is received.
+As a result, subscribers cannot infer the existence of a Group until an object in
+the Group is received.
 This can create gaps in the MoQ cache that MUST be filled by
 doing a Fetch upstream if a Fetch is received that requests those Groups.
 


### PR DESCRIPTION
Even if they're produced in ascending order.

Addresses half of #777
Clarifies #715