### PR TITLE
Add error codes for Duplicate and Invalid Subscribe ID

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1812,7 +1812,7 @@ FETCH Message {
    StartObject (i),
    EndGroup (i),
    EndObject (i),]
-  [ Subscribe ID (i),
+  [ Joining Subscribe ID (i),
     Joining Start (i),]
   Number of Parameters (i),
   Parameters (..) ...

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -562,11 +562,13 @@ code, as defined below:
 |------|---------------------------|
 | 0x3  | Protocol Violation        |
 |------|---------------------------|
-| 0x4  | Duplicate Track Alias     |
+| 0x4  | Duplicate Subscribe ID    |
 |------|---------------------------|
-| 0x5  | Parameter Length Mismatch |
+| 0x5  | Duplicate Track Alias     |
 |------|---------------------------|
-| 0x6  | Too Many Subscribes       |
+| 0x6  | Parameter Length Mismatch |
+|------|---------------------------|
+| 0x7  | Too Many Subscribes       |
 |------|---------------------------|
 | 0x10 | GOAWAY Timeout            |
 |------|---------------------------|
@@ -584,6 +586,9 @@ code, as defined below:
 
 * Protocol Violation: The remote endpoint performed an action that was
   disallowed by the specification.
+
+* Duplicate Subscribe ID: The endpoint attempted to use a Subscribe ID
+  that was already in use.
 
 * Duplicate Track Alias: The endpoint attempted to use a Track Alias
   that was already in use.
@@ -1397,7 +1402,9 @@ SUBSCRIBE Message {
 * Subscribe ID: The subscriber specified identifier used to manage a
 subscription. `Subscribe ID` is a variable length integer that MUST be
 unique and monotonically increasing within a session and MUST be less
-than the session's Maximum Subscribe ID.
+than the session's Maximum Subscribe ID.  If an endpoint receives a
+SUBSCRIBE with a Subscribe ID that is already in use, it MUST close
+the session with Duplicate Subscribe ID.
 
 * Track Alias: A session specific identifier for the track.
 Messages that reference a track, such as OBJECT ({{message-object}}),
@@ -1780,7 +1787,8 @@ Fields common to all Fetch Types:
 
 * Subscribe ID: The Subscribe ID identifies a given fetch request. Subscribe ID
 is a variable length integer that MUST be unique and monotonically increasing
-within a session.
+within a session.  If an endpoint receives a FETCH with a Subscribe ID that is
+already in use, it MUST close the session with Duplicate Subscribe ID.
 
 * Subscriber Priority: Specifies the priority of a fetch request relative to
 other subscriptions or fetches in the same session. Lower numbers get higher
@@ -1816,7 +1824,8 @@ Fields present only for Relative Fetch (0x2) and Absolute Fetch (0x3):
 
 * Joining Subscribe ID: The Subscribe ID of the existing subscription to be
 joined. If a publisher receives a Joining Fetch with a Subscribe ID that does
-not correspond to an existing Subscribe, it MUST respond with a Fetch Error.
+not correspond to an existing Subscribe, it MUST respond with a Fetch Error
+with code Invalid Subscribe ID.
 
 * Joining Start : for a Relative Joining Fetch (0x2), this value represents the
   group offset for the Fetch prior and relative to the Current Group of the
@@ -1948,6 +1957,8 @@ as defined below:
 | 0x5  | Invalid Range             |
 |------|---------------------------|
 | 0x6  | No Objects                |
+|------|---------------------------|
+| 0x7  | Invalid Subscribe ID      |
 |------|---------------------------|
 
 ## FETCH_CANCEL {#message-fetch-cancel}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2016,6 +2016,9 @@ as defined below:
 * No Objects - The beginning of the requested range is after the latest group
   and object for the track, or the track has not published any objects.
 
+* Invalid Subscribe ID - The joining Fetch referenced a Subscribe ID that did
+  not belong to an active Subscription.
+
 
 ## FETCH_CANCEL {#message-fetch-cancel}
 


### PR DESCRIPTION
Duplicate Subscribe ID is a session error, to mirror Duplicate Track Alias.

Invalid Subscribe ID is a FETCH_ERROR (not a session error) for Joining fetch if the dependent ID does not exist.  Since the client pipelines Subscribe+Joining Fetch, we don't want to close the session if the Subscribe fails and invalidates the ID.

Fixes: #674