### PR TITLE
Parameters on SUBSCRIBE_ANNOUNCES are subscription defaults

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2985,10 +2985,10 @@ an N of 0 or more than 32, it MUST close the session with a Protocol
 Violation.
 
 * Parameters: The parameters are defined in {{version-specific-params}}. Any
-parameter that is applicable to a subscription, such as DELIVERY TIMEOUT,
-SHOULD be applied to any subscriptions that result from the SUBSCRIBE_ANNOUNCES.
-This enables a user of SUBSCRIBE_ANNOUNCES to specify defaults for any
-resulting subscriptions.
+  parameter that is applicable to a subscription, such as DELIVERY TIMEOUT,
+  SHOULD be applied to any subscriptions that result from the
+  SUBSCRIBE_ANNOUNCES.  This enables a user of SUBSCRIBE_ANNOUNCES to specify
+  defaults for any resulting subscriptions.
 
 The publisher will respond with SUBSCRIBE_ANNOUNCES_OK or
 SUBSCRIBE_ANNOUNCES_ERROR.  If the SUBSCRIBE_ANNOUNCES is successful, the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2984,7 +2984,11 @@ would match both.  If an endpoint receives a Track Namespace Prefix tuple with
 an N of 0 or more than 32, it MUST close the session with a Protocol
 Violation.
 
-* Parameters: The parameters are defined in {{version-specific-params}}.
+* Parameters: The parameters are defined in {{version-specific-params}}. Any
+parameter that is applicable to a subscription, such as DELIVERY TIMEOUT,
+SHOULD be applied to any subscriptions that result from the SUBSCRIBE_ANNOUNCES.
+This enables a user of SUBSCRIBE_ANNOUNCES to specify defaults for any
+resulting subscriptions.
 
 The publisher will respond with SUBSCRIBE_ANNOUNCES_OK or
 SUBSCRIBE_ANNOUNCES_ERROR.  If the SUBSCRIBE_ANNOUNCES is successful, the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2988,7 +2988,11 @@ Violation.
   parameter that is applicable to a subscription, such as DELIVERY TIMEOUT,
   SHOULD be applied to any subscriptions that result from the
   SUBSCRIBE_ANNOUNCES.  This enables a user of SUBSCRIBE_ANNOUNCES to specify
-  defaults for any resulting subscriptions.
+  defaults for any resulting subscriptions. When a PUBLISH is caused by a
+  SUBSCRIBE_ANNOUNCES the publisher SHOULD copy any parameters that are
+  relevant to the subscription into the PUBLISH parameters. The publisher
+  SHOULD NOT copy any parameters it does not understand. The subscriber
+  then has the option to override any specified parameters in PUBLISH_OK.
 
 The publisher will respond with SUBSCRIBE_ANNOUNCES_OK or
 SUBSCRIBE_ANNOUNCES_ERROR.  If the SUBSCRIBE_ANNOUNCES is successful, the


### PR DESCRIPTION
This was discussed in Stockholm.  I believe it fixes an issue, but I can't quickly find it.