### PR TITLE
Put SUBSCRIBE_NAMESPACE on a stream, make Namespaces and PUBLISH independent

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -725,7 +725,10 @@ the endpoints exchange Setup messages ({{message-setup}}), followed by other
 messages defined in {{message}}.
 
 This specification only specifies two uses of bidirectional streams, the control
-stream and SUBSCRIBE_NAMESPACE. Objects are sent on unidirectional streams.
+stream, which begins with CLIENT_SETUP, and SUBSCRIBE_NAMESPACE. Bidirectional
+streams MUST NOT begin with any other message type unless negotiated. If they
+do, the peer MUST close the Session with a Protocol Violation. Objects are sent on
+unidirectional streams.
 
 A unidirectional stream containing Objects or bidirectional stream(s) containing a
 SUBSCRIBE_NAMESPACE could arrive prior to the control stream, in which case the


### PR DESCRIPTION
I did not remove Request ID entirely in this PR, because it makes the most sense to do that all at once, but I did create new 'NAMESPACE' and 'NAMESPACE_DONE' messages that are separate from PUBLISH_NAMESPACE/PUBLISH_NAMESPACE_DONE and much simpler.

Saves bytes on the wire by not repeating the 'Track Namespace Prefix' for every Namespace.

Removes UNSUBSCRIBE_NAMESPACE because we can just close the stream.

Fixes #1348 
Fixes #1310
Fixes #1305
Fixes part of #1168 
Fixes #843

Further possible changes:
  1) Don't send REQUEST_ERROR on errors, QUIC RESET_STREAM with the application error code. Loses Reason Phrase
  2) Don't send REQUEST_OK on success.  Loses response parameters.
  3) Allow for subscribing to full Track names and not just Namespaces.
  4) Prohibit sending NAMESPACE_DONE before a NAMESPACE is received for a SUBSCRIBE_NAMESPACE
  5) Add a PUBLISH_BLOCKED sent on the response stream when a new PUBLISH couldn't be sent #1262 
  6) Drop the length from NAMESPACE and NAMESPACE_DONE