### PR TITLE
Key-Value-Pairs Delta encoding editorial tweaks. 

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -275,8 +275,14 @@ Location A < Location B if:
 Key-Value-Pair is a flexible structure designed to carry key/value
 pairs in which the key is a variable length integer and the value
 is either a variable length integer or a byte field of arbitrary
-length. Key-Value-Pairs encode a Type value as a delta from the
-previous Type value, or from 0 if there is no previous Type value.
+length.
+
+Key-Value-Pairs encode a Type value as a delta from the previous Type value,
+or from 0 if there is no previous Type value. This is efficient on the wire
+and makes it easy to ensure there is only one instance of a type when needed.
+The previous Type value plus the Delta Type MUST NOT be greater than 2^64 - 1.
+If a Delta Type is received that would be too large, the Session MUST be closed
+with a `PROTOCOL_VIOLATION`.
 
 Key-Value-Pair is used in both the data plane and control plane, but
 is optimized for use in the data plane.
@@ -1628,12 +1634,7 @@ Receivers ignore unrecognized parameters.
 The number of parameters in a message is not specifically limited, but the
 total length of a control message is limited to 2^16-1 bytes.
 
-Parameters are serialized as Key-Value-Pairs {{moq-key-value-pair}} in
-increasing Parameter ID order with a delta encoding. This is efficient on the
-wire and makes it easy to ensure there is only one instance of parameters
-that cannot be repeated. The previous Type value plus the Delta Type MUST NOT be
-greater than 2^64 - 1.  If a Delta Type is received that would be too large, the Session
-MUST be closed with a `PROTOCOL_VIOLATION`.
+Parameters are serialized as Key-Value-Pairs {{moq-key-value-pair}}.
 
 Setup message parameters use a namespace that is constant across all MOQT
 versions. All other messages use a version-specific namespace.
@@ -3167,8 +3168,8 @@ definition of the extension, Extension Headers MAY be modified, added, removed,
 and/or cached by relays.
 
 Object Extension Headers are serialized as Key-Value-Pairs (see
-{{moq-key-value-pair}}) in increasing extension type order with a delta encoding,
-prefixed by the length of the serialized Key-Value-Pairs, in bytes.
+{{moq-key-value-pair}}), prefixed by the length of the serialized
+Key-Value-Pairs, in bytes.
 
 ~~~
 Extensions {


### PR DESCRIPTION
#1315 Follow up. 

Resubmitting my late-review proposal. I suspect my comment was ignored because getting a wire-format change into main without late unnecessary editorial discussion is good. That's why I am resubmitting. Editors, if I got that wrong, and you like the current wording, feel free to close this.

~I am not sure where the last-minute change of 2^62-1 to 2^64-1 came from. I think allowing bigger value than is encodable in a single delta is wrong. It doesn't really add any value and makes the handling complex, how is one supposed to encode it if needed without prior pairs? If I understand that wrongly and there is need for 2^64-1 I think there should be an explanation somewhere.~

I do think the size limit should be enforced for all Key-Value-Pairs. 

