### PR TITLE
OBJECT_DATAGRAM_STATUS

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3330,7 +3330,7 @@ There are 2 defined Type values for OBJECT_DATAGRAM_STATUS:
 |------|------------|
 
 The LSB of the type determines if the Extensions Headers Length and Extension
-headers are present. If an endpoint receives a datagram with Type 0x04 and
+headers are present. If an endpoint receives a datagram with Type 0x05 and
 Extension Headers Length is 0, it MUST close the session with Protocol Violation.
 
 ## Streams

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3329,8 +3329,9 @@ There are 2 defined Type values for OBJECT_DATAGRAM_STATUS:
 | 0x05 | Yes        |
 |------|------------|
 
-If an endpoint receives a datagram with Type 0x05 and Extension Headers Length is 0,
-it MUST close the session with Protocol Violation.
+The LSB of the type determines if the Extensions Headers Length and Extension
+headers are present. If an endpoint receives a datagram with Type 0x04 and
+Extension Headers Length is 0, it MUST close the session with Protocol Violation.
 
 ## Streams
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3318,11 +3318,19 @@ OBJECT_DATAGRAM_STATUS {
 ~~~
 {: #object-datagram-status-format title="MOQT OBJECT_DATAGRAM_STATUS"}
 
-The Type field takes the form 0b0000001X (or the set of values from 0x02 to
-0x03). The LSB of the type determines if the Extensions Headers Length and
-Extension headers are present. If an endpoint receives a datagram with Type
-0x03 and Extension Headers Length is 0, it MUST close the session with Protocol
-Violation.
+There are 2 defined Type values for OBJECT_DATAGRAM_STATUS:
+
+|------|------------|
+| Type | Extensions |
+|      | Present    |
+|------|------------|
+| 0x04 | No         |
+|------|------------|
+| 0x05 | Yes        |
+|------|------------|
+
+If an endpoint receives a datagram with Type 0x05 and Extension Headers Length is 0,
+it MUST close the session with Protocol Violation.
 
 ## Streams
 


### PR DESCRIPTION
Fixes: #1076 

I think Object Datagram Status might not have been updated with the other values moved? Added a table and altered the text to reflect the values given above. 

Maybe this is worth another issue, but I see that extensions being declared as present with a length of 0 is sometimes a protocol violation and sometimes not. (Datagram vs Stream). Not sure that's intentional?