### PR TITLE
Close on bad PATH

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -566,6 +566,8 @@ code, as defined below:
 |------|---------------------------|
 | 0x6  | Too Many Subscribes       |
 |------|---------------------------|
+| 0x7  | Invalid Path              |
+|------|---------------------------|
 | 0x10 | GOAWAY Timeout            |
 |------|---------------------------|
 | 0x11 | Control Message Timeout   |
@@ -1230,14 +1232,15 @@ The PATH parameter (Parameter Type 0x01) allows the client to specify the path
 of the MoQ URI when using native QUIC ({{QUIC}}).  It MUST NOT be used by
 the server, or when WebTransport is used.  If the peer receives a PATH
 parameter from the server, or when WebTransport is used, it MUST close
-the connection. It follows the URI formatting rules {{!RFC3986}}.
+the session with Invalid Path. It follows the URI formatting rules
+{{!RFC3986}}.
 
 When connecting to a server using a URI with the "moqt" scheme, the
 client MUST set the PATH parameter to the `path-abempty` portion of the
 URI; if `query` is present, the client MUST concatenate `?`, followed by
 the `query` portion of the URI to the parameter.  If the server receives an
-improperly formatted PATH parameter, it MUST close the session with a Protocol
-Violation.
+improperly formatted PATH parameter, it MUST close the session with Invalid
+Path.
 
 #### MAX_SUBSCRIBE_ID {#max-subscribe-id}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1318,7 +1318,7 @@ identified as 0xff00000D.
 The PATH parameter (Parameter Type 0x01) allows the client to specify the path
 of the MoQ URI when using native QUIC ({{QUIC}}).  It MUST NOT be used by
 the server, or when WebTransport is used.  If the peer receives a PATH
-parameter from the server, or when WebTransport is used, it MUST close
+parameter from the server, or when WebTransport is used, or the the one server doesn't support, it MUST close
 the session with Invalid Path.
 
 The PATH parameter follows the URI formatting rules {{!RFC3986}}.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -659,6 +659,11 @@ code, as defined below:
 * Too Many Subscribes: The session was closed because the subscriber used
   a Subscribe ID equal or larger than the current Maximum Subscribe ID.
 
+* Invalid Path: The PATH parameter was used by a server, on a WebTransport
+  session, or the server does not support the path.
+
+* Malformed Path: The PATH parameter does not conform to the rules in {{path}}.
+
 * GOAWAY Timeout: The session was closed because the peer took too long to
   close the session in response to a GOAWAY ({{message-goaway}}) message.
   See session migration ({{session-migration}}).

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1318,8 +1318,8 @@ identified as 0xff00000D.
 The PATH parameter (Parameter Type 0x01) allows the client to specify the path
 of the MoQ URI when using native QUIC ({{QUIC}}).  It MUST NOT be used by
 the server, or when WebTransport is used.  If the peer receives a PATH
-parameter from the server, or when WebTransport is used, or the the one server doesn't support, it MUST close
-the session with Invalid Path.
+parameter from the server, when WebTransport is used, or one the server
+does not support, it MUST close the session with Invalid Path.
 
 The PATH parameter follows the URI formatting rules {{!RFC3986}}.
 When connecting to a server using a URI with the "moqt" scheme, the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1235,7 +1235,9 @@ the connection. It follows the URI formatting rules {{!RFC3986}}.
 When connecting to a server using a URI with the "moqt" scheme, the
 client MUST set the PATH parameter to the `path-abempty` portion of the
 URI; if `query` is present, the client MUST concatenate `?`, followed by
-the `query` portion of the URI to the parameter.
+the `query` portion of the URI to the parameter.  If the server receives an
+improperly formatted PATH parameter, it MUST close the session with a Protocol
+Violation.
 
 #### MAX_SUBSCRIBE_ID {#max-subscribe-id}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -627,7 +627,9 @@ code, as defined below:
 |------|---------------------------|
 | 0x7  | Too Many Subscribes       |
 |------|---------------------------|
-| 0x7  | Invalid Path              |
+| 0x8  | Invalid Path              |
+|------|---------------------------|
+| 0x9  | Malformed Path            |
 |------|---------------------------|
 | 0x10 | GOAWAY Timeout            |
 |------|---------------------------|
@@ -1317,15 +1319,14 @@ The PATH parameter (Parameter Type 0x01) allows the client to specify the path
 of the MoQ URI when using native QUIC ({{QUIC}}).  It MUST NOT be used by
 the server, or when WebTransport is used.  If the peer receives a PATH
 parameter from the server, or when WebTransport is used, it MUST close
-the session with Invalid Path. The PATH parameter follows the URI formatting
-rules {{!RFC3986}}.
+the session with Invalid Path.
 
+The PATH parameter follows the URI formatting rules {{!RFC3986}}.
 When connecting to a server using a URI with the "moqt" scheme, the
 client MUST set the PATH parameter to the `path-abempty` portion of the
 URI; if `query` is present, the client MUST concatenate `?`, followed by
-the `query` portion of the URI to the parameter.  If the server receives an
-improperly formatted PATH parameter, it MUST close the session with Invalid
-Path.
+the `query` portion of the URI to the parameter. If a PATH does not conform to
+these rules, the session MUST be closed with Malformed Path.
 
 #### MAX_SUBSCRIBE_ID {#max-subscribe-id}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1232,8 +1232,8 @@ The PATH parameter (Parameter Type 0x01) allows the client to specify the path
 of the MoQ URI when using native QUIC ({{QUIC}}).  It MUST NOT be used by
 the server, or when WebTransport is used.  If the peer receives a PATH
 parameter from the server, or when WebTransport is used, it MUST close
-the session with Invalid Path. It follows the URI formatting rules
-{{!RFC3986}}.
+the session with Invalid Path. The PATH parameter follows the URI formatting
+rules {{!RFC3986}}.
 
 When connecting to a server using a URI with the "moqt" scheme, the
 client MUST set the PATH parameter to the `path-abempty` portion of the


### PR DESCRIPTION
Creates Invalid Path and Malformed Path error codes.

Fixes: #569