### PR TITLE
Allow unknown ranges in a FETCH response

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3661,14 +3661,14 @@ the Object ID.
 
 #### End of Range
 
-When Serialization Flags indicates an End of Range (e.g. values 0x8C or 0x10C), 
-the Group ID and Object ID
-fields are present.  Subgroup ID, Priority and Extensions are not present. All
-Objects with Locations between the last serialized Object, if any, and this
-Location, inclusive, either do not exist (when Serialization Flags is 0x8C) or
-are unknown (0x10C).  A publisher SHOULD NOT use `End of Non-Existent Range` in
-a FETCH response except to split a range of Objects that will not be serialized
-into those that are known not to exist and those with unknown status.
+When Serialization Flags indicates an End of Range (e.g. values 0x8C or 0x10C),
+the Group ID and Object ID fields are present.  Subgroup ID, Priority and
+Extensions are not present. All Objects with Locations between the last
+serialized Object, if any, and this Location, inclusive, either do not exist
+(when Serialization Flags is 0x8C) or are unknown (0x10C).  A publisher SHOULD
+NOT use `End of Non-Existent Range` in a FETCH response except to split a range
+of Objects that will not be serialized into those that are known not to exist
+and those with unknown status.
 
 ## Examples
 


### PR DESCRIPTION
This is a proposal to address several open FETCH issues.

Replace UNKNOWN_STATUS_IN_RANGE with a data-stream encoding of an UNKNOWN range.  This requires leaving DOES_NOT_EXIST serializations in fetch, so a omitted range can be split between DNE and UNKNOWN.  But that seems OK to me.

I'm unsure if it addresses #945 completely, but it gives a bandwidth constrained publisher another option that doesn't completely fail the fetch. (Ian believes it does resolve #945, unless others object)

Fixes: #1265 
Fixes: #1057 
Fixes: #945