### PR TITLE
Unify parameter parsing by always using byte length

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -337,6 +337,7 @@ length of the pairs in bytes.
 Key-Value-Pairs {
   Length (i),
   Pair (Key-Value)...,
+}
 ~~~
 {: #moq-key-value-pairs format title="MOQT Key-Value-Pairs"}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1506,14 +1506,14 @@ CLIENT_SETUP Message {
   Length (i),
   Number of Supported Versions (i),
   Supported Versions (i) ...,
-  Setup Parameters (..),
+  Setup Parameters (KeyValuePairs),
 }
 
 SERVER_SETUP Message {
   Type (i) = 0x21,
   Length (i),
   Selected Version (i),
-  Setup Parameters (..),
+  Setup Parameters (KeyValuePairs),
 }
 ~~~
 {: #moq-transport-setup-format title="MOQT Setup Messages"}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1327,7 +1327,7 @@ Receivers ignore unrecognized parameters.
 The number of parameters in a message is not specifically limited, but the
 total length of a control message is limited to 2^16-1.
 
-Parameters are serialized as Key-Value-Pairs {{moq-key-value-pair}}.
+Parameters are serialized as Key-Value-Pairs {{moq-key-value-pairs}}.
 
 Setup message parameters use a namespace that is constant across all MoQ
 Transport versions. All other messages use a version-specific namespace.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1752,7 +1752,7 @@ SUBSCRIBE Message {
   Filter Type (i),
   [Start Location (Location)],
   [End Group (i)],
-  Subscribe Parameters (KeyValuePairs)
+  Parameters (KeyValuePairs)
 }
 ~~~
 {: #moq-transport-subscribe-format title="MOQT SUBSCRIBE Message"}


### PR DESCRIPTION
Instead of the number of parameters, as are used in some control messages.

I thought the parsers were already the same, but it turns out some spots use number of parameters and Objects use total length.  I don't think that difference was intentional, but let me know if it was.

This was intended as an editorial change, but it isn't as currently written.