### PR TITLE
Add Next Group Start filter

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1502,7 +1502,9 @@ these Objects do not pass the Latest Object filter.
 Next Group Start (0x1): The filter start Location is `{Largest Object.Group + 1,
 0}` and `Largest Object` is communicated in SUBSCRIBE_OK. If no content has been
 delivered yet, the filter Start Location is {0, 0}.  There is no End Group -
-the subscription is open ended.
+the subscription is open ended. For scenarios where the subscriber intends to
+start more than one group in the future, it can use an AbsoluteStart filter
+instead.
 
 AbsoluteStart (0x3):  The filter Start Location is specified explicitly in the
 SUBSCRIBE message. The `Start` specified in the SUBSCRIBE message MAY be less


### PR DESCRIPTION
The name is kind of a bikeshed - Next can imply temporality. Maybe we should get rid of filter names since they all now have precise definitions of start and end.

Fixes: #744