### PR TITLE
Some editorial changes to v14

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -478,6 +478,18 @@ Track Namespace is an ordered set of between 1 and 32 Track Namespace Fields,
 encoded as follows:
 
 ~~~
+Track Namespace {
+  Number of Track Namespace Fields (i),
+  Track Namespace Field (..) ...
+}
+~~~
+
+*  Number of Track Namespace Fields: A variable-length integer specifying
+   the number of Track Namespace Fields in the Track Namespace.
+
+Each Track Namespace Field is encoded as follows:
+
+~~~
 Track Namespace Field {
   Track Namespace Field Length (i),
   Track Namespace Field Value (..)
@@ -489,16 +501,6 @@ Track Namespace Field {
 
 * Track Namespace Field Value: A sequence of bytes that forms a Track Namespace
   Field.
-
-~~~
-Track Namespace {
-  Number of Track Namespace Fields (i),
-  Track Namespace Field (Track Namespace Field) ...
-}
-~~~
-
-*  Number of Track Namespace Fields: A variable-length integer specifying
-   the number of Track Namespace Fields in the Track Namespace.
 
 The structured nature of Track Namespace allows relays and applications to
 manipulate prefixes of a namespace. If an endpoint receives a Track Namespace

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1928,7 +1928,7 @@ specified `End Group` is the same group specified in `Start`, the remainder of
 that Group passes the filter. `End Group` MUST specify the same or a larger Group
 than specified in `Start`.
 
-An endpoint that receives a filter type other than the above MUST be close the
+An endpoint that receives a filter type other than the above MUST close the
 session with a `PROTOCOL_VIOLATION`.
 
 Subscribe only delivers newly published or received Objects.  Objects from the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -508,7 +508,7 @@ Namespace and a Track Name.
 
 Track Namespace is an ordered set of between 1 and 32 Track Namespace Fields.
 The structured nature of Track Namespace allows relays and applications to
-manipulate prefixes of a namespace. If an endpoint receives a Track Namespace 
+manipulate prefixes of a namespace. If an endpoint receives a Track Namespace
 consisting of 0 or greater than 32 Track Namespace Fields, it MUST close the
 session with a `PROTOCOL_VIOLATION`.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2966,7 +2966,7 @@ SUBSCRIBE_NAMESPACE Message {
   Type (i) = 0x11,
   Length (16),
   Request ID (i),
-  Track Namespace Prefix (Track Namespace),
+  Track Namespace Prefix (..),
   Number of Parameters (i),
   Parameters (..) ...
 }
@@ -2975,14 +2975,15 @@ SUBSCRIBE_NAMESPACE Message {
 
 * Request ID: See {{request-id}}.
 
-* Track Namespace Prefix: An ordered set of between 1 and 32 Track Namespace Fields
-which are matched against track namespaces known to the publisher.  For example,
-if the publisher is a relay that has received PUBLISH_NAMESPACE messages for
-namespaces ("example.com", "meeting=123", "participant=100") and ("example.com",
-"meeting=123", "participant=200"), a SUBSCRIBE_NAMESPACE for ("example.com",
-"meeting=123") would match both.  If an endpoint receives a Track Namespace
-Prefix consisting of 0 or greater than than 32 Track Namespace Fields, it MUST
-close the session with a `PROTOCOL_VIOLATION`.
+* Track Namespace Prefix: A Track Namespace structure as described in
+  {{track-name}} with between 1 and 32 Track Namespace Fields.  This prefix is
+  matched against track namespaces known to the publisher.  For example, if the
+  publisher is a relay that has received PUBLISH_NAMESPACE messages for
+  namespaces ("example.com", "meeting=123", "participant=100") and
+  ("example.com", "meeting=123", "participant=200"), a SUBSCRIBE_NAMESPACE for
+  ("example.com", "meeting=123") would match both.  If an endpoint receives a
+  Track Namespace Prefix consisting of 0 or greater than than 32 Track Namespace
+  Fields, it MUST close the session with a `PROTOCOL_VIOLATION`.
 
 * Parameters: The parameters are defined in {{version-specific-params}}.
 
@@ -3095,7 +3096,7 @@ The format of `UNSUBSCRIBE_NAMESPACE` is as follows:
 UNSUBSCRIBE_NAMESPACE Message {
   Type (i) = 0x14,
   Length (16),
-  Track Namespace Prefix (Track Namespace)
+  Track Namespace Prefix (..)
 }
 ~~~
 {: #moq-transport-unsub-ann-format title="MOQT UNSUBSCRIBE_NAMESPACE Message"}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -326,38 +326,6 @@ If a receiver understands a Type, and the following Value or Length/Value does
 not match the serialization defined by that Type, the receiver MUST terminate
 the session with error code `KEY_VALUE_FORMATTING_ERROR`.
 
-### Track Namespace Field Structure {#track-namespace-field}
-
-Track Namespace Field provides a way for the sender to encode components of Track
-Namesapces.
-
-~~~
-Track Namespace Field {
-  Track Namespace Field Length (i),
-  Track Namespace Field Value (..)
-}
-~~~
-
-* Track Namespace Field Length: A variable-length integer specifying the length
-  of the Track Namespace Field in bytes.
-
-* Track Namespace Field Value: A sequence of bytes that forms a Track Namespace
-  Field.
-
-### Track Namespace Structure {#track-namespace}
-
-Track Namespace provides a way for the sender to encode Track Namesapces.
-
-~~~
-Track Namespace {
-  Number of Track Namespace Fields (i),
-  Track Namespace Field (..) ...
-}
-~~~
-
-*  Number of Track Namespace Fields: A variable-length integer specifying
-   the number of Track Namespace Fields in the Track Namespace.
-
 ### Reason Phrase Structure {#reason-phrase}
 
 Reason Phrase provides a way for the sender to encode additional diagnostic
@@ -506,7 +474,32 @@ active.
 In MOQT, every track is identified by a Full Track Name, consisting of a Track
 Namespace and a Track Name.
 
-Track Namespace is an ordered set of between 1 and 32 Track Namespace Fields.
+Track Namespace is an ordered set of between 1 and 32 Track Namespace Fields,
+encoded as follows:
+
+~~~
+Track Namespace Field {
+  Track Namespace Field Length (i),
+  Track Namespace Field Value (..)
+}
+~~~
+
+* Track Namespace Field Length: A variable-length integer specifying the length
+  of the Track Namespace Field in bytes.
+
+* Track Namespace Field Value: A sequence of bytes that forms a Track Namespace
+  Field.
+
+~~~
+Track Namespace {
+  Number of Track Namespace Fields (i),
+  Track Namespace Field (Track Namespace Field) ...
+}
+~~~
+
+*  Number of Track Namespace Fields: A variable-length integer specifying
+   the number of Track Namespace Fields in the Track Namespace.
+
 The structured nature of Track Namespace allows relays and applications to
 manipulate prefixes of a namespace. If an endpoint receives a Track Namespace
 consisting of 0 or greater than 32 Track Namespace Fields, it MUST close the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -176,7 +176,7 @@ Endpoint:
 
 Peer:
 
-: The other endpoint than the one being described
+: The other endpoint than the one being described.
 
 Publisher:
 
@@ -201,11 +201,11 @@ Publisher or End Subscriber, and conforms to all requirements in {{relays-moq}}.
 
 Upstream:
 
-: In the direction of the Original Publisher
+: In the direction of the Original Publisher.
 
 Downstream:
 
-: In the direction of the End Subscriber(s)
+: In the direction of the End Subscriber(s).
 
 Transport Session:
 
@@ -250,12 +250,12 @@ of the parts of RFC9000 field syntax that are used in this specification.
 
 x (L):
 
-: Indicates that x is L bits long
+: Indicates that x is L bits long.
 
 x (i):
 
 : Indicates that x holds an integer value using the variable-length
-  encoding as described in ({{?RFC9000, Section 16}})
+  encoding as described in ({{?RFC9000, Section 16}}).
 
 x (..):
 
@@ -264,12 +264,12 @@ x (..):
 
 [x (L)]:
 
-: Indicates that x is optional and has a length of L
+: Indicates that x is optional and has a length of L.
 
 x (L) ...:
 
 : Indicates that x is repeated zero or more times and that each instance
-  has a length of L
+  has a length of L.
 
 This document extends the RFC9000 syntax and with the additional field types:
 
@@ -277,7 +277,7 @@ x (b):
 
 : Indicates that x consists of a variable length integer encoding as
   described in ({{?RFC9000, Section 16}}), followed by that many bytes
-  of binary data
+  of binary data.
 
 x (tuple):
 
@@ -329,10 +329,10 @@ Key-Value-Pair {
 
 * Type: an unsigned integer, encoded as a varint, identifying the
   type of the value and also the subsequent serialization.
-* Length: Only present when Type is odd. Specifies the length of the Value field.
-  The maximum length of a value is 2^16-1 bytes.  If an endpoint receives a
-  length larger than the maximum, it MUST close the session with a Protocol
-  Violation.
+* Length: Only present when Type is odd. Specifies the length of the Value field
+  in bytes. The maximum length of a value is 2^16-1 bytes.  If an endpoint
+  receives a length larger than the maximum, it MUST close the session with a
+  Protocol Violation.
 * Value: A single varint encoded value when Type is even, otherwise a
   sequence of Length bytes.
 
@@ -353,7 +353,7 @@ Reason Phrase {
 ~~~
 
 * Reason Phrase Length: A variable-length integer specifying the length of the
-  reason phrase in bytes. The reason phrase length has a maximum length of
+  reason phrase in bytes. The reason phrase length has a maximum value of
   1024 bytes. If an endpoint receives a length exceeding the maximum, it MUST
   close the session with a `PROTOCOL_VIOLATION`
 
@@ -498,10 +498,10 @@ Violation.
 Track Name is a sequence of bytes that identifies an individual track within the
 namespace.
 
-The maximum total length of a Full Track Name is 4,096 bytes, computed as the
-sum of the lengths of each Track Namespace tuple field and the Track Name length
-field.  If an endpoint receives a Full Track Name exceeding this length, it MUST
-close the session with a `PROTOCOL_VIOLATION`.
+The maximum total length of a Full Track Name is 4,096 bytes. The length of a Full
+Track Name is computed as the sum of the lengths of each Track Namespace tuple
+field and the Track Name length field.  If an endpoint receives a Full Track Name
+exceeding this length, it MUST close the session with a `PROTOCOL_VIOLATION`.
 
 In this specification, both the Track Namespace tuple fields and the Track Name
 are not constrained to a specific encoding. They carry a sequence of bytes and
@@ -632,8 +632,8 @@ This protocol does not specify any semantics on the `path-abempty` and
 `query` portions of the URI.  The contents of those are left up to the
 application.
 
-The client can establish a connection to a MoQ server identified by a given URI
-by setting up a QUIC connection to the host and port identified by the
+The client can establish a connection to an MOQT server identified by a given
+URI by setting up a QUIC connection to the host and port identified by the
 `authority` section of the URI. The `authority`, `path-abempty` and `query`
 portions of the URI are also transmitted in SETUP parameters (see
 {{setup-params}}).

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1281,7 +1281,7 @@ Track Namespace or Full Track Name. When a SUBSCRIBE message is sent, its Full
 Track Name is matched exactly against existing upstream subscriptions.
 
 Namespace Prefix Matching is further used to decide which publishers receive a
-SUBSCRIBE and which subscribers receive a PUBLISH. In this process, the subsets
+SUBSCRIBE and which subscribers receive a PUBLISH. In this process, the fields
 in the Track Namespace are matched sequentially, requiring an exact match for
 each field. If the published or subscribed Track Namespace has the same or fewer
 fields than the Track Namespace in the message, it qualifies as a match.
@@ -2973,7 +2973,7 @@ SUBSCRIBE_NAMESPACE Message {
   Type (i) = 0x11,
   Length (16),
   Request ID (i),
-  Track Namespace Prefix(Track Namespace),
+  Track Namespace Prefix (Track Namespace),
   Number of Parameters (i),
   Parameters (..) ...
 }

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -470,7 +470,7 @@ by doing a Fetch upstream, if necessary.
 Applications that cannot produce Group IDs that increase with time are limited
 to the subset of MOQT that does not compare group IDs. Subscribers to these
 Tracks SHOULD NOT use range filters which span multiple Groups in FETCH or
-SUBSCRIBE.  SUBSCRIBE and FETCH delivery use Group Order, so so they could have
+SUBSCRIBE.  SUBSCRIBE and FETCH delivery use Group Order, so they could have
 an unexpected delivery order if Group IDs do not increase with time.
 
 Note that the increase in time between two groups is not defined by the protocol.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -470,9 +470,8 @@ by doing a Fetch upstream, if necessary.
 Applications that cannot produce Group IDs that increase with time are limited
 to the subset of MOQT that does not compare group IDs. Subscribers to these
 Tracks SHOULD NOT use range filters which span multiple Groups in FETCH or
-SUBSCRIBE.  SUBSCRIBE and FETCH delivery use Group Order, so a FETCH cannot
-deliver Groups out of order and a subscription could have unexpected delivery
-order if Group IDs do not increase with time.
+SUBSCRIBE.  SUBSCRIBE and FETCH delivery use Group Order, so so they could have
+an unexpected delivery order if Group IDs do not increase with time.
 
 Note that the increase in time between two groups is not defined by the protocol.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -527,7 +527,8 @@ include:
 4. An Object is received whose Object ID is larger than the final Object in the
    Subgroup.  The final Object in a Subgroup is the last Object received on a
    Subgroup stream before a FIN.
-5. A Subgroup is received with two or more different final Objects.
+5. A Subgroup is received over multiple transport streams terminated by FIN with
+   different final Objects.
 6. An Object is received in a Group whose Object ID is larger than the final
    Object in the Group.  The final Object in a Group is the Object with Status
    END_OF_GROUP or the last Object sent in a FETCH that requested the entire
@@ -1442,7 +1443,7 @@ An endpoint that receives an unknown message type MUST close the session.
 Control messages have a length to make parsing easier, but no control messages
 are intended to be ignored. The length is set to the number of bytes in Message
 Payload, which is defined by each message type.  If the length does not match
-the length of the Message Payload, the receiver MUST close the session with
+the length of the Message Payload, the receiver MUST close the session with a
 `PROTOCOL_VIOLATION`.
 
 ## Request ID
@@ -1928,7 +1929,7 @@ that Group passes the filter. `End Group` MUST specify the same or a larger Grou
 than specified in `Start`.
 
 An endpoint that receives a filter type other than the above MUST be close the
-session with `PROTOCOL_VIOLATION`.
+session with a `PROTOCOL_VIOLATION`.
 
 Subscribe only delivers newly published or received Objects.  Objects from the
 past are retrieved using FETCH ({{message-fetch}}).
@@ -2673,7 +2674,7 @@ Values of 0x0 and those larger than 0x2 are a protocol error.
   Location.
 
   If End Location is smaller than the Start Location in the corresponding FETCH
-  the receiver MUST close the session with `PROTOCOL_VIOLATION`.
+  the receiver MUST close the session with a `PROTOCOL_VIOLATION`.
 
 * Parameters: The parameters are defined in {{version-specific-params}}.
 
@@ -2972,7 +2973,7 @@ is a relay that has received PUBLISH_NAMESPACE messages for namespaces
 "meeting=123", "participant=200"), a SUBSCRIBE_NAMESPACE for ("example.com",
 "meeting=123") would match both.  If an endpoint receives a Track Namespace
 Prefix tuple with an N of 0 or more than 32, it MUST close the session with a
-Protocol Violation.
+`PROTOCOL_VIOLATION`.
 
 * Parameters: The parameters are defined in {{version-specific-params}}.
 
@@ -3306,7 +3307,7 @@ There are 10 defined Type values for OBJECT_DATAGRAM.
 * Extensions Present: If Extensions Present is "Yes" the Extension Headers
   Length and Extension headers fields are included. If an endpoint receives a
   datagram with Extensions Present as "Yes" and a Extension Headers Length of 0,
-  it MUST close the session with PROTOCOL_VIOLATION.
+  it MUST close the session with a `PROTOCOL_VIOLATION`.
 
 * Object ID Present: If Object ID Present is No, the Object ID field is omitted
   and the Object ID is 0.  When Object ID Present is Yes, the Object ID field is


### PR DESCRIPTION
This PR suggests some editorial changes, including a fix for the remaining item in #536 (i.e., removal of the new field types (b) and (tuple)) and fixes for #1186, #1187, and #1190, and some changes that are very minor and obvious, to v14 of the MOQT draft.

Fixes: #1186
Fixes: #1187
Fixes: #1190 
Fixes: #536 