### PR TITLE
Prior Object ID Gap Extension header

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3598,11 +3598,12 @@ The following Object Extension Headers are defined in MOQT.
 
 Prior Group ID Gap (Extension Header Type 0x3C) is a variable length integer
 containing the number of Groups prior to the current Group that do not and will
-never exist. For example, if the Original Publisher is publishing an Object in
-Group 7 and knows it will never publish any Objects in Group 8 or Group 9, it
-can include Prior Group ID Gap = 2 in any number of Objects in Group 10, as it
-sees fit.  A Track is considered malformed (see {{malformed-tracks}} if any of
-the following conditions are detected:
+never exist. This is equivalent to receiving an `End of Group` status with
+Object ID 0 for each skipped Group. For example, if the Original Publisher is
+publishing an Object in Group 7 and knows it will never publish any Objects in
+Group 8 or Group 9, it can include Prior Group ID Gap = 2 in any number of
+Objects in Group 10, as it sees fit.  A Track is considered malformed (see
+{{malformed-tracks}} if any of the following conditions are detected:
 
  * An Object contains more than one instance of Prior Group ID Gap
  * A Group contains more than one Object with different values for Prior Group
@@ -3625,10 +3626,12 @@ relays. This extension MUST NOT be modified or removed.
 
 Prior Object ID Gap (Extension Header Type 0x3E) is a variable length integer
 containing the number of Objects prior to the current Object that do not and
-will never exist. For example, if the Original Publisher is publishing Object 10
-in Group 3 and knows it will never publish Objects 8 or 9 in this Group, it can
-include Prior Object ID Gap = 2.  A Track is considered malformed (see
-{{malformed-tracks}} if any of the following conditions are detected:
+will never exist. This is equivalent to receiving an `Object Does Not Exist`
+status for each skipped Object ID. For example, if the Original Publisher is
+publishing Object 10 in Group 3 and knows it will never publish Objects 8 or 9
+in this Group, it can include Prior Object ID Gap = 2.  A Track is considered
+malformed (see {{malformed-tracks}} if any of the following conditions are
+detected:
 
  * An Object contains more than one instance of Prior Object ID Gap
  * An Object has a Prior Object ID Gap larger than the Object ID


### PR DESCRIPTION
Similar to Prior Group ID Gap.  I rewrote the text on the malformed conditions, and also changed the code points to be in the 1 byte range.

Fixes: #889