### PR TITLE
Make START LOCATION and END LOCATION params

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1608,8 +1608,8 @@ re-requests them.
 
 The START LOCATION parameter (Parameter Type 0x03) indicates the beginning
 of a subscription or fetch and can be used in SUBSCRIBE, SUBSCRIBE_UPDATE,
-FETCH, PUBLISH, and PUBLISH_OK. The default for START LOCATION is the
-beginning of the Track, equivalent to {0, 0}.
+FETCH, and PUBLISH_OK. The default for START LOCATION is the beginning of
+the Track, equivalent to None (0x0).
 
 There are 6 types of filter locations and any other value MUST be treated
 as an error. Some types are only the type value and others have one or
@@ -1639,8 +1639,8 @@ two sequential varints.
 
 The END LOCATION parameter (Parameter Type 0x05) indicates the end of a
 subscription or fetch and can be used in SUBSCRIBE, SUBSCRIBE_UPDATE,
-FETCH, PUBLISH, and PUBLISH_OK. The default for END LOCATION is the
-end of the Track, equivalent to {MaxVarint, MaxVarint}.
+FETCH, and PUBLISH_OK. The default for END LOCATION is the end of the
+Track, equivalent to None (0x1).
 
 The types and formatting of END LOCATION are identical to
 START LOCATION {{start-location}} defined above.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1607,9 +1607,9 @@ re-requests them.
 #### START LOCATION Parameter {#start-location}
 
 The START LOCATION parameter (Parameter Type 0x03) indicates the beginning
-of a subscription or fetch and can be used in SUBSCRIBE, SUBSCRIBE_UPDATE,
-FETCH, and PUBLISH_OK. The default for START LOCATION is the beginning of
-the Track, equivalent to None (0x0).
+of a subscription filter or fetch and can be used in SUBSCRIBE,
+SUBSCRIBE_UPDATE, FETCH, and PUBLISH_OK. The default for START LOCATION is
+the beginning of the Track, equivalent to None (0x0).
 
 There are 6 types of filter locations and any other value MUST be treated
 as an error. Some types are only the type value and others have one or
@@ -1638,7 +1638,7 @@ two sequential varints.
 #### END LOCATION Parameter {#end-location}
 
 The END LOCATION parameter (Parameter Type 0x05) indicates the end of a
-subscription or fetch and can be used in SUBSCRIBE, SUBSCRIBE_UPDATE,
+subscription filter or fetch and can be used in SUBSCRIBE, SUBSCRIBE_UPDATE,
 FETCH, and PUBLISH_OK. The default for END LOCATION is the end of the
 Track, equivalent to None (0x1).
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1629,7 +1629,7 @@ Prior Group (0x3): The filter Location is '{Largest Object.Group - numgroups}'
 where numgroups is a specified as a subsequent varint.
 
 Absolute Group (0x4): The filter Group is specified explicitly as a
-subsequent varint.
+subsequent varint, and the Start Object is 0.
 
 Absolute Location (0x5): The filter Location is specified explicitly by
 two sequential varints.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1863,7 +1863,7 @@ The `Largest Object` is defined to be the object with the largest Location
 processing the SUBSCRIBE message. Largest Object updates when the first byte of
 an Object with a larger Location than the previous value is published or
 received through a subscription. The Start MAY be less than the `Largest Object`
-observed at the publisher. 
+observed at the publisher.
 
 Subscribe only delivers newly published or received Objects.  Objects from the
 past are retrieved using FETCH ({{message-fetch}}).

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1611,7 +1611,7 @@ of a subscription or fetch and can be used in SUBSCRIBE, SUBSCRIBE_UPDATE,
 FETCH, PUBLISH, and PUBLISH_OK. The default for START LOCATION is the
 beginning of the Track, equivalent to {0, 0}.
 
-There are 4 types of filter locations and any other value MUST be treated
+There are 6 types of filter locations and any other value MUST be treated
 as an error. Some types are only the type value and others have one or
 more following varints.
 


### PR DESCRIPTION
Adds the START LOCATION and END LOCATION params and updates SUBSCRIBE, SUBSCRIBE_UPDATE, PUBLISH and FETCH to use them.

Currently this allows some functionality the current draft does not, such as subscriptions that end at a specific Object rather than a Group boundary.  We could restrict that if we wanted, but it's not clear it adds any implementation complexity.

Fixes #1035 