### PR TITLE
Allow AUTHORIZATION TOKEN parameter in CLIENT_SETUP and other Auth fixes

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1446,9 +1446,9 @@ Token {
 
 
 * Token Alias - a Session-specific integer identifier that references a Token
-  Value. There are separate Alias spaces for the client and server (eg: they can
-  each register Alias=1). Once a Token Alias has been registered, it cannot be
-  re-registered by the same sender in the Session without first being
+  Value. There are separate Alias spaces for the client and server (e.g.: they
+  can each register Alias=1). Once a Token Alias has been registered, it cannot
+  be re-registered by the same sender in the Session without first being
   deleted. Use of the Token Alias is optional.
 
 * Token Type - a numeric identifier for the type of Token payload being
@@ -1477,7 +1477,8 @@ in the token cache, even if the message fails for other reasons, including
 previously registered tokens without potentially terminating the entire Session.
 A receiver MAY store an error code (eg: Unauthorized or Malformed Auth Token) in
 place of the Token Type and Token Alias if any future message referencing the
-Token Alias will result in that error.
+Token Alias will result in that error. The size of a registered cache entry
+includes the length of the Token Value, regardless of whether it is stored.
 
 If a receiver detects that an authorization token has expired, it MUST retain
 the registered Alias until it is deleted by the sender, though it MAY discard
@@ -1654,7 +1655,7 @@ See {{authorization-token}}.  The endpoint can specify one or more tokens in
 CLIENT_SETUP or SERVER_SETUP that the peer can use to authorize MOQT session
 establishment.
 
-If a server receives an AUTHORIZATION TOKEN parmeter in CLIENT_SETUP with Alias
+If a server receives an AUTHORIZATION TOKEN parameter in CLIENT_SETUP with Alias
 Type REGISTER_TOKEN that exceeds its MAX_AUTH_TOKEN_CACHE_SIZE, it MUST NOT fail
 the session with `Auth Token Cache Overflow`.  Instead, it MUST treat the
 parameter as Alias Type USE_VALUE.  A client MUST handle registration failures

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1651,8 +1651,8 @@ initiation.
 #### AUTHORIZATION TOKEN {#setup-auth-token}
 
 See {{authorization-token}}.  The endpoint can specify one or more tokens in
-CLIENT_SETUP or SERVER_SETUP that the peer can use to authorize 
-MOQT session establishment.
+CLIENT_SETUP or SERVER_SETUP that the peer can use to authorize MOQT session
+establishment.
 
 If a server receives an AUTHORIZATION TOKEN parmeter in CLIENT_SETUP with Alias
 Type REGISTER_TOKEN that exceeds its MAX_AUTH_TOKEN_CACHE_SIZE, it MUST NOT fail

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1442,7 +1442,7 @@ the session and SHOULD retire previously registered tokens once their utility
 has passed.
 
 By registering a Token, the sender is requiring the receiver to store the Token
-Alias and Token Value until they are delete, or the session ends. The receiver
+Alias and Token Value until they are deleted, or the session ends. The receiver
 can protect its resources by sending a SETUP parameter defining the
 MAX_AUTH_TOKEN_CACHE_SIZE {{max-auth-token-cache-size}} limit it is willing to
 accept. If a registration is attempted which would cause this limit to be

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -727,8 +727,8 @@ code, as defined below:
 * Malformed Auth Token - Invalid Auth Token serialization during registration
   (see {{authorization-token}}).
 
-* Unknown Auth Token Alias - Authorization Token refers to an Alias that is
-  not registered (see {{authorization-token}}).
+* Unknown Auth Token Alias - No registered token found for the provided Alias
+  (see {{authorization-token}}).
 
 * Expired Auth Token - Authorization token has expired {{authorization-token}}).
 
@@ -1346,9 +1346,9 @@ these parameters to appear in Setup messages.
 
 #### AUTHORIZATION TOKEN {#authorization-token}
 
-The AUTHORIZATION TOKEN parameter (Parameter Type 0x03) MAY appeat in a
-CLIENT_SETUP, SUBSCRIBE, SUBSCRIBE_ANNOUNCES, ANNOUNCE TRACK_STATUS_REQUEST or
-FETCH message. This parameter converys information to authorize the sender to
+The AUTHORIZATION TOKEN parameter (Parameter Type 0x03) MAY appear in a
+CLIENT_SETUP, SUBSCRIBE, SUBSCRIBE_ANNOUNCES, ANNOUNCE, TRACK_STATUS_REQUEST or
+FETCH message. This parameter conveys information to authorize the sender to
 perform the operation carrying the parameter.
 
 The AUTHORIZATION TOKEN parameter MAY be repeated within a message.


### PR DESCRIPTION
* Updating the description of the Unauthorized Session Error Code
* Adding other Session Error Codes that can be used by Auth
* Make Unknown Token Alias a session error and remove from message error tables
* Clarify various error conditions
* Replaced "client" with "sender"
* Consistent capitalization of Alias and session
* TOKEN -> Token structure

Fixes: #721
Fixes: #839
Fixes: #964 
Fixes: #967
Fixes: #970 
Fixes: #984
Fixes: #997