### PR TITLE
Copy DELIVERY_TIMEOUT min requirement from parameter to extension

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3767,9 +3767,9 @@ DELIVERY_TIMEOUT, if present, MUST contain a value greater than 0.  If an
 endpoint receives a DELIVERY_TIMEOUT equal to 0 it MUST close the session with
 `PROTOCOL_VIOLATION`.
 
-If both the subscriber specifies this parameter and the Track has a
-DELIVERY_TIMEOUT extension, the endpoints use the min of
-the two values for the subscription.
+If both the subscriber specifies a DELIVERY_TIMEOUT parameter and the Track has
+a DELIVERY_TIMEOUT extension, the endpoints use the min of the two values for
+the subscription.
 
 If unspecified, the subscriber's DELIVERY_TIMEOUT is used. If neither endpoint
 specified a timeout, Objects do not time out.


### PR DESCRIPTION
Duplicate the DELIVERY_TIMEOUT language from the parameter to the extension, so that it's clear what happens when both are present.