### PR TITLE
Make default PUBLISHER PRIORITY a parameter, optional in Subgroup/Datagram

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1056,11 +1056,9 @@ implementation dependent what happens to objects that have already been
 scheduled.
 
 _Publisher Priority_ is a priority number associated with an individual
-schedulable object.  A default can be specified in the parameters of PUBLISH,
-SUBSCRIBE_OK, or FETCH_OK. Publisher priority can also be specified in the
-Extension Headers of the first Object in a subgroup, datagrams, or any
-Object in a FETCH response. If no value is specified, publisher priority
-defaults to 128.
+schedulable object.  A default can be specified in the parameters of PUBLISH, or
+SUBSCRIBE_OK. Publisher priority can also be specified in a subgroup header or
+datagram
 
 _Group Order_ is a property of an individual subscription.  It can be either
 'Ascending' (groups with lower group ID are sent first), or 'Descending'

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1037,8 +1037,9 @@ received and possibly scheduled.
 _Publisher Priority_ is a priority number associated with an individual
 schedulable object.  A default can be specified in the parameters of PUBLISH,
 SUBSCRIBE_OK, or FETCH_OK. Publisher priority can also be specified in the
-parameters in first Object of a subgroup, datagrams, or each Object in a
-FETCH response. If no value is specified, publisher priority defaults to 128.
+Extension Headers of the first Object in a subgroup, datagrams, or any
+Object in a FETCH response. If no value is specified, publisher priority
+defaults to 128.
 
 _Group Order_ is a property of an individual subscription.  It can be either
 'Ascending' (groups with lower group ID are sent first), or 'Descending'
@@ -1612,7 +1613,8 @@ The PUBLISHER PRIORITY parameter (Parameter Type 0x0E) specifies the priority
 of a subscription relative to other subscriptions in the same session.
 The value is from 0 to 255 and lower numbers get higher priority.
 See {{priorities}}. Priorities above 255 are invalid. The PUBLISHER PRIORITY
-parameter is valid in SUBSCRIBE_OK, PUBLISH and FETCH_OK.
+parameter is valid in SUBSCRIBE_OK, PUBLISH and FETCH_OK, as well as in
+Object Extension Headers.
 
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1130,7 +1130,7 @@ scheduled.
 _Publisher Priority_ is a priority number associated with an individual
 schedulable object.  A default can be specified in the parameters of PUBLISH, or
 SUBSCRIBE_OK. Publisher priority can also be specified in a subgroup header or
-datagram
+datagram (see {{data-streams}}).
 
 _Group Order_ is a property of an individual subscription.  It can be either
 'Ascending' (groups with lower group ID are sent first), or 'Descending'

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1657,12 +1657,14 @@ handles a downstream request that includes those Objects re-requests them.
 
 #### PUBLISHER PRIORITY Parameter {#subscriber-priority}
 
-The PUBLISHER PRIORITY parameter (Parameter Type 0x0E) specifies the priority
-of a subscription relative to other subscriptions in the same session.
-The value is from 0 to 255 and lower numbers get higher priority.
-See {{priorities}}. Priorities above 255 are invalid. The PUBLISHER PRIORITY
-parameter is valid in SUBSCRIBE_OK, PUBLISH and FETCH_OK, as well as in
-Object Extension Headers.
+The PUBLISHER PRIORITY parameter (Parameter Type 0x0E) specifies the priority of
+a subscription relative to other subscriptions in the same session.  The value
+is from 0 to 255 and lower numbers get higher priority.  See
+{{priorities}}. Priorities above 255 are invalid. The PUBLISHER PRIORITY
+parameter is valid in SUBSCRIBE_OK and PUBLISH. Subgroups and Datagrams for this
+subscription inherit this priority, unless they specifically override it.
+
+The subscription has Publisher Priorty 128 if this parameter is omitted.
 
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}
 
