### PR TITLE
Explain interaction of caching, status and extensions

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -858,7 +858,7 @@ or MAY use them to update the cache. Implementations that update the
 cache need to protect against cache poisoning.  The only fields that can be
 updated are the following:
 
-1. Object Status can transition from any status to Object Not Exists in cases
+1. Object Status can transition from any status to Object Does Not Exist in cases
    where the object is no longer available.  Transitions between Normal, End
    of Group and End of Track are invalid.
 3. Object Header Extensions can be added, removed or updated, subject

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -861,7 +861,7 @@ updated are the following:
 1. Object Status can transition from any status to Object Not Exists in cases
    where the object is no longer available
 2. Object Header Extensions can be added, removed or updated, subject
-to the constraints of the specific header extension.
+   to the constraints of the specific header extension.
 
 An endpoint that receives a duplicate object with an illegal Object Status
 change, or a Forwarding Preference, Subgroup ID, Priority or Payload that
@@ -891,7 +891,7 @@ subscriber, dependent on the congestion response.
 
 Relays MUST be able to process objects for the same Full Track Name from
 multiple publishers and forward objects to active matching subscriptions.  The
-same object SHOULD NOT be forwarded more than once to the same subscriber.
+same object SHOULD NOT be forwarded more than once on the same subscription.
 
 A relay MUST NOT reorder or drop objects received on a multi-object stream when
 forwarding to subscribers, unless it has application specific information.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -862,8 +862,9 @@ updated are the following:
    where the object is no longer available
 2. Object Header Extensions can be added, removed or updated
 
-An endpoint that receives a duplicate object with fields that differ from a
-previous version other than these MUST close the session with a Protocol
+An endpoint that receives a duplicate object with an illegal Object Status
+change, or a Forwarding Preference, Subgroup ID, Priority or Payload that
+differ from a previous version MUST close the session with a Protocol
 Violation.
 
 ## Subscriber Interactions

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -859,14 +859,20 @@ cache need to protect against cache poisoning.  The only fields that can be
 updated are the following:
 
 1. Object Status can transition from any status to Object Not Exists in cases
-   where the object is no longer available
-2. Object Header Extensions can be added, removed or updated, subject
+   where the object is no longer available.  Transitions between Normal, End
+   of Group and End of Track are invalid.
+3. Object Header Extensions can be added, removed or updated, subject
    to the constraints of the specific header extension.
 
-An endpoint that receives a duplicate object with an illegal Object Status
+An endpoint that receives a duplicate Object with an invalid Object Status
 change, or a Forwarding Preference, Subgroup ID, Priority or Payload that
-differ from a previous version MUST close the session with a Protocol
-Violation.
+differ from a previous version MUST treat the track as Malformed.
+
+Note that due to reordering, an implementation can receive a duplicate Object
+with a status of Normal, End of Group or End of Track after receiving a
+previous status of Object Not Exists.  The endpoint SHOULD NOT cache or
+forward the duplicate object in this case.
+
 
 ## Subscriber Interactions
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -846,7 +846,25 @@ validating subscribe and publish requests at the edge of a network.
 Relays are endpoints, which means they terminate Transport Sessions in order to
 have visibility of MoQ Object metadata.
 
+## Caching Relays
+
 Relays MAY cache Objects, but are not required to.
+
+A caching relay saves Objects to its cache identified by the Object's
+Full Track Name, Group ID and Object ID.
+If multiple objects are received with the same Full Track Name,
+Group ID and Object ID, Relays MAY ignore subsequently received Objects
+or MAY use them to update the cache. Implementations that update the
+cache need to protect against cache poisoning.  The only fields that can be
+updated are the following:
+
+1. Object Status can transition from any status to Object Not Exists in cases
+   where the object is no longer available
+2. Object Header Extensions can be added, removed or updated
+
+An endpoint that receives a duplicate object with fields that differ from a
+previous version other than these MUST close the session with a Protocol
+Violation.
 
 ## Subscriber Interactions
 
@@ -869,14 +887,9 @@ subscribers for each track. Each new OBJECT belonging to the
 track within the subscription range is forwarded to each active
 subscriber, dependent on the congestion response.
 
-A caching relay saves Objects to its cache identified by the Object's
-Full Track Name, Group ID and Object ID. Relays MUST be able to
-process objects for the same Full Track Name from multiple
-publishers and forward objects to active matching subscriptions.
-If multiple objects are received with the same Full Track Name,
-Group ID and Object ID, Relays MAY ignore subsequently received Objects
-or MAY use them to update the cache. Implementations that update the
-cache need to protect against cache poisoning.
+Relays MUST be able to process objects for the same Full Track Name from
+multiple publishers and forward objects to active matching subscriptions.  The
+same object SHOULD NOT be forwarded more than once to the same subscriber.
 
 A relay MUST NOT reorder or drop objects received on a multi-object stream when
 forwarding to subscribers, unless it has application specific information.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -850,17 +850,16 @@ have visibility of MoQ Object metadata.
 
 Relays MAY cache Objects, but are not required to.
 
-A caching relay saves Objects to its cache identified by the Object's
-Full Track Name, Group ID and Object ID.
-If multiple objects are received with the same Full Track Name,
-Group ID and Object ID, Relays MAY ignore subsequently received Objects
-or MAY use them to update the cache. Implementations that update the
-cache need to protect against cache poisoning.  The only fields that can be
-updated are the following:
+A caching relay saves Objects to its cache identified by the Object's Full Track
+Name, Group ID and Object ID. If multiple objects are received with the same
+Full Track Name, Group ID and Object ID, Relays MAY ignore subsequently received
+Objects or MAY use them to update certain cached fields. Implementations that
+update the cache need to protect against cache poisoning.  The only Object
+fields that can be updated are the following:
 
-1. Object Status can transition from any status to Object Does Not Exist in cases
-   where the object is no longer available.  Transitions between Normal, End
-   of Group and End of Track are invalid.
+1. Object Status can transition from any status to Object Does Not Exist in
+   cases where the object is no longer available.  Transitions between Normal,
+   End of Group and End of Track are invalid.
 3. Object Header Extensions can be added, removed or updated, subject
    to the constraints of the specific header extension.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -860,7 +860,8 @@ updated are the following:
 
 1. Object Status can transition from any status to Object Not Exists in cases
    where the object is no longer available
-2. Object Header Extensions can be added, removed or updated
+2. Object Header Extensions can be added, removed or updated, subject
+to the constraints of the specific header extension.
 
 An endpoint that receives a duplicate object with an illegal Object Status
 change, or a Forwarding Preference, Subgroup ID, Priority or Payload that


### PR DESCRIPTION
This is the simplest proposal, but doesn't cover the case of an extension that was added by the Original Publisher that was  added/modified/removed by a relay illegally (eg: LoC metadata).  To support that, the extension mechanism needs a way to identify immutable extensions.

Also added a normative statement about forwarding the same object more than once.

Fixes: #741 
Fixes: #745