### PR TITLE
Add Forward to SUBSCRIBE_NAMESPACE

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2969,6 +2969,7 @@ SUBSCRIBE_NAMESPACE Message {
   Length (16),
   Request ID (i),
   Track Namespace Prefix (..),
+  Forward (8),
   Number of Parameters (i),
   Parameters (..) ...
 }
@@ -2986,6 +2987,12 @@ SUBSCRIBE_NAMESPACE Message {
   ("example.com", "meeting=123") would match both.  If an endpoint receives a
   Track Namespace Prefix consisting of 0 or greater than than 32 Track Namespace
   Fields, it MUST close the session with a `PROTOCOL_VIOLATION`.
+
+ 
+* Forward: The Forward value that new subscriptions resulting from this
+  SUBSCRIBE_NAMESPACE will have. If 0, the subscriber will be notified of all
+  available tracks in the namespace, but not receive Objects unless it changes
+  Forward to 1 in PUBLISH_OK.
 
 * Parameters: The parameters are defined in {{version-specific-params}}.
 


### PR DESCRIPTION
Because you might not want all the Objects for all Tracks until you find out what the Tracks are.

This has been discussed a number of times, including during the Params discussions, but I am not sure if it fixes any filed issues.