### PR TITLE
Encode Message Parameters as TV

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1817,7 +1817,7 @@ Type Delta: The difference between this Parameter Type and the previous
    parameter. Parameters MUST be serialized in ascending order by Type.
 
 * Value: The encoding is specified by each parameter definition.
-The parameters defined in this draft are:
+The encodings defined in this draft are:
   * uint8: A single-byte unsigned integer (0-255)
   * varint: A variable-length integer
   * Location: Two consecutive varints (Group, Object)


### PR DESCRIPTION

- Type does not use even/odd convention
- Each parameter specifies its value encoding: uint8, varint, Location, or length-prefixed

Parameter encoding types:
- AUTHORIZATION TOKEN: length-prefixed
- DELIVERY TIMEOUT: varint
- SUBSCRIBER_PRIORITY: uint8
- GROUP_ORDER: uint8
- SUBSCRIPTION_FILTER: length-prefixed
- EXPIRES: varint
- LARGEST_OBJECT: Location
- FORWARD: uint8
- NEW_GROUP_REQUEST: varint

Setup Options continue to use Key-Value-Pairs encoding.

Fixes: #1184 