### PR TITLE
Allow multiple Subscriptions to a Track

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1089,18 +1089,14 @@ subscriptions initiated by other endpoints, and all published Objects will be
 forwarded back to the endpoint, subject to priority and congestion response
 rules.
 
-For a given Track, an endpoint can have at most one subscription to a Track
-acting as the publisher and at most one acting as a subscriber.  If an endpoint
-receives a message attempting to establish a second subscription to a Track
-with the same role, it MUST fail that request with a `DUPLICATE_SUBSCRIPTION`
-error.
+For a given Track, an endpoint SHOULD avoid overlapping Subscriptions because
+it could be unclear which Subscription an Object is for. If a Publisher has
+multiple overlapping Subscriptions within a Session, it MAY send duplicate
+Objects.
 
-If a publisher receives a SUBSCRIBE request for a Track with an existing
-subscription in `Pending (publisher)` state, it MUST fail that request with
-a `DUPLICATE_SUBSCRIPTION` error. If a subscriber receives a PUBLISH for a Track
-with a subscription in the `Pending (Subscriber)` state, it MUST ensure the
-subscription it initiated transitions to the `Terminated` state before sending
-PUBLISH_OK.
+If a publisher receives an identical SUBSCRIBE request for a Track with an
+existing subscription in `Pending (publisher)` state, it MAY fail that request
+with a `DUPLICATE_SUBSCRIPTION` error.
 
 A publisher SHOULD begin sending incomplete objects when available to avoid
 incurring additional latency.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1089,10 +1089,10 @@ subscriptions initiated by other endpoints, and all published Objects will be
 forwarded back to the endpoint, subject to priority and congestion response
 rules.
 
-For a given Track, an endpoint SHOULD avoid overlapping Subscriptions because
-it could be unclear which Subscription an Object is for. If a Publisher has
-multiple overlapping Subscriptions within a Session, it MAY send duplicate
-Objects.
+For a given Track, an endpoint SHOULD avoid overlapping Subscriptions, because
+they can have the same Track Alias ({{track-alias}}), so it could be unclear
+which Subscription an Object is for. If a Publisher has multiple overlapping
+Subscriptions within a Session, it MAY send duplicate Objects.
 
 If a publisher receives an identical SUBSCRIBE request for a Track with an
 existing subscription in `Pending (publisher)` state, it MAY fail that request
@@ -3235,7 +3235,7 @@ session.
 Every Object has a 'Object Forwarding Preference' and the Original Publisher
 MAY use both Subgroups and Datagrams within a Group or Track.
 
-## Track Alias
+## Track Alias {#track-alias}
 
 To optimize wire efficiency, Subgroups and Datagrams refer to a track by a
 numeric identifier, rather than the Full Track Name.  Track Alias is chosen by
@@ -3246,6 +3246,8 @@ Objects can arrive after a subscription has been cancelled.  Subscribers SHOULD
 retain sufficient state to quickly discard these unwanted Objects, rather than
 treating them as belonging to an unknown Track Alias.
 
+If multiple Subscriptions are established for the same Track, the Publisher
+MAY use the same Track Alias for all of them, but it is not required to.
 
 ## Objects {#message-object}
 


### PR DESCRIPTION
This was motivated by the Filters PR #1401, though there are existing use cases, such as a relay wanting to propagate two disjoint SUBSCRIBEs from different Subscribers upstream on the same upstream Session.