### PR TITLE
Clarify Latest Object Filter

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1361,10 +1361,10 @@ SUBSCRIBE_OK will be delivered by the publisher. This is most useful where the
 Group ID implies a temporal relationship.
 
 All Objects (0x6): All objects that arrive via upstream SUBSCRIBE at, or are
-created by, the publisher after the object indicated by the Largest Group ID and
-Largest Object ID fields in the SUBSCRIBE_OK, whether or not the Location is
-higher.  This is most useful for tracks where the Group ID does not imply a
-temporal relationship.
+created by, the publisher after processing the SUBSCRIBE, whether or not the
+Location is higher than the highest observed when the SUBSCRIBE is processed.
+This is most useful for tracks where the Group ID does not imply a temporal
+relationship.
 
 A filter type other than the above MUST be treated as error.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1357,14 +1357,11 @@ Object' filter.
 
 Higher Objects (0x5): Specifies an open-ended subscription. All objects with
 a Location greater than the Largest Group ID and Latest Object ID fields in the
-SUBSCRIBE_OK will be delivered by the publisher. This is most useful where the
-Group ID implies a temporal relationship.
+SUBSCRIBE_OK will be delivered by the publisher.
 
 All Objects (0x6): All objects that arrive via upstream SUBSCRIBE at, or are
 created by, the publisher after processing the SUBSCRIBE, whether or not the
 Location is higher than the highest observed when the SUBSCRIBE is processed.
-This is most useful for tracks where the Group ID does not imply a temporal
-relationship.
 
 A filter type other than the above MUST be treated as error.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -879,7 +879,7 @@ allows relays to make only a single upstream subscription for the
 track. The published content received from the upstream subscription
 request is cached and shared among the pending subscribers.
 Because SUBSCRIBE_UPDATE only allows narrowing a subscription, relays that
-aggregate upstream subscriptions can subscribe using the Latest Object
+aggregate upstream subscriptions can subscribe using the Higher Objects
 filter to avoid churn as downstream subscribers with disparate filters
 subscribe and unsubscribe from a track.
 
@@ -1346,7 +1346,7 @@ There are 3 types of filters:
 AbsoluteStart (0x3):  Specifies an open-ended subscription beginning
 from the object identified in the StartGroup and StartObject fields. If the
 StartGroup is prior to the current group, the subscription starts at the
-beginning of the current object like the 'Latest Object' filter.
+beginning of the current object like the 'Highest Objects' filter.
 
 AbsoluteRange (0x4):  Specifies a closed subscription starting at StartObject
 in StartGroup and ending at the largest object in EndGroup.  The start and
@@ -1356,22 +1356,22 @@ subscription starts at the beginning of the current object like the 'Latest
 Object' filter.
 
 Higher Objects (0x5): Specifies an open-ended subscription. All objects with
-a sequence number higher than the Largest ID in the SUBSCRIBE_OK will be
-delivered by the publisher. This is most useful where the Group ID implies a
-temporal relationship.
+a Location greater than the Largest Group ID and Latest Object ID fields in the
+SUBSCRIBE_OK will be delivered by the publisher. This is most useful where the
+Group ID implies a temporal relationship.
 
-Later Objects (0x6): All objects that arrive at, or are created by, the
-publisher after the object indicated by the Largest ID field in the
-SUBSCRIBE_OK, whether or not the ID is higher. This is most useful for tracks
-where the Group ID does not imply a temporal relationship.
+All Objects (0x6): All objects that arrive via upstream SUBSCRIBE at, or are
+created by, the publisher after the object indicated by the Largest Group ID and
+Largest Object ID fields in the SUBSCRIBE_OK, whether or not the Location is
+higher.  This is most useful for tracks where the Group ID does not imply a
+temporal relationship.
 
 A filter type other than the above MUST be treated as error.
 
-If a subscriber wants to subscribe to Objects both before and after
-the Latest Object, it can send a SUBSCRIBE for the Latest Object
-followed by a FETCH. Depending upon the application, one might want to send
-both messages at the same time or wait for the first to return before sending
-the second.
+If a subscriber wants to subscribe to Objects that precede the Higher Objects
+filter, it can send a SUBSCRIBE for Higher Objects followed by a FETCH.
+Depending upon the application, one might want to send both messages at the same
+time or wait for the first to return before sending the second.
 
 The format of SUBSCRIBE is as follows:
 
@@ -1778,7 +1778,7 @@ A Subscriber can use a Joining Fetch to, for example, fill a playback buffer wit
 certain number of groups prior to the live edge of a track.
 
 A Joining Fetch is only permitted when the associated Subscribe has the Filter
-Type Latest Object.
+Type Higher Objects.
 
 A Fetch Type other than 0x1, 0x2 or 0x3 MUST be treated as an error.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1343,10 +1343,6 @@ the publisher to identify which objects need to be delivered.
 
 There are 3 types of filters:
 
-Latest Object (0x2): Specifies an open-ended subscription beginning from
-the current object of the current group.  If no content has been delivered yet,
-the subscription starts with the first published or received group.
-
 AbsoluteStart (0x3):  Specifies an open-ended subscription beginning
 from the object identified in the StartGroup and StartObject fields. If the
 StartGroup is prior to the current group, the subscription starts at the
@@ -1358,6 +1354,16 @@ end of the range are inclusive.  EndGroup MUST specify the same or a later
 group than StartGroup. If the StartGroup is prior to the current group, the
 subscription starts at the beginning of the current object like the 'Latest
 Object' filter.
+
+Higher Objects (0x5): Specifies an open-ended subscriptions. All objects with
+a Group and Object ID higher than the Largest ID in the SUBSCRIBE_OK will be
+delivered by the subscriber. This is most useful where the Group ID implies a
+temporal relationship.
+
+Later Objects (0x6): All objects that arrive at, or are created by, the
+publisher after the object indicated by the Largest ID field in the
+SUBSCRIBE_OK, whether or not the ID is higher. This is most useful for tracks
+where the Group ID does not imply a temporal relationship.
 
 A filter type other than the above MUST be treated as error.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1355,9 +1355,9 @@ group than StartGroup. If the StartGroup is prior to the current group, the
 subscription starts at the beginning of the current object like the 'Latest
 Object' filter.
 
-Higher Objects (0x5): Specifies an open-ended subscriptions. All objects with
-a Group and Object ID higher than the Largest ID in the SUBSCRIBE_OK will be
-delivered by the subscriber. This is most useful where the Group ID implies a
+Higher Objects (0x5): Specifies an open-ended subscription. All objects with
+a sequence number higher than the Largest ID in the SUBSCRIBE_OK will be
+delivered by the publisher. This is most useful where the Group ID implies a
 temporal relationship.
 
 Later Objects (0x6): All objects that arrive at, or are created by, the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1346,7 +1346,7 @@ There are 3 types of filters:
 AbsoluteStart (0x3):  Specifies an open-ended subscription beginning
 from the object identified in the StartGroup and StartObject fields. If the
 StartGroup is prior to the current group, the subscription starts at the
-beginning of the current object like the 'Highest Objects' filter.
+beginning of the current object like the 'Higher Objects' filter.
 
 AbsoluteRange (0x4):  Specifies a closed subscription starting at StartObject
 in StartGroup and ending at the largest object in EndGroup.  The start and


### PR DESCRIPTION
Fixes #758 

Since the current Local Object definition is ambiguous, I eliminated it and replaced it with two unambiguous definition.

I am open-minded about naming.