### PR TITLE
Minor editorial issue of "can support causes" -> "can cause"

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -109,7 +109,7 @@ Latency is necessary to correct for variable network throughput. Ideally live
 content is consumed at the same bitrate it is produced. End-to-end latency would
 be fixed and only subject to encoding and transmission delays. Unfortunately,
 networks have variable throughput, primarily due to congestion. Attempting to
-deliver content encoded at a higher bitrate than the network can support causes
+deliver content encoded at a higher bitrate than the network can cause
 queuing along the path from producer to consumer. The speed at which a protocol
 can detect and respond to congestion determines the overall latency. TCP-based
 protocols are simple but are slow to detect congestion and suffer from


### PR DESCRIPTION
In the following sentence in Section 1.1.1 of draft-ietf-moq-transport-10:

Attempting to deliver content encoded at a higher bitrate than the network can support causes queuing along the path from producer to consumer.

"can support causes" should be replaced with "can cause".

Fixes: #950