@@ -3299,19 +3301,27 @@ OBJECT_DATAGRAM {
 The Type value determines which fields are present in the OBJECT_DATAGRAM.
 There are 10 defined Type values for OBJECT_DATAGRAM.
 
-|------|---------------|------------|-----------|------------------|
-| Type | End Of Group  | Extensions | Object ID | Status / Payload |
-| | | Present | Present | |
-| 0x00 | No | No | Yes | Payload |
-| 0x01 | No | Yes | Yes | Payload |
-| 0x02 | Yes | No | Yes | Payload |
-| 0x03 | Yes | Yes | Yes | Payload |
-| 0x04 | No | No | No | Payload |
-| 0x05 | No | Yes | No | Payload |
-| 0x06 | Yes | No | No | Payload |
-| 0x07 | Yes | Yes | No | Payload |
-| 0x20 | No | No | Yes | Status |
-| 0x21 | No | Yes | Yes | Status |
+| Type | End Of Group | Extensions | Object ID | Priority Present | Status / Payload |
+| 0x00 | No | No | Yes | Yes | Payload |
+| 0x01 | No | Yes | Yes | Yes | Payload |
+| 0x02 | Yes | No | Yes | Yes | Payload |
+| 0x03 | Yes | Yes | Yes | Yes | Payload |
+| 0x04 | No | No | No | Yes | Payload |
+| 0x05 | No | Yes | No | Yes | Payload |
+| 0x06 | Yes | No | No | Yes | Payload |
+| 0x07 | Yes | Yes | No | Yes | Payload |
+| 0x20 | No | No | Yes | Yes | Status |
+| 0x21 | No | Yes | Yes | Yes | Status |
+| 0x08 | No | No | Yes | No | Payload |
+| 0x09 | No | Yes | Yes | No | Payload |
+| 0x0A | Yes | No | Yes | No | Payload |
+| 0x0B | Yes | Yes | Yes | No | Payload |
+| 0x0C | No | No | No | No | Payload |
+| 0x0D | No | Yes | No | No | Payload |
+| 0x0E | Yes | No | No | No | Payload |
+| 0x0F | Yes | Yes | No | No | Payload |
+| 0x28 | No | No | Yes | No | Status |
+| 0x29 | No | Yes | Yes | No | Status |
 
 * End of Group: For Type values where End of Group is "Yes" the Object is the
   last Object in the Group.
@@ -3324,6 +3334,11 @@ There are 10 defined Type values for OBJECT_DATAGRAM.
 * Object ID Present: If Object ID Present is No, the Object ID field is omitted
   and the Object ID is 0.  When Object ID Present is Yes, the Object ID field is
   present and encodes the Object ID.
+
+* Priority Present: If Priority Present is No, Priority is not present and this
+  Object inherits the Publisher Priority specified in the control message that
+  established the subscription.  When Priority Present is Yes, the Priority field
+  is present.
 
 * Payload and Status: The Object Status field and Object Payload are mutually
   exclusive.
@@ -3377,6 +3392,7 @@ SUBGROUP_HEADER {
   Track Alias (i),
   Group ID (i),
   [Subgroup ID (i),]
+  [Publisher Priority (8),]
 }
 ~~~
 {: #object-header-format title="MOQT SUBGROUP_HEADER"}
@@ -3384,36 +3400,60 @@ SUBGROUP_HEADER {
 All Objects received on a stream opened with `SUBGROUP_HEADER` have an
 `Object Forwarding Preference` = `Subgroup`.
 
-There are 12 defined Type values for SUBGROUP_HEADER:
+There are 24 defined Type values for SUBGROUP_HEADER:
 
-|------|---------------|-----------------|------------|--------------|
-| Type | Subgroup ID   | Subgroup ID     | Extensions | Contains End |
-|      | Field Present | Value           | Present    | of Group     |
-|------|---------------|-----------------|------------|--------------|
-| 0x10 | No            | 0               | No         | No           |
-|------|---------------|-----------------|------------|--------------|
-| 0x11 | No            | 0               | Yes        | No           |
-|------|---------------|-----------------|------------|--------------|
-| 0x12 | No            | First Object ID | No         | No           |
-|------|---------------|-----------------|------------|--------------|
-| 0x13 | No            | First Object ID | Yes        | No           |
-|------|---------------|-----------------|------------|--------------|
-| 0x14 | Yes           | N/A             | No         | No           |
-|------|---------------|-----------------|------------|--------------|
-| 0x15 | Yes           | N/A             | Yes        | No           |
-|------|---------------|-----------------|------------|--------------|
-| 0x18 | No            | 0               | No         | Yes          |
-|------|---------------|-----------------|------------|--------------|
-| 0x19 | No            | 0               | Yes        | Yes          |
-|------|---------------|-----------------|------------|--------------|
-| 0x1A | No            | First Object ID | No         | Yes          |
-|------|---------------|-----------------|------------|--------------|
-| 0x1B | No            | First Object ID | Yes        | Yes          |
-|------|---------------|-----------------|------------|--------------|
-| 0x1C | Yes           | N/A             | No         | Yes          |
-|------|---------------|-----------------|------------|--------------|
-| 0x1D | Yes           | N/A             | Yes        | Yes          |
-|------|---------------|-----------------|------------|--------------|
+|------|---------------|-----------------|------------|--------------|---------------|
+| Type | Subgroup ID   | Subgroup ID     | Extensions | Contains End | Priority      |
+|      | Field Present | Value           | Present    | of Group     | Present       |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x10 | No            | 0               | No         | No           | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x11 | No            | 0               | Yes        | No           | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x12 | No            | First Object ID | No         | No           | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x13 | No            | First Object ID | Yes        | No           | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x14 | Yes           | N/A             | No         | No           | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x15 | Yes           | N/A             | Yes        | No           | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x18 | No            | 0               | No         | Yes          | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x19 | No            | 0               | Yes        | Yes          | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x1A | No            | First Object ID | No         | Yes          | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x1B | No            | First Object ID | Yes        | Yes          | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x1C | Yes           | N/A             | No         | Yes          | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x1D | Yes           | N/A             | Yes        | Yes          | Yes           |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x30 | No            | 0               | No         | No           | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x31 | No            | 0               | Yes        | No           | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x32 | No            | First Object ID | No         | No           | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x33 | No            | First Object ID | Yes        | No           | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x34 | Yes           | N/A             | No         | No           | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x35 | Yes           | N/A             | Yes        | No           | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x38 | No            | 0               | No         | Yes          | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x39 | No            | 0               | Yes        | Yes          | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x3A | No            | First Object ID | No         | Yes          | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x3B | No            | First Object ID | Yes        | Yes          | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x3C | Yes           | N/A             | No         | Yes          | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
+| 0x3D | Yes           | N/A             | Yes        | Yes          | No            |
+|------|---------------|-----------------|------------|--------------|---------------|
 
 For Type values where Contains End of Group is Yes, the last Object in this
 Subgroup stream before a FIN is the last Object in the Group.  If the Subgroup
@@ -3429,6 +3469,11 @@ For Type values where Extensions Present is No, Extensions Headers Length is
 not present and all Objects have no extensions.  When Extensions Present is
 Yes, Extension Headers Length is present in all Objects in this subgroup.
 Objects with no extensions set Extension Headers Length to 0.
+
+For Type values where Priority Present is No, Priority is not present and this
+Subgroup inherits the Publisher Priority specified in the control message that
+established the subscription.  When Priority Present is Yes, the Priority field
+is present in the Subgroup header.
 
 To send an Object with `Object Forwarding Preference` = `Subgroup`, find the open
 stream that is associated with the subscription, `Group ID` and `Subgroup ID`,
@@ -3584,6 +3629,7 @@ Each object sent on a fetch stream after the FETCH_HEADER has the following form
   Group ID (i),
   Subgroup ID (i),
   Object ID (i),
+  Publisher Priority (8),
   Extension Headers Length (i),
   [Extension headers (...)],
   Object Payload Length (i),
@@ -3610,6 +3656,7 @@ SUBGROUP_HEADER {
   Track Alias = 2
   Group ID = 0
   Subgroup ID = 0
+  Priority = 0
 }
 {
   Object ID = 0
@@ -3630,7 +3677,7 @@ Extension Headers.
 Stream = 2
 
 SUBGROUP_HEADER {
-  Type = 0x15
+  Type = 0x35
   Track Alias = 2
   Group ID = 0
   Subgroup ID = 0

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1035,8 +1035,10 @@ implementation dependent what happens to objects that have already been
 received and possibly scheduled.
 
 _Publisher Priority_ is a priority number associated with an individual
-schedulable object.  It is specified in the header of the respective subgroup or
-datagram, or in each object in a FETCH response.
+schedulable object.  A default can be specified in the parameters of PUBLISH,
+SUBSCRIBE_OK, or FETCH_OK. Publisher priority can also be specified in the
+parameters in first Object of a subgroup, datagrams, or each Object in a
+FETCH response. If no value is specified, publisher priority defaults to 128.
 
 _Group Order_ is a property of an individual subscription.  It can be either
 'Ascending' (groups with lower group ID are sent first), or 'Descending'
@@ -1603,6 +1605,14 @@ earlier in a multi-object stream will expire earlier than Objects later in the
 stream. Once Objects have expired from cache, their state becomes unknown, and
 a relay that handles a downstream request that includes those Objects
 re-requests them.
+
+#### PUBLISHER PRIORITY Parameter {#subscriber-priority}
+
+The PUBLISHER PRIORITY parameter (Parameter Type 0x0E) specifies the priority
+of a subscription relative to other subscriptions in the same session.
+The value is from 0 to 255 and lower numbers get higher priority.
+See {{priorities}}. Priorities above 255 are invalid. The PUBLISHER PRIORITY
+parameter is valid in SUBSCRIBE_OK, PUBLISH and FETCH_OK.
 
 ## CLIENT_SETUP and SERVER_SETUP {#message-setup}
 
@@ -3304,7 +3314,6 @@ OBJECT_DATAGRAM {
   Track Alias (i),
   Group ID (i),
   Object ID (i),
-  Publisher Priority (8),
   [Extension Headers Length (i),
   Extension headers (...)],
   Object Payload (..),
@@ -3350,7 +3359,6 @@ OBJECT_DATAGRAM_STATUS {
   Track Alias (i),
   Group ID (i),
   Object ID (i),
-  Publisher Priority (8),
   [Extension Headers Length (i),
   Extension headers (...)],
   Object Status (i),
@@ -3402,7 +3410,6 @@ SUBGROUP_HEADER {
   Track Alias (i),
   Group ID (i),
   [Subgroup ID (i),]
-  Publisher Priority (8),
 }
 ~~~
 {: #object-header-format title="MOQT SUBGROUP_HEADER"}
@@ -3619,7 +3626,6 @@ Each object sent on a fetch stream after the FETCH_HEADER has the following form
   Group ID (i),
   Subgroup ID (i),
   Object ID (i),
-  Publisher Priority (8),
   Extension Headers Length (i),
   [Extension headers (...)],
   Object Payload Length (i),
@@ -3646,7 +3652,6 @@ SUBGROUP_HEADER {
   Track Alias = 2
   Group ID = 0
   Subgroup ID = 0
-  Publisher Priority = 0
 }
 {
   Object ID = 0
@@ -3670,7 +3675,6 @@ SUBGROUP_HEADER {
   Type = 1
   Track Alias = 2
   Group ID = 0
-  Publisher Priority = 0
 }
 {
   Object ID = 0


### PR DESCRIPTION
Adds the ability to specify the parameter in PUBLISH, SUBSCRIBE_OK, and FETCH_OK.

Putting it on every Datagram and Fetch Object seems quite wasteful for most use cases, so this allows you to only specify a different value from the overall subscription value when needed.

Inspired by #1055 
Fixes: #1202 