### PR TITLE
Explain {Group, Object} notation

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -261,8 +261,10 @@ Location {
 ~~~
 {: #moq-location format title="Location structure"}
 
-In this document, the constituent parts of any Location A can be referred to
-using A.Group or A.Object.
+In this document, a Location can be expressed in the form of {GroupID,
+ObjectID}, where GroupID and ObjectID indicate the Group ID and Object ID of the
+Location, respectively.  The constituent parts of any Location A can be referred
+to using A.Group or A.Object.
 
 Location A < Location B if:
 


### PR DESCRIPTION
#1298 removed Location math to address #1251 but the reviewers felt like the existing text was clear enough.

Adding a note that {group, object} can be used to express a location.

Fixes: #1251