### PR TITLE
Proposing `BATCH_SUBSCRIBE`

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1077,6 +1077,8 @@ MOQT Control Message {
 |-------|-----------------------------------------------------|
 | 0x5   | SUBSCRIBE_ERROR ({{message-subscribe-error}})       |
 |-------|-----------------------------------------------------|
+| 0x6   | BATCH_SUBSCRIBE ({{message-batch-subscribe}})       |
+|-------|-----------------------------------------------------|
 | 0xA   | UNSUBSCRIBE ({{message-unsubscribe}})               |
 |-------|-----------------------------------------------------|
 | 0x2   | SUBSCRIBE_UPDATE ({{message-subscribe-update}})     |
@@ -1507,6 +1509,50 @@ specified and the publisher SHOULD start delivering objects.
 If a publisher cannot satisfy the requested start or end or if the end has
 already been published it SHOULD send a SUBSCRIBE_ERROR with code 'Invalid Range'.
 A publisher MUST NOT send objects from outside the requested start and end.
+
+## BATCH_SUBSCRIBE {#message-batch-subscribe}
+
+A message format to enable subscriptions to multiple tracks sharing the
+same track namespace prefix with a single message instead of multiple
+SUBSCRIBE messages.
+
+~~~
+BATCH_SUBSCRIBE Message {
+  Type (i) = 0x6,
+  Length (i),
+  Track Namespace Prefix (tuple),
+  Number of Subscriptions (i),
+  (
+    Subscribe ID (i),
+    Track Alias (i),
+    Track Namespace Suffix (tuple),
+    Track Name Length (i),
+    Track Name (..),
+    Subscriber Priority (8),
+    Group Order (8),
+    Filter Type (i),
+    [StartGroup (i),
+     StartObject (i)],
+    [EndGroup (i)],
+    Number of Parameters (i),
+    Subscribe Parameters (..) ...
+  ) ...
+}
+~~~
+
+The receiver of the BATCH_SUBSCRIBE message MUST treat it as identical to receiving
+multiple SUBSCRIBE messages; this includes replying to each of them individually
+with SUBSCRIBE_OK (or SUBSCRIBE_ERROR), allowing update and cancel
+each SUBSCRIBE individually with SUBSCRIBE_UPDATE and UNSUBSCRIBE.
+
+* Track Namespace Prefix: The namespace prefix which will be prepended to the
+Track Namespace Suffix for all the subscriptions, it MAY be a empty tuple
+if there is no common prefix.
+
+It contains the Number of Subscriptions followed by those many number of
+subscribe messages, with a format nearly identical to SUBSCRIBE except for
+the Track Namespace field replaced with Track Namespace Suffix.
+
 
 ## SUBSCRIBE_OK {#message-subscribe-ok}
 


### PR DESCRIPTION
Often multiple channels of media such as subtitles, audio, base layer / enhancement layer video are subscribed to simultaneously.

It would make sense that they are all within the same track namespace

Consider the following object model

```
very_long_namespace_prefix/media_id/subtitles/eng
very_long_namespace_prefix/media_id/audio/eng
very_long_namespace_prefix/media_id/base_layer_video
very_long_namespace_prefix/media_id/enhancement_layer_video
``` 

Currently this would require 4 different subscribe messages to be sent, each with the same track namespace prefix of  "`very_long_namespace_prefix/media_id`"

We propose a simple fix to this redundancy with the `BATCH_SUBSCRIBE` message to subscribe to multiple tracks using a single message.

```
BATCH_SUBSCRIBE Message {
  Type (i) = 0x6,
  Length (i),
  Track Namespace Prefix (tuple),
  Number of Subscriptions (i),
  (
    Subscribe ID (i),
    Track Alias (i),
    Track Namespace Suffix (tuple),
    Track Name Length (i),
    Track Name (..),
    Subscriber Priority (8),
    Group Order (8),
    Filter Type (i),
    [StartGroup (i),
     StartObject (i)],
    [EndGroup (i)],
    Number of Parameters (i),
    Subscribe Parameters (..) ...
  ) ...
}
```

This also provides the implementation an hint that these subscriptions are related and possibly optimise delivery accordingly.

Answers to some possible questions
1. **Why not update the existing `SUBSCRIBE` message?** : Updating the existing subscribe message adds an overhead of 1-2 bytes in situations where no batched subscriptions are being made. I do not have a strong opinion on whether the 1-2 bytes are significant

2. **How do we handle the numerous interactions associated with `SUBSCRIBE`?** : The receiver of the `BATCH_SUBSCRIBE` must treat it to be identical to receiving multiple `SUBSCRIBE` messages, this means it should reply to it using multiple `SUBSCRIBE_OK`/`SUBSCRIBE_ERROR` messages and `SUBSCRIBE_DONE` when the subscription is fulfilled, allow updates or cancels on each of the subscriptions individually using `SUBSCRIBE_UPDATE` or `UNSUBSCRIBE`. This removes much of the complexity associated with handling `BATCH_SUBSCRIBE` separately. 

3. **There are already talks of wildcard subscription, why do we need this?** : Assuming wildcard subscriptions to mean all tracks within a namespace; this might seldom be the right solution. Consider the above mentioned case, a wildcard subscription to all tracks within `very_long_namespace_prefix/media_id` would mean the client receives all subtitles and audio they are authorized to, this might include languages the client is not interested in receiving and data which would end up being discarded by the client. There might also be multiple post processed versions of the for censorship, better experience for specially-abled, etc.,  




