### PR TITLE
Explain when a relay can reuse or must reset a subgroup

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3134,7 +3134,7 @@ with a reliable_size equal to the length of the stream header. This explicitly
 tells the receiver there is an unsent Subgroup.
 
 A relay MUST NOT forward an Object on an existing Subgroup stream unless it is
-the next Object in that Subgroup.  A relay knows that that an Object is the next
+the next Object in that Subgroup.  A relay knows that an Object is the next
 Object in the Subgroup if
  * the Object ID is one greater than the previous Object sent on this Subgroup
    stream.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3133,6 +3133,19 @@ a SUBGROUP_HEADER on a new stream, with no objects, and then send RESET_STREAM_A
 with a reliable_size equal to the length of the stream header. This explicitly
 tells the receiver there is an unsent Subgroup.
 
+A relay MUST NOT forward an Object on an existing Subgroup stream unless it is
+the next Object in that Subgroup.  A relay can know that that an Object is next
+Object in the Subgroup if
+ * the Object ID is one greater than the previous Object sent on this Subgroup
+   stream.
+ * the Object was received on the same upstream Subgroup stream as the
+   previously sent Object, with no other Objects in between.
+ * it knows all Object IDs between the current and previous Object IDs
+   on the Subgroup stream belong to different Subgroups or do not exist.
+
+If the relay does not know if an Object is the next Object, it MUST reset the
+Subgroup stream and open a new one to forward it.
+
 Since SUBSCRIBEs always end on a group boundary, an ending subscription can
 always cleanly close all its subgroups. A sender that terminates a stream
 early for any other reason (e.g., to handoff to a different sender) MUST

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3139,7 +3139,8 @@ Object in the Subgroup if at least one of the following is true:
  * the Object ID is one greater than the previous Object sent on this Subgroup
    stream.
  * the Object was received on the same upstream Subgroup stream as the
-   previously sent Object, with no other Objects in between.
+   previously sent Object on the downstream Subgroup stream, with no other
+   Objects in between.
  * it knows all Object IDs between the current and previous Object IDs
    on the Subgroup stream belong to different Subgroups or do not exist.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3135,7 +3135,7 @@ tells the receiver there is an unsent Subgroup.
 
 A relay MUST NOT forward an Object on an existing Subgroup stream unless it is
 the next Object in that Subgroup.  A relay knows that an Object is the next
-Object in the Subgroup if
+Object in the Subgroup if at least one of the following is true:
  * the Object ID is one greater than the previous Object sent on this Subgroup
    stream.
  * the Object was received on the same upstream Subgroup stream as the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3134,7 +3134,7 @@ with a reliable_size equal to the length of the stream header. This explicitly
 tells the receiver there is an unsent Subgroup.
 
 A relay MUST NOT forward an Object on an existing Subgroup stream unless it is
-the next Object in that Subgroup.  A relay can know that that an Object is next
+the next Object in that Subgroup.  A relay knows that that an Object is the next
 Object in the Subgroup if
  * the Object ID is one greater than the previous Object sent on this Subgroup
    stream.


### PR DESCRIPTION
Fixes: #610 
Fixes: #943