### PR TITLE
Remove Expires field from SUBSCRIBE_OK

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2157,7 +2157,6 @@ SUBSCRIBE_OK Message {
   Length (16),
   Request ID (i),
   Track Alias (i),
-  Expires (i),
   Group Order (8),
   Content Exists (8),
   [Largest Location (Location),]


### PR DESCRIPTION
The description was deleted and replaced with a parameter in #1012.  Removing the actual field was missed, but in the spirit of that PR, so marking this editorial.