### PR TITLE
Reset stream clarification when setting SUBSCRIBE_UPDATE to false

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3144,12 +3144,13 @@ stream, it MUST use a RESET_STREAM or RESET_STREAM_AT
 Subgroup exceeding its Delivery Timeout, early termination of subscription due to
 an UNSUBSCRIBE message, a publisher's decision to end the subscription early, or a
 SUBSCRIBE_UPDATE moving the end of the subscription to before the current Group
-or the start after the current Group.  When RESET_STREAM_AT is used, the
-reliable_size SHOULD include the stream header so the receiver can identify the
-corresponding subscription and accurately account for reset data streams when
-handling SUBSCRIBE_DONE (see {{message-subscribe-done}}).  Publishers that reset
-data streams without using RESET_STREAM_AT with an appropriate reliable_size can
-cause subscribers to hold on to subscription state until a timeout expires.
+or the start after the current Group, or a SUBSCRIBE_UPDATE that changes the
+forwarding flag to false.  When RESET_STREAM_AT is used, the reliable_size SHOULD
+include the stream header so the receiver can identify the corresponding subscription
+and accurately account for reset data streams when handling SUBSCRIBE_DONE
+(see {{message-subscribe-done}}).  Publishers that reset data streams without using
+RESET_STREAM_AT with an appropriate reliable_size can cause subscribers to hold on to
+subscription state until a timeout expires.
 
 A sender might send all objects in a Subgroup and the FIN on a QUIC stream,
 and then reset the stream. In this case, the receiving application would receive


### PR DESCRIPTION
There's some ambiguity as to whether the publisher should send a FIN or RESET the stream when forward is set to false, causing no more objects to be delivered in a subgroup. I'm attempting to clarify it here.