### PR TITLE
RFC: Generic Filters for Subscriptions and FETCH

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1665,8 +1665,8 @@ Extension ID is present only when Operand is Extension ID (value 0x4) and
 indicates the Extension to filter. This MUST indicate an Extension with an
 integer type.  Objects without the Extension do not pass the filter.
 
-Values is an array of integers which encode the values of interest.  The
-array is a sequence of pairs indicating the start and length of
+Values is an array of variable-length integers (i) which encode the values of
+interest.  The array is a sequence of pairs indicating the start and length of
 the matching range.  The Start is encoded as a delta from the previous End, or
 from 0 for the first element.  The length indicates the number of elements
 including Start to match.  An odd number of elements indicates the final range


### PR DESCRIPTION
Based on proposal in #1068

Fixes: #441 

One thing that is strange is allowing Group ID filters here, since these overlap with the built-in filters in Subscribe and Fetch.  This may be what Victor was suggesting in Stockholm.

The pathological case of this encoding is for every other object, which would double the length of the Values array.  We could fix it by shifting the start value left by one and using the LSB to indicate single vs range, but it seemed like overkill.