### PR TITLE
Duplicate subscription processing

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -947,7 +947,7 @@ with the same role, it MUST fail that request with a `DUPLICATE_SUBSCRIPTION`
 error.
 
 If a publisher receives a SUBSCRIBE request for a Track with an existing
-subscription not in `Pending (publisher)` state, it MUST fail that request with
+subscription in `Pending (publisher)` state, it MUST fail that request with
 a `DUPLICATE_SUBSCRIPTION` error. If a subscriber receives a PUBLISH for a Track
 with a subscription in the `Pending (Subscriber)` state, it MUST ensure the
 subscription it initiated transitions to the `Terminated` state before sending


### PR DESCRIPTION
1) Makes duplicate subscriptions a request error rather than a session error, since it can happen accidentally 2) explain who wins publish/subscribe races
3) update the state machine to indicate that the initiator of a subscription can cancel it from the pending state

We actually allow > 1 subscription to the same track in the same session, with self-subscribe.  The restriction is actually per track + role.

Fixes: #1340 