### PR TITLE
Remove subgroup ID from priority tiebreakers

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1395,10 +1395,9 @@ the objects SHOULD be selected as follows:
    decide the one that is scheduled to be sent first.
 3. If two objects in response to the same request have the same subscriber
    and publisher priority and belong to the same group of the same track, the
-   one with **the lowest Subgroup ID** (for objects with forwarding preference
-   Subgroup), or **the lowest Object ID** (for objects with forwarding preference
-   Datagram) is scheduled to be sent first.  If the two objects have
-   different Forwarding Preferences the order is implementation dependent.
+   one with **the lowest Object ID** is scheduled to be sent first.  For objects
+   with forwarding preference Subgroup, the first Object ID in the Subgroup is
+   used for comparison, providing a stable ordering for the entire Subgroup.
 
 The definition of "scheduled to be sent first" in the algorithm is implementation
 dependent and is constrained by the prioritization interface of the underlying


### PR DESCRIPTION
Replace it with "first object ID in the subgroup".

This is only for cases where the publisher set equal pri for multiple subgroups (eg: publisher has no preference).  It makes it easier to compare mixed datagram / subgroup tracks.

Fixes: #1405