### PR TITLE
Clarify how SUBSCRIBE filters work, allow Absolute start before Latest

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1421,7 +1421,7 @@ AbsoluteRange (0x4):  The filer Start Location and End Group are specified
 explicitly in the SUBSCRIBE message. The `Start` specified in the SUBSCRIBE
 message MAY be less than the `Largest Object` observed at the publisher. If the
 specified `EndGroup` is the same group specified in `Start`, the remainder of
-that Group passes the filter. `EndGroup` MUST specify the same or a later Group
+that Group passes the filter. `EndGroup` MUST specify the same or a larger Group
 than specified in `Start`.
 
 A filter type other than the above MUST be treated as error.
@@ -1648,7 +1648,7 @@ delivered.
 
 Unlike a new subscription, SUBSCRIBE_UPDATE can not cause an Object to be
 delivered multiple times.  Like SUBSCRIBE, EndGroup MUST specify the
-same or a later object than StartGroup and StartObject.
+same or a larger Object than StartGroup and StartObject.
 
 If a parameter included in `SUBSCRIBE` is not present in
 `SUBSCRIBE_UPDATE`, its value remains unchanged.  There is no mechanism to
@@ -1861,7 +1861,7 @@ The Object Forwarding Preference does not apply to fetches.
 
 Fetch specifies an inclusive range of Objects starting at StartObject
 in StartGroup and ending at EndObject in EndGroup. EndGroup and EndObject MUST
-specify the same or a later object than StartGroup and StartObject.
+specify the same or a larger Object than StartGroup and StartObject.
 
 The format of FETCH is as follows:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1861,7 +1861,7 @@ The Object Forwarding Preference does not apply to fetches.
 
 Fetch specifies an inclusive range of Objects starting at StartObject
 in StartGroup and ending at EndObject in EndGroup. EndGroup and EndObject MUST
-specify the same or a larger Object than StartGroup and StartObject.
+specify the same or a larger Location than StartGroup and StartObject.
 
 The format of FETCH is as follows:
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1414,7 +1414,7 @@ Latest Object filter.
 AbsoluteStart (0x3):  The Start Location is specified explicitly in the message.
 The Start Location MAY be less than the `Largest Object`. There is no End Group
 - the subscription is open ended.  To receive any object that is published or
-is received after this subscription is processed, a subscriber can use a an
+is received after this subscription is processed, a subscriber can use an
 AbsoluteStart filter with Start Location = {0, 0}.
 
 AbsoluteRange (0x4):  The Start Location and End Group are specified explicitly

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1410,8 +1410,8 @@ prioritization, relays can receive objects with Locations smaller than `Largest
 Object` after the SUBSCRIBE is processed, but these objects do not pass the
 Latest Object filter.
 
-AbsoluteStart (0x3):  The Start Location is specified explicitly in the message.
-The Start Location MAY be less than the `Largest Object`. There is no End Group
+AbsoluteStart (0x3):  The Start Location is specified explicitly in the Subscribe message.
+The Start Location specified in the Subscribe message MAY be less than the `Largest Object` observed at the publisher. There is no End Group
 - the subscription is open ended.  To receive any object that is published or
 is received after this subscription is processed, a subscriber can use an
 AbsoluteStart filter with Start Location = {0, 0}.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1393,7 +1393,7 @@ the publisher to identify which objects need to be delivered.
 
 All filters have a Start Location and an optional End Group.  Only objects
 published or received via a subscription having Locations greater than or
