### PR TITLE
Consistent use of "`Established` subscription"

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1350,7 +1350,7 @@ the content associated with the Track. The authorization information can be part
 of request itself or part of the encompassing session. The specifics of how a
 relay authorizes a user are outside the scope of this specification.
 
-The relay MUST have an established upstream subscription before sending
+The relay MUST have an `Established` upstream subscription before sending
 SUBSCRIBE_OK in response to a downstream SUBSCRIBE.  If a relay does not have
 sufficient information to send a FETCH_OK immediately in response to a FETCH, it
 MUST withhold sending FETCH_OK until it does.
@@ -1943,7 +1943,7 @@ Relay Handling:
 A relay that receives a NEW_GROUP_REQUEST for a Track without an `Established`
 subscription MUST include the NEW_GROUP_REQUEST when subscribing upstream.
 
-A relay that receives a NEW_GROUP_REQUEST for an established subscription with a
+A relay that receives a NEW_GROUP_REQUEST for an `Established` subscription with a
 value of 0 or a value larger than the Largest Group MUST send a REQUEST_UPDATE
 including the NEW_GROUP_REQUEST to the publisher unless:
 
@@ -2927,7 +2927,7 @@ PUBLISH_NAMESPACE_CANCEL Message {
 ## SUBSCRIBE_NAMESPACE {#message-subscribe-ns}
 
 The subscriber sends the SUBSCRIBE_NAMESPACE control message to a publisher to
-request the current set of matching published namespaces and established
+request the current set of matching published namespaces and `Established`
 subscriptions, as well as future updates to the set.
 
 ~~~
@@ -2966,7 +2966,7 @@ the corresponding PUBLISH_NAMESPACE or PUBLISH_NAMESPACE_DONE message.
 
 A subscriber cannot make overlapping namespace subscriptions on a single
 session. Within a session, if a publisher receives a SUBSCRIBE_NAMESPACE with a
-Track Namespace Prefix that shares a common prefix with an established namespace
+Track Namespace Prefix that shares a common prefix with an `Established` namespace
 subscription, it MUST respond with REQUEST_ERROR with error code
 `PREFIX_OVERLAP`.
 


### PR DESCRIPTION
I was reviewing @afrind's #1332 and noticed a few places inconsistent use of "`Established` subscription", but I could not directly suggest changes for some of the places therein, then I tried reviewing in codespace, made the changes, but did not know how to suggest the changes, and by trial and error a couple of times, I ended up submitting this PR, which seems to not only include the minor changes for consistent use of "`Established` subscription", but also include all changes in #1332. 

@afrind Please feel free to apply the intended additional changes herein to your #1332 and then close this one.

