### PR TITLE
Enable mixing datagrams with streams in one track

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1180,7 +1180,7 @@ MOQT maintains priorities between different schedulable objects.
 A schedulable object in MOQT is either:
 
 1. The first or next Object in a Subgroup that is in response to a subscription.
-2. An Object with delivery preference Datagram.
+2. An Object with forwarding preference Datagram.
 3. An Object in response to a FETCH where that Object is the next
    Object in the response.
 


### PR DESCRIPTION
As discussed in Toronto, Datagrams to be mixed with Subgroups in one single track should be allowed. (see #1103) 
This PR fixes the related descriptions in the draft.