### PR TITLE
Explain FETCH routing for relays

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1222,6 +1222,13 @@ that sent PUBLISH_NAMESPACE namespace=(foobar).
 Relays MUST forward SUBSCRIBE messages to all publishers and PUBLISH_NAMESPACE
 and PUBLISH messages to all subscribers that have a Namespace Prefix Match.
 
+When a Relay needs to make an upstream FETCH request, it determines the
+available publishers using the same matching rules as SUBSCRIBE. When more than
+one publisher is available, the Relay MUST send the FETCH to at least one of
+them.  If FETCH fails with `UNKNOWN_STATUS_IN_RANGE` (see {{message-fetch}}),
+the Relay MUST attempt the FETCH against other matching publishers until the
+FETCH succeeds or fails for a different reason.
+
 When a relay receives an incoming SUBSCRIBE that triggers an upstream
 subscription, it SHOULD send a SUBSCRIBE request to each publisher that has
 published the subscription's namespace or prefix thereof, unless it already has

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1224,10 +1224,7 @@ and PUBLISH messages to all subscribers that have a Namespace Prefix Match.
 
 When a Relay needs to make an upstream FETCH request, it determines the
 available publishers using the same matching rules as SUBSCRIBE. When more than
-one publisher is available, the Relay MUST send the FETCH to at least one of
-them.  If FETCH fails with `UNKNOWN_STATUS_IN_RANGE` (see {{message-fetch}}),
-the Relay MUST attempt the FETCH against other matching publishers until the
-FETCH succeeds or fails for a different reason.
+one publisher is available, the Relay MAY send the FETCH to any of them.
 
 When a relay receives an incoming SUBSCRIBE that triggers an upstream
 subscription, it SHOULD send a SUBSCRIBE request to each publisher that has


### PR DESCRIPTION
Fixes: #728

* Use the same rules as SUBSCRIBE to find available publishers
---
EDIT: 

Originally this PR had
* MUST send to at least one, and try against others for UNKNOWN_STATUS_IN_RANGE

But now it reads:

* MAY send to any publisher if there is more than one.
---

This leaves the door open for making the FETCHes in parallel, but doesn't require it.

I didn't see any other FETCH_ERROR codes that seemed retryable in this way, but if there are we can make the relay language more generic.

REMINDER for Editors: This is targeted against #1116, retarget main before merging.