### PR TITLE
Make TRACK_STATUS mirror SUBSCRIBE

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2509,12 +2509,12 @@ The TRACK_STATUS message format is identical to the SUBSCRIBE message
 ({{message-subscribe-req}}).
 
 The receiver of a TRACK_STATUS message treats it identically as if it had
-received a SUBSCRIBE message, except it does not create subscription state or
-send any Objects.  Relays without an active subscription MAY forward
-TRACK_STATUS to one or more publishers, or MAY initiate a subscription as
-described in {{publisher-interactions}} to determine the response. The publisher
-does not send SUBSCRIBE_DONE for this request, and the subscriber cannot send
-SUBSCRIBE_UPDATE or UNSUBSCRIBE.
+received a SUBSCRIBE message, except it does not create downstream subscription
+state or send any Objects.  Relays without an active subscription MAY forward
+TRACK_STATUS to one or more publishers, or MAY initiate a subscription (subject
+to authorization) as described in {{publisher-interactions}} to determine the
+response. The publisher does not send SUBSCRIBE_DONE for this request, and the
+subscriber cannot send SUBSCRIBE_UPDATE or UNSUBSCRIBE.
 
 ## TRACK_STATUS_OK {#message-track-status-ok}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1256,9 +1256,11 @@ The following Message Types are defined:
 |-------|-----------------------------------------------------|
 | 0x17  | FETCH_CANCEL ({{message-fetch-cancel}})             |
 |-------|-----------------------------------------------------|
-| 0xD   | TRACK_STATUS_REQUEST ({{message-track-status-req}}) |
+| 0xD   | TRACK_STATUS ({{message-track-status}})             |
 |-------|-----------------------------------------------------|
-| 0xE   | TRACK_STATUS ({{message-track-status}})             |
+| 0xE   | TRACK_STATUS_OK ({{message-track-status-ok}}        |
+|-------|-----------------------------------------------------|
+| 0xF   | TRACK_STATUS_ERROR ({{message-track-status-error}}) |
 |-------|-----------------------------------------------------|
 | 0x6   | ANNOUNCE  ({{message-announce}})                    |
 |-------|-----------------------------------------------------|
@@ -1335,8 +1337,8 @@ these parameters to appear in Setup messages.
 
 The AUTHORIZATION TOKEN parameter (Parameter Type 0x01) identifies a track's
 authorization information in a SUBSCRIBE, SUBSCRIBE_ANNOUNCES, ANNOUNCE
-TRACK_STATUS_REQUEST or FETCH message. This parameter is populated for
-cases where the authorization is required at the track or namespace level.
+TRACK_STATUS or FETCH message. This parameter is populated for cases where the
+authorization is required at the track or namespace level.
 
 The AUTHORIZATION TOKEN parameter MAY be repeated within a message.
 
@@ -1475,6 +1477,18 @@ earlier in a multi-object stream will expire earlier than Objects later in the
 stream. Once Objects have expired from cache, their state becomes unknown, and
 a relay that handles a downstream request that includes those Objects
 re-requests them.
+
+#### TRACK STATUS RESPONDER
+
+The TRACK_STATUS_RESPONDER parameter (Parameter Type 0x6) indicates the entity
+that sent a TRACK_STATUS_OK or TRACK_STATUS_ERROR.  The allowed values are:
+
+0x0: Original Publisher
+0x1: Relay with Active Subscription
+0x2: Relay without Active Subscription
+
+If a subscriber receives any other value for this header it MUST close the
+session with error `Protocol Violation`.
 
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}
 
