### PR TITLE
Major FETCH Reorganization

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2510,8 +2510,9 @@ Objects retrieved by the FETCH and SUBSCRIBE are contiguous and non-overlapping.
 The publisher receiving a Joining Fetch sets the End Location to {Subscribe
 Largest Location.Object + 1}.
 
-Note: the last Object requested by the Joining FETCH is Subscribe Largest
-Location, which is encoded by adding one to the Object ID.
+Note: the last Object included in the Joining FETCH response is Subscribe
+Largest Location.  The `+ 1` above indicates the equivalent Standalone Fetch
+encoding.
 
 For a Relative Joining Fetch, the publisher sets the Start Location to
 {Subscribe Largest Location.Group - Joining Start, 0}.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2554,11 +2554,11 @@ FETCH Message {
 * Fetch Type: Identifies the type of Fetch, whether Standalone, Relative
   Joining or Absolute Joining.
 
-* Parameters: The parameters are defined in {{version-specific-params}}.
-
 * Standalone: Standalone Fetch structure included when Fetch Type is 0x1
 
 * Joining: Joining Fetch structure included when Fetch Type is 0x2 or 0x3.
+
+* Parameters: The parameters are defined in {{version-specific-params}}.
 
 A publisher responds to a FETCH request with either a FETCH_OK or a FETCH_ERROR
 message.  The publisher creates a new unidirectional stream that is used to send the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2513,7 +2513,7 @@ Largest Location.Object + 1}.
 Note: the last Object requested by the Joining FETCH is Subscribe Largest
 Location, which is encoded by adding one to the Object ID.
 
-For a Relative Joining Fetch, the publisher sets the Start Location to 
+For a Relative Joining Fetch, the publisher sets the Start Location to
 {Subscribe Largest Location.Group - Joining Start, 0}.
 
 For an Absolute Joining Fetch, the publisher sets the Start Location to
@@ -2644,7 +2644,7 @@ Values of 0x0 and those larger than 0x2 are a protocol error.
      final) Object, End Location is {Largest.Group, Largest.Object + 1}
    - If End Location.Object in the FETCH request was 0 and the response covers
      the last Object in the Group, End Location is {Fetch.End Location.Group, 0}
-   - Otherwise, End Location is Fetch.End Location 
+   - Otherwise, End Location is Fetch.End Location
   Where Fetch.End Location is either Fetch.Standalone.End Location or the computed
   End Location described in {{joining-fetch-range-calculation}}.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2469,9 +2469,10 @@ Standalone Fetch {
 A Joining Fetch is associated with a Subscribe request by
 specifying the Request ID of an active subscription.
 A publisher receiving a Joining Fetch uses properties of the associated
-Subscribe to determine the Track Namespace, Track
+Subscribe to determine the Track Namespace, Track Name
 and End Location such that it is contiguous with the associated
-Subscribe.
+Subscribe.  The subscriber can set the Start Location to an absolute Location or
+a Location relative to the current group.
 
 A Subscriber can use a Joining Fetch to, for example, fill a playback buffer with a
 certain number of groups prior to the live edge of a track.


### PR DESCRIPTION
I started trying to remove the multiline square bracket notation and ended up reorganizing the entire section.  The new format is:

* Fetch
  * Standalone Fetch
  * Joining Fetches
    * Joining Fetch Range Calculation
  * Fetch Handling


I resisted the urge to reflow lines and drive-by capitalize defined terms.

I included the fix for the End calculation so we don't have to merge later.

Fixes: #708
Fixes: #1171