### PR TITLE
Explain Modularity of MOQT

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -843,8 +843,8 @@ using only SUBSCRIBE related messages.  Limited endpoints SHOULD respond to any
 unsupported messages with the appropriate `NOT_SUPPORTED` error code or close
 the session, rather than ignoring them.
 
-Relays MUST all MOQT messages defined in this document, as well as processing
-rules described in {{relays-moq}}.
+Relays MUST implement all MOQT messages defined in this document, as well as
+processing rules described in {{relays-moq}}.
 
 # Publishing and Retrieving Tracks
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -836,8 +836,7 @@ subscribing endpoints as well as highly functional Relays.  Non-Relay endpoints
 MAY implement only the subset of functionality required to perform necessary
 tasks.  For example, a limited media player could operate using only SUBSCRIBE
 related messages.  Limited endpoints SHOULD respond to any unsupported messages
-with the appropriate `NOT_SUPPORTED` error code or close the session, rather
-than ignoring them.
+with the appropriate `NOT_SUPPORTED` error code, rather than ignoring them.
 
 Relays MUST implement all MOQT messages defined in this document, as well as
 processing rules described in {{relays-moq}}.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -194,10 +194,14 @@ End Subscriber:
 
 : A subscriber that initiates a subscription and does not send the data on to other subscribers.
 
-Relay:
+Intermediary:
 
 : An entity that is both a Publisher and a Subscriber, but not the Original
 Publisher or End Subscriber.
+
+Relay:
+
+: An intermediary that conforms to all requirements in {{relays-moq}}.
 
 Upstream:
 
@@ -828,6 +832,19 @@ For example, BBR's PROBE_RTT state halves the sending rate for more than a round
 in order to obtain an accurate minimum RTT. Similarly, Reno halves it's congestion
 window upon detecting loss.  In both cases, the large reduction in sending rate might
 cause issues with latency sensitive applications.
+
+# Modularity
+
+MOQT defines all messages necessary to implement both simple publishing or
+subscribing endpoints as well as highly functional Relays.  Non-Relay endpoints
+and intermediaries MAY implement only the subset of functionality required to
+perform necessary tasks.  For example, a limited media player could operate
+using only SUBSCRIBE related messages.  Limited endpoints SHOULD respond to any
+unsupported messages with the appropriate `NOT_SUPPORTED` error code or close
+the session, rather than ignoring them.
+
+Relays MUST all MOQT messages defined in this document, as well as processing
+rules described in {{relays-moq}}.
 
 # Publishing and Retrieving Tracks
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -194,14 +194,10 @@ End Subscriber:
 
 : A subscriber that initiates a subscription and does not send the data on to other subscribers.
 
-Intermediary:
-
-: An entity that is both a Publisher and a Subscriber, but not the Original
-Publisher or End Subscriber.
-
 Relay:
 
-: An intermediary that conforms to all requirements in {{relays-moq}}.
+: An entity that is both a Publisher and a Subscriber, is not the Original
+Publisher or End Subscriber, and conforms to all requirements in {{relays-moq}}.
 
 Upstream:
 
@@ -837,11 +833,11 @@ cause issues with latency sensitive applications.
 
 MOQT defines all messages necessary to implement both simple publishing or
 subscribing endpoints as well as highly functional Relays.  Non-Relay endpoints
-and intermediaries MAY implement only the subset of functionality required to
-perform necessary tasks.  For example, a limited media player could operate
-using only SUBSCRIBE related messages.  Limited endpoints SHOULD respond to any
-unsupported messages with the appropriate `NOT_SUPPORTED` error code or close
-the session, rather than ignoring them.
+MAY implement only the subset of functionality required to perform necessary
+tasks.  For example, a limited media player could operate using only SUBSCRIBE
+related messages.  Limited endpoints SHOULD respond to any unsupported messages
+with the appropriate `NOT_SUPPORTED` error code or close the session, rather
+than ignoring them.
 
 Relays MUST implement all MOQT messages defined in this document, as well as
 processing rules described in {{relays-moq}}.


### PR DESCRIPTION
Fixes: #908

Added a new term "intermediary" which was our old Relay definition, and redefined Relay to mean "an intermediary that follows all the rules". An example of a non-relay intermediary might be an ingest proxy, that only supports PUBLISH related messages upstream and downstream.

Added a top-level "Modularity" section between "Sessions" and "Publishing and Receiving Tracks" - open to suggestions if there's a better place.