### PR TITLE
Remove reference to TRACK_STATUS_OK

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1604,8 +1604,8 @@ receiving the Objects on the same subscription.
 ## Relay Track Handling
 
 A relay MUST include all Extension Headers associated with a Track when sending any PUBLISH,
-SUBSCRIBE_OK, TRACK_STATUS_OK or FETCH_OK, unless allowed by the extension's
-specification (see {{extension-headers}}).
+SUBSCRIBE_OK, REQUEST_OK when in response to a TRACK_STATUS, or FETCH_OK, unless allowed by
+the extension's specification (see {{extension-headers}}).
 
 ## Relay Object Handling
 


### PR DESCRIPTION
We don't use TRACK_STATUS_OK any more, so I'm replacing the terminology here.