### PR TITLE
Remove TRACK_STATUS from REQUEST_UPDATE

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2442,7 +2442,7 @@ SUBSCRIBE_OK Message {
 
 ## REQUEST_UPDATE {#message-request-update}
 
-The sender of a request (SUBSCRIBE, PUBLISH, FETCH, TRACK_STATUS,
+The sender of a request (SUBSCRIBE, PUBLISH, FETCH,
 PUBLISH_NAMESPACE, SUBSCRIBE_NAMESPACE) can later send a REQUEST_UPDATE to
 modify it.  A subscriber can also send REQUEST_UPDATE to modify parameters of a
 subscription established with PUBLISH.


### PR DESCRIPTION
REQUEST_UPDATE should not have TRACK_STATUS mentioned as a sender. 

It also makes it consistent with this section

>Relays without an `Established` subscription MAY forward TRACK_STATUS to one or more
publishers, or MAY initiate a subscription (subject to authorization) as
described in {{publisher-interactions}} to determine the response. The publisher
does not send PUBLISH_DONE for this request, and the subscriber cannot send
REQUEST_UPDATE or UNSUBSCRIBE.