### PR TITLE
Editorial: Unify sesion termination

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -299,7 +299,7 @@ Key-Value-Pair {
   sequence of Length bytes.
 
 If a receiver understands a Type, and the following Value or Length/Value does
-not match the serialization defined by that Type, the receiver MUST terminate
+not match the serialization defined by that Type, the receiver MUST close
 the session with error code `KEY_VALUE_FORMATTING_ERROR`.
 
 ### Reason Phrase Structure {#reason-phrase}
@@ -799,7 +799,7 @@ MOQT enables proactively draining sessions via the GOAWAY message ({{message-goa
 The server sends a GOAWAY message, signaling the client to establish a new
 session and migrate any `Established` subscriptions. The GOAWAY message optionally
 contains a new URI for the new session, otherwise the current URI is
-reused. The server SHOULD terminate the session with `GOAWAY_TIMEOUT` after a
+reused. The server SHOULD close the session with `GOAWAY_TIMEOUT` after a
 sufficient timeout if there are still open subscriptions or fetches on a
 connection.
 
@@ -1768,7 +1768,7 @@ not depend upon the forwarding preference. There is no explicit signal that an
 Object was not sent because the delivery timeout was exceeded.
 
 DELIVERY_TIMEOUT, if present, MUST contain a value greater than 0.  If an
-endpoint receives a DELIVERY_TIMEOUT equal to 0 it MUST terminate the session
+endpoint receives a DELIVERY_TIMEOUT equal to 0 it MUST close the session
 with `PROTOCOL_VIOLATION`.
 
 If both the subscriber and publisher specify the parameter, they use the min of
@@ -2084,7 +2084,7 @@ Upon receiving a GOAWAY, an endpoint SHOULD NOT initiate new requests to the
 peer including SUBSCRIBE, PUBLISH, FETCH, PUBLISH_NAMESPACE,
 SUBSCRIBE_NAMESPACE and TRACK_SATUS.
 
-The endpoint MUST terminate the session with a `PROTOCOL_VIOLATION`
+The endpoint MUST close the session with a `PROTOCOL_VIOLATION`
 ({{session-termination}}) if it receives multiple GOAWAY messages.
 
 ~~~
@@ -2106,7 +2106,7 @@ GOAWAY Message {
   maximum, it MUST close the session with a `PROTOCOL_VIOLATION`.
 
   If a server receives a GOAWAY with a non-zero New Session URI Length it MUST
-  terminate the session with a `PROTOCOL_VIOLATION`.
+  close the session with a `PROTOCOL_VIOLATION`.
 
 ## MAX_REQUEST_ID {#message-max-request-id}
 
@@ -2351,7 +2351,7 @@ When updating the Subscription Filter (see {{subscription-filters}}),
 the Start Location MUST not decrease, as an attempt to
 to do so could fail. If Objects with Locations smaller than the current
 subscription's Largest Location are required, FETCH can be used to retrieve
-them. A publisher MUST terminate the session with a `PROTOCOL_VIOLATION` if the
+them. A publisher MUST close the session with a `PROTOCOL_VIOLATION` if the
 SUBSCRIBE_UPDATE violates this rule.
 
 When a subscriber narrows their subscription (increase the Start Location and/or
@@ -3129,7 +3129,7 @@ are beyond the end of a group or track.
          {{malformed-tracks}}). This SHOULD be cached.
 
 Any other value SHOULD be treated as a protocol error and the session SHOULD
-be terminated with a `PROTOCOL_VIOLATION` ({{session-termination}}).
+be closed with a `PROTOCOL_VIOLATION` ({{session-termination}}).
 Any object with a status code other than zero MUST have an empty payload.
 
 #### Object Extension Header {#object-extensions}
@@ -3277,7 +3277,7 @@ There are 10 defined Type values for OBJECT_DATAGRAM.
 When Objects are sent on streams, the stream begins with a Subgroup or Fetch
 Header and is followed by one or more sets of serialized Object fields.
 If a stream ends gracefully (i.e., the stream terminates with a FIN) in the
-middle of a serialized Object, the session SHOULD be terminated with a
+middle of a serialized Object, the session SHOULD be closed with a
 `PROTOCOL_VIOLATION`.
 
 A publisher SHOULD NOT open more than one stream at a time with the same Subgroup


### PR DESCRIPTION
Unification makes it much easier to search through the document. Especially when backreferencing or validating an implementation. 

As advised publicly by Alan, I am not filing an editorial issue; instead, I am directly filling a PR.

Starting this as a single PR. Happy to split into multiple PRs or drop some changes if deemed better. I didn't want to unnecessarily pollute PRs. 

### Close session vs. terminate session:

I know the document has a `## Termination  {#session-termination}` section. But even in it, "terminate" and "close" are both used. I do think "close" is better, because there are other uses of the word "terminate". 

https://github.com/moq-wg/moq-transport/blob/586da24d41327cafc22dd4d886b5e2602d166116/draft-ietf-moq-transport.md?plain=1#L1288-L1289

Looking back at this, this may also need clarification.

I tried to do a minimum number of changes for unification, so I chose to use "close" for session and keep "termination" for streams and subscriptions.

Sorry if this is a wrong call; English is (obviously) not my 1st language. 
