### PR TITLE
Reference concept of "time" in 2.3.1

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -450,7 +450,8 @@ their group membership.  Groups can contain any number of objects.
 ### Group Ordering
 
 Within a track, the original publisher SHOULD publish Group IDs which increase
-with time. In some cases, Groups will be produced in increasing order, but sent
+with time (where "time" is defined according to the internal clock of the media
+being sent). In some cases, Groups will be produced in increasing order, but sent
 to subscribers in a different order, for example when the subscription's Group
 Order is Descending.  Due to network reordering and the partial reliability
 features of MoQT, Groups can always be received out of order.
@@ -465,6 +466,8 @@ SHOULD NOT use range filters which span multiple Groups in FETCH or SUBSCRIBE.
 SUBSCRIBE and FETCH delivery use Group Order, so a FETCH cannot deliver Groups
 out of order and a subscription could have unexpected delivery order if Group IDs
 do not increase with time.
+
+Note that the increase in time between two groups is not defined by the protocol.
 
 ## Track {#model-track}
 


### PR DESCRIPTION
The concept of "time" elsewhere in the document refers to protocol event time. In this particular section, it refers to media time. This should be called out.