### PR TITLE
Add FETCH_ERROR for Unknown Status in Range

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1714,6 +1714,9 @@ objects within a track. The publisher responding to a FETCH is responsible for r
 all available Objects. If there are gaps between Objects, the publisher omits them from the
 fetch response. All omitted objects have status Object Does Not Exist.
 
+If an Original Publisher receives a FETCH with a range that includes an object with
+unknown status, it MUST return FETCH_ERROR with code Unknown Status in Range.
+
 **Fetch Types**
 
 There are three types of Fetch messages:
@@ -1948,6 +1951,8 @@ as defined below:
 | 0x5  | Invalid Range             |
 |------|---------------------------|
 | 0x6  | No Objects                |
+|------|---------------------------|
+| 0x7  | Unknown Status in Range   |
 |------|---------------------------|
 
 ## FETCH_CANCEL {#message-fetch-cancel}


### PR DESCRIPTION
This is my proposal to handle cases where the Original Publisher receives a FETCH for a range that it can't satisfy because it has no knowledge of one or more objects requested.

Addresses part of #728 