### PR TITLE
Add a PUBLISH message for publisher initiated subscriptions

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -803,8 +803,8 @@ State is 0, the publisher does not send objects for the subscription.  If the
 Forward State is 1, the publisher sends objects.  The initiator of the
 subscription sets the initial Forward State in either PUBLISH or SUBSCRIBE.  The
 sender of PUBLISH_OK can update the Forward State based on its preference.  Once
-established, the subscriber can change the Forward State by sending
-SUBSCRIBE_UPDATE.
+the subscription is established, the subscriber can update the Forward State by
+sending SUBSCRIBE_UPDATE.
 
 Either endpoint can initiate a subscription to a track without exchanging any
 prior messages other than SETUP.  Relays MUST NOT send any PUBLISH messages
@@ -883,8 +883,8 @@ publishers to contact, if any.
 
 An UNSUBSCRIBE_ANNOUNCES withdraws a previous SUBSCRIBE_ANNOUNCES. It does not
 prohibit original publishers from sending further ANNOUNCE or PUBLISH messages,
-but relays MUST not send a PUBLISH message to a client without knowing the
-client is interested in and authorized to receive the content.
+but relays MUST not send any further PUBLISH messages to a client without
+knowing the client is interested in and authorized to receive the content.
 
 ## Announcements
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -529,7 +529,7 @@ The subscriber either accepts or rejects the subscription using PUBLISH_OK or
 PUBLISH_ERROR.  A subscriber initiates a subscription to a track by sending the
 SUBSCRIBE message.  The publisher either accepts or rejects the subscription
 using SUBSCRIBE_OK or SUBSCRIBE_ERROR.  Once either of these sequences is
-complete, the subscription can be updated by the subscriber using
+successful, the subscription can be updated by the subscriber using
 SUBSCRIBE_UPDATE, terminated by the subscriber using UNSUBSCRIBE, or terminated
 by the publisher using SUBSCRIBE_DONE.
 
@@ -883,8 +883,8 @@ forward the result to the application, so the application can decide which other
 publishers to contact, if any.
 
 An UNSUBSCRIBE_ANNOUNCES withdraws a previous SUBSCRIBE_ANNOUNCES. It does not
-prohibit the publishers from sending further ANNOUNCE or PUBLISH messages, but
-it does prevent relays from sending them.
+prohibit original publishers from sending further ANNOUNCE or PUBLISH messages,
+but it does prevent relays from sending them.
 
 ## Announcements
 
@@ -1169,8 +1169,8 @@ subscription in Forward State=0, it SHOULD send a SUBSCRIBE_UDPATE with
 Forward=1 to all publishers.
 
 When a relay receives an incoming PUBLISH message, it SHOULD send a PUBLISH
-request to each subscriber that has subscribed to the track's namespace or
-prefix thereof.
+request to each subscriber that has subscribed (via SUBSCRIBE_ANNOUNCES)
+to the track's namespace or prefix thereof.
 
 When a relay receives an incoming ANNOUNCE for a given namespace, for
 each active upstream subscription that matches that namespace, it SHOULD send a
@@ -2227,7 +2227,8 @@ PUBLISH_OK Message
 
 * Subscriber Priority: The Subscriber Priority for this subscription.
 
