### PR TITLE
Change SUBSCRIBE_UPDATE to REQUEST_UPDATE and expand ability to update

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2416,9 +2416,10 @@ SUBSCRIBE_OK Message {
 
 ## REQUEST_UPDATE {#message-request-update}
 
-The sender of a request can later send a REQUEST_UPDATE to modify it.  The
-receiver of a PUBLISH can also send REQUEST_UPDATE to modify subscriber sent
-parameters.
+The sender of a request (SUBSCRIBE, PUBLISH, FETCH, TRACK_STATUS,
+PUBLISH_NAMESPACE, SUBSCRIBE_NAMESPACE) can later send a REQUEST_UPDATE to
+modify it.  A subscriber can also send REQUEST_UPDATE to modify parameters of a
+subscription established with PUBLISH.
 
 The receiver of a REQUEST_UPDATE MUST respond with exactly one REQUEST_OK
 or REQUEST_ERROR message indicating if the update was successful.


### PR DESCRIPTION
This creates a mechanism to refresh auth credentials for PUBLISH, SUBSCRIBE_NAMESPACE and PUBLISH_NAMESPACE.

A side-effect is that it allows the subscriber to change the priority of a FETCH (we closed #1204 already but this would address it).

If we decide to address #1270, this will help.

Fixes: #1267 
Fixes: #1204