-equal to start and strictly less than than or within the End Group (when
+equal to Start and strictly less than or within the End Group (when
 present) pass the filter.
 
 The `Largest Object` is defined to be the object with the largest Location
@@ -1421,15 +1421,12 @@ AbsoluteRange (0x4):  The Start Location and End Group are specified explicitly
 in the message. The Start Location MAY be less than the `Largest Object`. If End
 Group is the same group specified in Start Location, the remainder of that group
 passes the filter.  EndGroup MUST specify the same or a later group than
-specified in `Start`. 
+specified in `Start`.
 
 A filter type other than the above MUST be treated as error.
 
-Because objects can be reordered on the network, a SUBSCRIBE with the Latest
-Object filter might begin at 
-
-Subscribe only delivers newly published or received Objects.  Objects from
-the past are retrieved using FETCH ({{message-fetch}}).
+Subscribe only delivers newly published or received Objects.  Objects from the
+past are retrieved using FETCH ({{message-fetch}}).
 
 A Subscription can also request a publisher to not forward Objects for a given
 track by setting the `Forward` field to 0. This allows the publisher or relay

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1402,25 +1402,27 @@ processing the SUBSCRIBE message.
 
 There are 3 types of filters:
 
-Latest Object (0x2): The Start Location is `{Largest Object.Group, Largest Object.Object + 1}`. `Largest Object` is
-communicated in SUBSCRIBE_OK. If no content has been delivered yet, the Start
-Location is {0, 0}.  There is no End Group - the
-subscription is open ended.  Note that due to network reordering or
-prioritization, relays can receive objects with Locations smaller than `Largest
-Object` after the SUBSCRIBE is processed, but these objects do not pass the
-Latest Object filter.
+Latest Object (0x2): The filter Start Location is `{Largest Object.Group,
+Largest Object.Object + 1}` and `Largest Object` is communicated in
+SUBSCRIBE_OK. If no content has been delivered yet, the filter Start Location is
+{0, 0}. There is no End Group - the subscription is open ended.  Note that due
+to network reordering or prioritization, relays can receive Objects with
+Locations smaller than  `Largest Object` after the SUBSCRIBE is processed, but
+these Objects do not pass the Latest Object filter.
 
-AbsoluteStart (0x3):  The Start Location is specified explicitly in the Subscribe message.
-The Start Location specified in the Subscribe message MAY be less than the `Largest Object` observed at the publisher. There is no End Group
-- the subscription is open ended.  To receive any object that is published or
-is received after this subscription is processed, a subscriber can use an
-AbsoluteStart filter with Start Location = {0, 0}.
+AbsoluteStart (0x3):  The filter Start Location is specified explicitly in the
+SUBSCRIBE message. The `Start` specified in the SUBSCRIBE message MAY be less
+than the `Largest Object` observed at the publisher. There is no End Group - the
+subscription is open ended.  To receive any Object that is published or is
+received after this subscription is processed, a subscriber can use an
+AbsoluteStart filter with `Start` = {0, 0}.
 
-AbsoluteRange (0x4):  The Start Location and End Group are specified explicitly
-in the message. The Start Location MAY be less than the `Largest Object`. If End
-Group is the same group specified in Start Location, the remainder of that group
-passes the filter.  EndGroup MUST specify the same or a later group than
-specified in `Start`.
+AbsoluteRange (0x4):  The filer Start Location and End Group are specified
+explicitly in the SUBSCRIBE message. The `Start` specified in the SUBSCRIBE
+message MAY be less than the `Largest Object` observed at the publisher. If the
+specified `EndGroup` is the same group specified in `Start`, the remainder of
+that Group passes the filter. `EndGroup` MUST specify the same or a later Group
+than specified in `Start`.
 
 A filter type other than the above MUST be treated as error.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1393,7 +1393,7 @@ the publisher to identify which objects need to be delivered.
 
 All filters have a Start Location and an optional End Group.  Only objects
 published or received via a subscription having Locations greater than or
-equal to Start and strictly less than or within the End Group (when
+equal to Start and strictly less than or equal to the End Group (when
 present) pass the filter.
 
 The `Largest Object` is defined to be the object with the largest Location
@@ -1402,8 +1402,7 @@ processing the SUBSCRIBE message.
 
 There are 3 types of filters:
 
-Latest Object (0x2): The Start Location is the next object published or received
-via subscription with a Location larger than the `Largest Object`, which is
+Latest Object (0x2): The Start Location is `{Largest Object.Group, Largest Object.Object + 1}`. `Largest Object` is
 communicated in SUBSCRIBE_OK. If no content has been delivered yet, the Start
 Location is the first published or received group.  There is no End Group - the
 subscription is open ended.  Note that due to network reordering or

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1413,7 +1413,7 @@ these Objects do not pass the Latest Object filter.
 AbsoluteStart (0x3):  The filter Start Location is specified explicitly in the
 SUBSCRIBE message. The `Start` specified in the SUBSCRIBE message MAY be less
 than the `Largest Object` observed at the publisher. There is no End Group - the
-subscription is open ended.  To receive any Object that is published or is
+subscription is open ended.  To receive all Objects that are published or are
 received after this subscription is processed, a subscriber can use an
 AbsoluteStart filter with `Start` = {0, 0}.
 
@@ -1647,8 +1647,8 @@ processed promptly and some extra objects from the existing subscription are
 delivered.
 
 Unlike a new subscription, SUBSCRIBE_UPDATE can not cause an Object to be
-delivered multiple times.  Like SUBSCRIBE, EndGroup MUST specify the
-same or a larger Object than StartGroup and StartObject.
+delivered multiple times.  Like SUBSCRIBE, EndGroup MUST be greater than or
+equal to the Group specified in `Start`.
 
 If a parameter included in `SUBSCRIBE` is not present in
 `SUBSCRIBE_UPDATE`, its value remains unchanged.  There is no mechanism to

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1404,7 +1404,7 @@ There are 3 types of filters:
 
 Latest Object (0x2): The Start Location is `{Largest Object.Group, Largest Object.Object + 1}`. `Largest Object` is
 communicated in SUBSCRIBE_OK. If no content has been delivered yet, the Start
-Location is the first published or received group.  There is no End Group - the
+Location is {0, 0}.  There is no End Group - the
 subscription is open ended.  Note that due to network reordering or
 prioritization, relays can receive objects with Locations smaller than `Largest
 Object` after the SUBSCRIBE is processed, but these objects do not pass the


### PR DESCRIPTION
This is an alternate to #853, attempting to resolve #758.

Fixes: #758
Closes #726 