@@ -1625,9 +1639,9 @@ MAX_REQUEST_ID Message {
 
 * Request ID: The new Maximum Request ID for the session. If a Request ID equal
   or larger than this is received by the endpoint that sent the MAX_REQUEST_ID
-  in any request message (ANNOUNCE, FETCH, SUBSCRIBE, SUBSCRIBE_ANNOUNCES
-  or TRACK_STATUS_REQUEST), the endpoint MUST close the session with an error
-  of 'Too Many Requests'.
+  in any request message (ANNOUNCE, FETCH, SUBSCRIBE, SUBSCRIBE_ANNOUNCES or
+  TRACK_STATUS), the endpoint MUST close the session with an error of 'Too Many
+  Requests'.
 
 MAX_REQUEST_ID is similar to MAX_STREAMS in ({{?RFC9000, Section 4.6}}), and
 similar considerations apply when deciding how often to send MAX_REQUEST_ID.
@@ -2433,87 +2447,43 @@ FETCH_CANCEL Message {
 * Request ID: The Request ID of the FETCH ({{message-fetch}}) this message is
   cancelling.
 
-## TRACK_STATUS_REQUEST {#message-track-status-req}
-
-A potential subscriber sends a 'TRACK_STATUS_REQUEST' message on the control
-stream to obtain information about the current status of a given track.
-
-A TRACK_STATUS message MUST be sent in response to each TRACK_STATUS_REQUEST.
-
-~~~
-TRACK_STATUS_REQUEST Message {
-  Type (i) = 0xD,
-  Length (16),
-  Request ID (i),
-  Track Namespace (tuple),
-  Track Name Length (i),
-  Track Name (..),
-  Number of Parameters (i),
-  Parameters (..) ...,
-}
-~~~
-{: #moq-track-status-request-format title="MOQT TRACK_STATUS_REQUEST Message"}
-
-* Request ID: See {{request-id}}.
-
-* Track Namespace: Identifies the namespace of the track as defined in
-  ({{track-name}}).
-
-* Track Name: Identifies the track name as defined in ({{track-name}}).
-
-* Parameters: The parameters are defined in {{version-specific-params}}.
-
 ## TRACK_STATUS {#message-track-status}
 
-A publisher sends a 'TRACK_STATUS' message on the control stream in response
-to a TRACK_STATUS_REQUEST message.
+A potential subscriber sends a 'TRACK_STATUS' message on the control
+stream to obtain information about the current status of a given track.
 
-~~~
-TRACK_STATUS Message {
-  Type (i) = 0xE,
-  Length (16),
-  Request ID (i),
-  Status Code (i),
-  Largest Location (Location),
-  Number of Parameters (i),
-  Parameters (..) ...,
-}
-~~~
-{: #moq-track-status-format title="MOQT TRACK_STATUS Message"}
+The TRACK_STATUS message format is identical to the SUBSCRIBE message
+({{message-subscribe-req}}).
 
-* Request ID: The Request ID of the TRACK_STATUS_REQUEST this message is
-  replying to {{message-track-status}}.
+The receiver of a TRACK_STATUS message treats it identically as if it had
+received a SUBSCRIBE message, except it does not create subscription state or
+send any Objects.  The publisher does not send SUBSCRIBE_DONE for this request,
+and the subscriber cannot send SUBSCRIBE_UPDATE or UNSUBSCRIBE.
 
-* Status Code: Provides additional information about the status of the
-track. It MUST hold one of the following values. Any other value is a malformed
-message.
+## TRACK_STATUS_OK {#message-track-status-ok}
 
-0x00: The track is in progress, and subsequent fields contain the highest group
-and object ID for that track.
+The publisher sends a TRACK_STATUS_OK control message in response
+to a successful TRACK_STATUS message.
 
-0x01: The track does not exist. Subsequent fields MUST be zero, and any other
-value is a malformed message.
+The TRACK_STATUS_OK message format is identical to the SUBSCRIBE_OK message
+({{message-subscribe-ok}}).
 
-0x02: The track has not yet begun. Subsequent fields MUST be zero. Any other
-value is a malformed message.
+The publisher populates the fields of TRACK_STATUS_OK exactly as it would have
+populated a SUBSCRIBE_OK, and adds the TRACK_STATUS_RESPONDER parameter.  It is
+not considered an error if the specified Track Alias is already in use by an
+active subscription.
 
-0x03: The track has finished, so there is no "live edge." Subsequent fields
-contain the highest Group and object ID known.
 
-0x04: The publisher is a relay that cannot obtain the current track status from
-upstream. Subsequent fields contain the largest group and object ID known.
+## TRACK_STATUS_ERROR {#message-track-status-error}
 
-Any other value in the Status Code field is a malformed message.
+The publisher sends a TRACK_STATUS_ERROR control message in response
+to a failed TRACK_STATUS message.
 
-TODO: Auth Failures
+The TRACK_STATUS_ERROR message format is identical to the SUBSCRIBE_ERROR
+message ({{message-subscribe-error}}).
 
-* Largest Location: represents the largest Object location observed by the
-Publisher for an active subscription. If the publisher is a relay without an
-active subscription, it SHOULD send a TRACK_STATUS_REQUEST upstream or MAY
-subscribe to the track, to obtain the same information. If neither is possible,
-it should return the best available information with status code 0x04.
-
-The `Parameters` are defined in {{version-specific-params}}.
+The publisher populates the fields of TRACK_STATUS_ERROR exactly as it would
+have populated a SUBSCRIBE_ERROR, and adds the TRACK_STATUS_RESPONDER parameter.
 
 ## ANNOUNCE {#message-announce}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1533,18 +1533,6 @@ stream. Once Objects have expired from cache, their state becomes unknown, and
 a relay that handles a downstream request that includes those Objects
 re-requests them.
 
-#### TRACK STATUS RESPONDER
-
-The TRACK_STATUS_RESPONDER parameter (Parameter Type 0x6) indicates the entity
-that sent a TRACK_STATUS_OK or TRACK_STATUS_ERROR.  The allowed values are:
-
-0x0: Original Publisher
-0x1: Relay with Active Subscription
-0x2: Relay without Active Subscription
-
-If a subscriber receives any other value for this header it MUST close the
-session with error `Protocol Violation`.
-
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}
 
 The `CLIENT_SETUP` and `SERVER_SETUP` messages are the first messages exchanged
@@ -2522,8 +2510,11 @@ The TRACK_STATUS message format is identical to the SUBSCRIBE message
 
 The receiver of a TRACK_STATUS message treats it identically as if it had
 received a SUBSCRIBE message, except it does not create subscription state or
-send any Objects.  The publisher does not send SUBSCRIBE_DONE for this request,
-and the subscriber cannot send SUBSCRIBE_UPDATE or UNSUBSCRIBE.
+send any Objects.  Relays without an active subscription MAY forward
+TRACK_STATUS to one or more publishers, or MAY initiate a subscription as
+described in {{publisher-interactions}} to determine the response. The publisher
+does not send SUBSCRIBE_DONE for this request, and the subscriber cannot send
+SUBSCRIBE_UPDATE or UNSUBSCRIBE.
 
 ## TRACK_STATUS_OK {#message-track-status-ok}
 
@@ -2534,9 +2525,8 @@ The TRACK_STATUS_OK message format is identical to the SUBSCRIBE_OK message
 ({{message-subscribe-ok}}).
 
 The publisher populates the fields of TRACK_STATUS_OK exactly as it would have
-populated a SUBSCRIBE_OK, and adds the TRACK_STATUS_RESPONDER parameter.  It is
-not considered an error if the specified Track Alias is already in use by an
-active subscription.
+populated a SUBSCRIBE_OK, setting Track Alias to 0. It is not considered an error
+if Track Alias 0 is already in use by an active subscription.
 
 
 ## TRACK_STATUS_ERROR {#message-track-status-error}
@@ -2548,7 +2538,7 @@ The TRACK_STATUS_ERROR message format is identical to the SUBSCRIBE_ERROR
 message ({{message-subscribe-error}}).
 
 The publisher populates the fields of TRACK_STATUS_ERROR exactly as it would
-have populated a SUBSCRIBE_ERROR, and adds the TRACK_STATUS_RESPONDER parameter.
+have populated a SUBSCRIBE_ERROR.
 
 ## ANNOUNCE {#message-announce}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1681,11 +1681,11 @@ MAX_REQUEST_ID Message {
 ~~~
 {: #moq-transport-max-request-id format title="MOQT MAX_REQUEST_ID Message"}
 
-* Request ID: The new Maximum Request ID for the session. If a Request ID equal
-  or larger than this is received by the endpoint that sent the MAX_REQUEST_ID
-  in any request message (ANNOUNCE, FETCH, SUBSCRIBE, SUBSCRIBE_ANNOUNCES or
-  TRACK_STATUS), the endpoint MUST close the session with an error of 'Too Many
-  Requests'.
+* Request ID: The new Maximum Request ID for the session plus one. If
+  a Request ID equal or larger than this is received by the endpoint
+  that sent the MAX_REQUEST_ID in any request message (ANNOUNCE,
+  FETCH, SUBSCRIBE, SUBSCRIBE_ANNOUNCES or TRACK_STATUS), the endpoint
+  MUST close the session with an error of 'Too Many Requests'.
 
 MAX_REQUEST_ID is similar to MAX_STREAMS in ({{?RFC9000, Section 4.6}}), and
 similar considerations apply when deciding how often to send MAX_REQUEST_ID.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1681,11 +1681,11 @@ MAX_REQUEST_ID Message {
 ~~~
 {: #moq-transport-max-request-id format title="MOQT MAX_REQUEST_ID Message"}
 
-* Request ID: The new Maximum Request ID for the session plus one. If
-  a Request ID equal or larger than this is received by the endpoint
-  that sent the MAX_REQUEST_ID in any request message (ANNOUNCE,
-  FETCH, SUBSCRIBE, SUBSCRIBE_ANNOUNCES or TRACK_STATUS), the endpoint
-  MUST close the session with an error of 'Too Many Requests'.
+* Request ID: The new Maximum Request ID for the session plus one. If a Request
+  ID equal or larger than this is received by the endpoint that sent the
+  MAX_REQUEST_ID in any request message (ANNOUNCE, FETCH, SUBSCRIBE,
+  SUBSCRIBE_ANNOUNCES or TRACK_STATUS), the endpoint MUST close the session with
+  an error of 'Too Many Requests'.
 
 MAX_REQUEST_ID is similar to MAX_STREAMS in ({{?RFC9000, Section 4.6}}), and
 similar considerations apply when deciding how often to send MAX_REQUEST_ID.


### PR DESCRIPTION
I added a parameter (TRACK_STATUS_RESPONDER) to allow for cases where a relay has cached information about a track and doesn't want to or can't establish a subscription or send TRACK_STATUS upstream.

Fixes: #895
Fixes: #1002 