### PR TITLE
RFC: Rename ANNOUNCE to PUBLISH_NAMESPACE

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -965,7 +965,7 @@ in a namespace without having received a PUBLISH_NAMESPACE for it.
 If a publisher is authoritative for a given namespace, or is a relay that has
 received an authorized PUBLISH_NAMESPACE for that namespace from an upstream
 publisher, it MUST send a PUBLISH_NAMESPACE to any subscriber that has
-subscribed to PUBLISH_NAMESPACE for that namespace, or a more generic set
+subscribed via SUBSCRIBE_NAMESPACE for that namespace, or a more generic set
 including that namespace. A publisher MAY send the PUBLISH_NAMESPACE to any
 other subscriber.
 


### PR DESCRIPTION
This is now symmetric with SUBSCRIBE/SUBSCRIBE_NAMESPACE

UNANNOUNCE -> PUBLISH_NAMESPACE_DONE