### PR TITLE
Remove object ID restriction language

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -337,9 +337,7 @@ underlying encoding, compression, any end-to-end encryption, or
 authentication. A relay MUST NOT combine, split, or otherwise modify object
 payloads.
 
-Objects within a Group are ordered numerically by their Object ID. The first
-Object in a Group has an Object ID of 0, and IDs increase sequentially for
-each Object within the Group.
+Objects within a Group are ordered numerically by their Object ID.
 
 ## Subgroups {#model-subgroup}
 


### PR DESCRIPTION
Fixes: #808 

Make draft consistent with WG understanding per direction from chairs: https://mailarchive.ietf.org/arch/msg/moq/_RSE6JTeka4MMHxkisEydvHrr4Q/

There are two other issues where discussion of object IDs are taking place: #358 and #772