### PR TITLE
Security considerations on Relay: ANNOUNCE and SUBSCRIBE_NAMESPACE considerations

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3760,12 +3760,12 @@ an expected time.  Each implementation is expected to set its own limits.
 
 ## Relay memory consumption
 
-A Relay SHOULD have mechanisms to prevent malicious endpoints from flooding
-it with ANNOUNCE or SUBSCRIBE_ANNOUNCE requests that could bloat data
-structures. It could use the advertised MAX_REQUEST_ID to limit the number
-of such requests, or could have application-specific policies that can
-reject incoming ANNOUNCE or SUBSCRIBE_NAMESPACE requests that cause the
-state maintenance for the session to be excessive.
+A Relay SHOULD have mechanisms to prevent malicious endpoints from flooding it
+with PUBLISH_NAMESPACE or SUBSCRIBE_NAMESPACE requests that could bloat data
+structures. It could use the advertised MAX_REQUEST_ID to limit the number of
+such requests, or could have application-specific policies that can reject
+incoming PUBLISH_NAMESPACE or SUBSCRIBE_NAMESPACE requests that cause the state
+maintenance for the session to be excessive.
 
 # IANA Considerations {#iana}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3757,6 +3757,16 @@ Implementations are advised to use timeouts to prevent resource
 exhaustion attacks by a peer that does not send expected data within
 an expected time.  Each implementation is expected to set its own limits.
 
+
+## Relay memory consumption
+
+A Relay SHOULD have mechanisms to prevent malicious endpoints from flooding
+it with ANNOUNCE or SUBSCRIBE_ANNOUNCE requests that could bloat data
+structures. It could use the advertised MAX_REQUEST_ID to limit the number
+of such requests, or could have application-specific policies that can
+reject incoming ANNOUNCE or SUBSCRIBE_NAMESPACE requests that cause the
+state maintenance for the session to be excessive.
+
 # IANA Considerations {#iana}
 
 TODO: fill out currently missing registries:


### PR DESCRIPTION
If an endpoint sends a relay a large number of ANNOUNCE or SUBSCRIBE_NAMESPACE messages, the relay would be required to store the mappings, potentially forever. A flood of bogus namespaces could bloat data structures on a relay that store namespace tables. This PR adds some language in the "Security considerations" section in order to encourage implementations to guard against this.

Resolves #1094 