-* Group Order: The Group Order preference for this subscription.
+* Group Order: The Group Order preference for this subscription.  This
+overwrites the GroupOrder specified PUBLISH.
 
 * Filter Type, Start, End Group: See {{message-subscribe-req}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3242,11 +3242,6 @@ Extension headers are present. If an endpoint receives a datagram with Type
 0x03 and Extension Headers Length is 0, it MUST close the session with Protocol
 Violation.
 
-* Track Alias: The Track Alias ({{track-alias}} indicating the track this
-  Datagram belongs to.  If an endpoint receives a datagram with an unknown Track
-  Alias, it MAY drop the datagram or choose to buffer it for a brief period to
-  handle reordering with the control message that establishes the Track Alias.
-
 ## Streams
 
 When objects are sent on streams, the stream begins with a Subgroup Header

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1145,7 +1145,7 @@ new tracks.
 
 2. Send an ANNOUNCE message for a Track Namespace to the relay. This enables the
 relay to send SUBSCRIBE messages for Tracks in this Namespace in response to
-Consumer SUBSCRIBE messages.
+received SUBSCRIBE messages.
 
 Relays MUST verify that publishers are authorized to publish the set of tracks
 whose Track Namespace matches the namespace in

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -891,7 +891,7 @@ publishers to contact, if any.
 
 An UNSUBSCRIBE_ANNOUNCES withdraws a previous SUBSCRIBE_ANNOUNCES. It does not
 prohibit original publishers from sending further ANNOUNCE or PUBLISH messages,
-but relays MUST not send any further PUBLISH messages to a client without
+but relays MUST NOT send any further PUBLISH messages to a client without
 knowing the client is interested in and authorized to receive the content.
 
 ## Announcements
@@ -1147,10 +1147,10 @@ new tracks.
 relay to send SUBSCRIBE messages for Tracks in this Namespace in response to
 Consumer SUBSCRIBE messages.
 
-Relays MUST verify that publishers are authorized to publish the content
-associated with the set of tracks whose Track Namespace matches the namespace in
-an ANNOUNCE, or the Full Track Name in PUBLISH. Where the authorization and
-identification of the publisher occurs depends on the way the relay is managed
+Relays MUST verify that publishers are authorized to publish the set of tracks
+whose Track Namespace matches the namespace in
+an ANNOUNCE, or the Full Track Name in PUBLISH. The authorization and
+identification of the publisher depends on the way the relay is managed
 and is application specific.
 
 A Relay can receive announcements for the same Track Namespace or PUBLISH
@@ -2248,7 +2248,7 @@ overwrites the GroupOrder specified PUBLISH.
 
 ## PUBLISH_ERROR {#message-publish-error}
 
-The subscriber sends an PUBLISH_ERROR control message for to reject
+The subscriber sends an PUBLISH_ERROR control message to reject
 a subscription initiated by PUBLISH.
 
 ~~~

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1129,11 +1129,15 @@ to the old relay can be stopped with an UNSUBSCRIBE.
 
 ## Publisher Interactions
 
-There are two ways to publish through a relay - sending a PUBLISH messages for a
-specific Track or sending an ANNOUNCE message for a Track Namespace and waiting
-for SUBSCRIBE.  Relays MAY respond to PUBLISH with PUBLISH_OK in Forward State=0
-until there are known subscribers for new tracks. ANNOUNCE enables the relay to
-know which publisher to forward a SUBSCRIBE to.
+There are two ways to publish through a relay:
+
+1. Send a PUBLISH message for a specific Track to the relay. The relay MAY
+respond with PUBLISH_OK in Forward State=0 until there are known subscribers for
+new tracks.
+
+2. Send an ANNOUNCE message for a Track Namespace to the relay. This enables the
+relay to send SUBSCRIBE messages for Tracks in this Namespace in response to
+Consumer SUBSCRIBE messages.
 
 Relays MUST verify that publishers are authorized to publish the content
 associated with the set of tracks whose Track Namespace matches the namespace in
@@ -2246,8 +2250,7 @@ PUBLISH_ERROR Message
   Length (i),
   Request ID (i),
   Error Code (i),
-  Reason Phrase Length (i),
-  Reason Phrase (..),
+  Error Reason (Reason Phrase),
 }
 ~~~
 {: #moq-transport-publish-error format title="MOQT PUBLISH_ERROR Message"}
@@ -2257,7 +2260,7 @@ PUBLISH_ERROR Message
 
 * Error Code: Identifies an integer error code for failure.
 
-* Reason Phrase: Provides the reason for error.
+* Error Reason: Provides the reason for subscription error. See {{reason-phrase}}.
 
 The application SHOULD use a relevant error code in PUBLISH_ERROR, as defined
 below:

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1160,8 +1160,9 @@ determine which publishers receive a SUBSCRIBE or which subscribers receive a
 PUBLISH. For example, a SUBSCRIBE namespace=(foo,bar), track=x message will be
 forwarded to the sessions that sent ANNOUNCE namespace=(foo) and ANNOUNCE
 namespace=(foo, bar) respectively, but not one that sent ANNOUNCE
-namespace=(foobar).  Relays MUST forward to all publishers or subscribers that
-have a namespace prefix match.  TODO: do we need to say more about this.
+namespace=(foobar).  Relays MUST forward SUBSCRIBE messages to all publishers
+and ANNOUNCE and PUBLISH messages to all subscribers that have a namespace
+prefix match.
 
 When a relay receives an incoming SUBSCRIBE that triggers an upstream
 subscription, it SHOULD send a SUBSCRIBE request to each publisher that has

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1163,8 +1163,8 @@ in a namespace it previously responded ANNOUNCE_OK to by sending an
 ANNOUNCE_CANCEL.
 
 A relay manages sessions from multiple publishers and subscribers, connecting
-them based on the track namespace or track name.  Prefix matching is used to
-determine which publishers receive a SUBSCRIBE or which subscribers receive a
+them based on the Track Namespace or Full Track Name.  Prefix matching is used
+to determine which publishers receive a SUBSCRIBE or which subscribers receive a
 PUBLISH. For example, a SUBSCRIBE namespace=(foo,bar), track=x message will be
 forwarded to the sessions that sent ANNOUNCE namespace=(foo) and ANNOUNCE
 namespace=(foo, bar) respectively, but not one that sent ANNOUNCE

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -541,10 +541,12 @@ sender of PUBLISH_OK can update the Forward State based on its preference.  Once
 established, the subscriber can change the Forward State by sending
 SUBSCRIBE_UPDATE.
 
-Either endpoint can initiate a subscription to a track without exhanging any
-prior messages other than SETUP.  Relays however do not send any PUBLISH
-messages without first receiving a SUBSCRIBE_ANNOUNCES to a relevant track
-namespace or namespace prefix.
+Either endpoint can initiate a subscription to a track without exchanging any
+prior messages other than SETUP.  Relays MUST NOT send any PUBLISH messages
+without knowing the client is interested in and authorized to receive the
+content. The communication of intent and authorization can be accomplished by
+the client sending SUBSCRIBE_ANNOUNCES, or conveyed in other mechanisms out of
+band.
 
 # Sessions {#session}
 
@@ -884,7 +886,8 @@ publishers to contact, if any.
 
 An UNSUBSCRIBE_ANNOUNCES withdraws a previous SUBSCRIBE_ANNOUNCES. It does not
 prohibit original publishers from sending further ANNOUNCE or PUBLISH messages,
-but it does prevent relays from sending them.
+but relays MUST not send a PUBLISH message to a client without knowing the
+client is interested in and authorized to receive the content.
 
 ## Announcements
 
@@ -1160,7 +1163,7 @@ namespace=(foo, bar) respectively, but not one that sent ANNOUNCE
 namespace=(foobar).  Relays MUST forward to all publishers or subscribers that
 have a namespace prefix match.  TODO: do we need to say more about this.
 
-When a relay receives an incoming SUBSCRIBE request that triggers an upstream
+When a relay receives an incoming SUBSCRIBE that triggers an upstream
 subscription, it SHOULD send a SUBSCRIBE request to each publisher that has
 announced the subscription's namespace or prefix thereof, unless it already has
 an active subscription for the Objects requested by the incoming SUBSCRIBE

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1144,8 +1144,8 @@ respond with PUBLISH_OK in Forward State=0 until there are known subscribers for
 new tracks.
 
 2. Send an ANNOUNCE message for a Track Namespace to the relay. This enables the
-relay to send SUBSCRIBE messages for Tracks in this Namespace in response to
-received SUBSCRIBE messages.
+relay to send SUBSCRIBE messages to publishers for Tracks in this Namespace in
+response to received SUBSCRIBE messages.
 
 Relays MUST verify that publishers are authorized to publish the set of tracks
 whose Track Namespace matches the namespace in
@@ -1180,7 +1180,7 @@ request from all available publishers.  If it already has a matching upstream
 subscription in Forward State=0, it SHOULD send a SUBSCRIBE_UDPATE with
 Forward=1 to all publishers.
 
-When a relay receives an incoming PUBLISH message, it SHOULD send a PUBLISH
+When a relay receives an incoming PUBLISH message, it MUST send a PUBLISH
 request to each subscriber that has subscribed (via SUBSCRIBE_ANNOUNCES)
 to the track's namespace or prefix thereof.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2193,10 +2193,14 @@ PUBLISH Message {
   uses the same Track Alias as a different track with an active subscription, it
   MUST close the session with error 'Duplicate Track Alias'.
 
+* Group Order: Indicates the subscription will be delivered in
+  Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
+  Values of 0x0 and those larger than 0x2 are a protocol error.
+
 * ContentExists: 1 if an object has been published on this track, 0 if not.
-If 0, then the Largest Group ID and Largest Object ID fields will not be
-present. Any other value is a protocol error and MUST terminate the
-session with a Protocol Violation ({{session-termination}}).
+  If 0, then the Largest Group ID and Largest Object ID fields will not be
+  present. Any other value is a protocol error and MUST terminate the
+  session with a Protocol Violation ({{session-termination}}).
 
 * Largest: The location of the largest object available for this track.
 
@@ -2239,8 +2243,10 @@ PUBLISH_OK Message
 
 * Subscriber Priority: The Subscriber Priority for this subscription.
 
-* Group Order: The Group Order preference for this subscription.  This
-overwrites the GroupOrder specified PUBLISH.
+* Group Order: Indicates the subscription will be delivered in
+  Ascending (0x1) or Descending (0x2) order by group. See {{priorities}}.
+  Values of 0x0 and those larger than 0x2 are a protocol error. This
+  overwrites the GroupOrder specified PUBLISH.
 
 * Filter Type, Start, End Group: See {{message-subscribe-req}}.
 
@@ -2889,15 +2895,15 @@ Violation.
 The publisher will respond with SUBSCRIBE_ANNOUNCES_OK or
 SUBSCRIBE_ANNOUNCES_ERROR.  If the SUBSCRIBE_ANNOUNCES is successful, the
 publisher will immediately forward existing ANNOUNCE and PUBLISH messages that
-have the Track Namespace Prefix.  If the set of matching ANNOUNCE messages
-changes, the publisher sends the corresponding ANNOUNCE or UNANNOUNCE
-message.
+match the Track Namespace Prefix that have not already been sent to this
+subscriber.  If the set of matching ANNOUNCE messages changes, the publisher
+sends the corresponding ANNOUNCE or UNANNOUNCE message.
 
 A subscriber cannot make overlapping namespace subscriptions on a single
 session.  Within a session, if a publisher receives a SUBSCRIBE_ANNOUNCES with a
-Track Namespace Prefix that is a prefix of an earlier SUBSCRIBE_ANNOUNCES or
-vice versa, it MUST respond with SUBSCRIBE_ANNOUNCES_ERROR, with error code
-Namespace Prefix Overlap.
+Track Namespace Prefix that is a prefix of, suffix of, or equal to an active
+SUBSCRIBE_ANNOUNCES, it MUST respond with SUBSCRIBE_ANNOUNCES_ERROR, with error
+code Namespace Prefix Overlap.
 
 The publisher MUST ensure the subscriber is authorized to perform this
 namespace subscription.


### PR DESCRIPTION
Also changes relay matching from exact namespace match to namespace tuple prefix match.

Note: this includes PR #977 - please review that first

Fixes: #615
Fixes: #765
Fixes: #778