### PR TITLE
Save a byte when subgroup ID is a common value

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2552,7 +2552,9 @@ the type of the stream in question.
 |-------------|-------------------------------------------------|
 | ID          | Type                                            |
 |------------:|:------------------------------------------------|
-| 0x08-0x09   | SUBGROUP_HEADER  ({{subgroup-header}})          |
+| 0x08-0x0D   | SUBGROUP_HEADER  ({{subgroup-header}})          |
+|-------------|-------------------------------------------------|
+| 0x0E-0xF    | RESERVED                                        |
 |-------------|-------------------------------------------------|
 | 0x05        | FETCH_HEADER  ({{fetch-header}})                |
 |-------------|-------------------------------------------------|
@@ -2772,7 +2774,7 @@ SUBGROUP_HEADER {
   Type (i),
   Track Alias (i),
   Group ID (i),
-  Subgroup ID (i),
+  [Subgroup ID (i),]
   Publisher Priority (8),
 }
 ~~~
@@ -2781,11 +2783,26 @@ SUBGROUP_HEADER {
 All Objects received on a stream opened with `SUBGROUP_HEADER` have an
 `Object Forwarding Preference` = `Subgroup`.
 
-The Type field takes the form 0b0000100X (or the set of values from 0x08 to
-0x09). The LSB determines if the Extensions Headers Length is present in Objects
-in this subgroup.  When it is 0, Extensions Headers Length is not present and all
-Objects have no extensions.  When it is 1, Extension Headers Length is present in
-all Objects in this subgroup.
+The Type field takes the form 0b00001XXX (or the set of values from 0x08 to
+0x0D). The three low-order bits of the frame type determine the fields that
+are present in the frame:
+
+The EXT bit (0x01) determines if the Extensions Headers Length is present in
+Objects in this subgroup.  When it is 0, Extensions Headers Length is not
+present and all Objects have no extensions.  When it is 1, Extension Headers
+Length is present in all Objects in this subgroup.
+
+The HAS_SUBGROUP_ID  bit (0x02) determines if the Subgroup ID field is present.
+When it is 0, there is no explicit Subgroup ID field and the SUBGROUP_ID bit
+determines the Subgroup ID.  When it is 1, the Subgroup ID field is present.
+
+The SUBGROUP_ID bit (0x4) determines the implicit Subgroup ID when the
+HAS_SUBGROUP_ID bit is 0.  When the SUBGROUP_ID bit is 0, the Subgroup ID is 0.
+When the SUBGROUP_ID bit is 1, the Subgroup ID is the Object ID of the first
+object transmitted in this subgroup.
+
+It is not valid to send HAS_SUBGROUP_ID=1 and SUBGROUP_ID=1.  Those values of
+type (0x0E-0x0F) are reserved and have no meaning in MoQT.
 
 To send an Object with `Object Forwarding Preference` = `Subgroup`, find the open
 stream that is associated with the subscription, `Group ID` and `Subgroup ID`,


### PR DESCRIPTION
Use the Type field to encode Subgroup ID=0 (eg stream-per-group) or Subgroup ID=Object ID (eg stream-per-object).

Fixes: #909