### PR TITLE
Clarify handling of unknown extensions

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -618,10 +618,10 @@ concerning processing, modification, caching and forwarding.
 
 If unsupported by the relay, Extension Headers MUST NOT be modified, MUST be
 cached as part of the Track or Object and MUST be forwarded by relays.  If a
-Track or Object arrives with a different set of unknown extensions, the most
-recent set SHOULD replace any cached values, removing any unknown values not
-present in the new set.  Relays MUST NOT attempt to merge sets of unknown
-extensions received in different messages.
+Track or Object arrives with a different set of unknown extensions than
+previously cached, the most recent set SHOULD replace any cached values,
+removing any unknown values not present in the new set.  Relays MUST NOT attempt
+to merge sets of unknown extensions received in different messages.
 
 If supported by the relay and subject to the processing rules specified in the
 definition of the extension, Extension Headers MAY be modified, added, removed,


### PR DESCRIPTION
Per the issue:

* Supported extensions are processed according to their own rules
* Unsupported extensions are taken wholesale from a single publisher (no attempts to merge)
* Caches SHOULD serve the unknown extensions that arrived most recently (this allows publishers to "fix" corruption). SHOULD


Fixes: #1380