### PR TITLE
Minimal Stream definition

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -369,7 +369,7 @@ track to allow the subscriber to pick the appropriate resolution given
 the display environment and available bandwidth. Each "group of pictures"
 in a video is sent as a group because the first frame is needed to
 decode later frames. This allows the client to join at the logical points
-where they can get the information to start decoding the stream.
+where they can get the information to start decoding the media.
 The temporal layers are sent as separate sub groups to allow the
 priority mechanism to favour the base layer when there is not enough
 bandwidth to send both the base and enhancement layers. Each frame of

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -211,6 +211,11 @@ Transport Session:
 
 : A raw QUIC connection or a WebTransport session.
 
+Stream:
+
+: A bidirectional or unidirectional bytestream provided by the
+QUIC transport or WebTransport.
+
 Congestion:
 
 : Packet loss and queuing caused by degraded or overloaded networks.


### PR DESCRIPTION
I believe this is the minimal change needed to address #1001.

I’m unsure about the preferred ordering of terms. Is there any guidance on that, or on other editorial details of this kind?

---

Section 9. Talks about “Data streams”. And it is referenced in a couple of places as “data stream”.  Without a prior definition and a differentiation of “Data stream” and “streams”. 
I don’t know the best way forward there. If even a tangible difference between Data stream and stream exists in the context of this document, or what the original reason for the “data” stream term was.

Note. [RTP over QUIC](https://www.ietf.org/archive/id/draft-ietf-avtcore-rtp-over-quic-14.html#section-2-11.18.1) also “struggles” with the usage and definition of the word stream.

This is my first PR here. I am sorry if it ends up being more of a burden than a help. I know this borders on bikeshedding, but hopefully it nudges things a little forward and improves clarity for new readers.