### PR TITLE
Delivery timeouts are both Track and Object Properties

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1953,9 +1953,9 @@ DELIVERY_TIMEOUT, if present, MUST contain a value greater than 0.  If an
 endpoint receives a DELIVERY_TIMEOUT equal to 0 it MUST close the session
 with `PROTOCOL_VIOLATION`.
 
-If both the subscriber specifies this parameter and the Track has a
-DELIVERY_TIMEOUT extension, the endpoints use the min of
-the two values for the subscription.
+If both the subscriber specifies this parameter and the publisher specifies a
+DELIVERY_TIMEOUT extension (Track or Object), the endpoints use the min of
+the two values for each Object.
 
 Publishers can, at their discretion, discontinue forwarding Objects earlier than
 the negotiated DELIVERY TIMEOUT, subject to stream closure and ordering
@@ -3819,17 +3819,19 @@ specifies whether it can be used with Tracks, Objects, or both.
 
 #### DELIVERY TIMEOUT {#delivery-timeout-ext}
 
-The DELIVERY TIMEOUT extension (Extension Header Type 0x02) is a Track
-Extension.  It expresses the publisher's DELIVERY_TIMEOUT for a Track (see
-{{delivery-timeout}}).
+The DELIVERY TIMEOUT extension (Extension Header Type 0x02) is a Track and
+Object Extension.  As a Track Extension, it expresses the publisher's
+DELIVERY_TIMEOUT for all Objects in the Track (see {{delivery-timeout}}).
+As an Object Extension, it expresses the publisher's DELIVERY_TIMEOUT for that
+specific Object, overriding any Track-level DELIVERY_TIMEOUT.
 
 DELIVERY_TIMEOUT, if present, MUST contain a value greater than 0.  If an
 endpoint receives a DELIVERY_TIMEOUT equal to 0 it MUST close the session with
 `PROTOCOL_VIOLATION`.
 
-If both the subscriber specifies a DELIVERY_TIMEOUT parameter and the Track has
-a DELIVERY_TIMEOUT extension, the endpoints use the min of the two values for
-the subscription.
+If the subscriber specifies a DELIVERY_TIMEOUT parameter, the endpoint uses the
+min of the subscriber's value and the publisher's value (whether from a Track or
+Object Extension) for each Object.
 
 If unspecified, the subscriber's DELIVERY_TIMEOUT is used. If neither endpoint
 specified a timeout, Objects do not time out.
@@ -4094,7 +4096,7 @@ TODO: register the URI scheme and the ALPN and grease the Extension types
 
 | Type | Name | Scope | Specification |
 |-----:|:-----|:------|:--------------|
-| 0x02 | DELIVERY_TIMEOUT | Track | {{delivery-timeout-ext}} |
+| 0x02 | DELIVERY_TIMEOUT | Track, Object | {{delivery-timeout-ext}} |
 | 0x04 | MAX_CACHE_DURATION | Track | {{max-cache-duration}} |
 | 0x0B | IMMUTABLE_EXTENSIONS | Track, Object | {{immutable-extensions}} |
 | 0x0E | DEFAULT_PUBLISHER_PRIORITY | Track | {{publisher-priority}} |

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1814,9 +1814,12 @@ are expressed in milliseconds; both are optional; a value of 0 means that
 there is no timeout set.
 
 The publisher communicates both timeout values as a Track Property; the
-subscriber communicates them as Message Parameters.  For each type of timeout,
-if both the publisher and the subscriber have a non-zero value, the smaller of
-the two is used.
+subscriber communicates them as Message Parameters.  Either timeout value can
+also be set as an Object Property on the first object in a subgroup, overriding
+the Track-level value for that subgroup.  For each type of timeout, the
+publisher's value is the Object Property when present on the first object of the
+subgroup, and the Track Property otherwise.  If both the publisher's value and
+the subscriber's value are non-zero, the smaller of the two is used.
 
 If the OBJECT_DELIVERY_TIMEOUT is not zero, the MOQT implementation MUST retain
 the time at which the first payload byte of every object has been either
@@ -4414,13 +4417,17 @@ See {{properties}} for usage guidance.
 
 ## SUBGROUP_DELIVERY_TIMEOUT {#subgroup-delivery-timeout-ext}
 
-SUBGROUP_DELIVERY_TIMEOUT (Property Type 0x06) is a Track Property.  It is a
-varint.  Its semantics are defined in {{delivery-timeouts}}.
+SUBGROUP_DELIVERY_TIMEOUT (Property Type 0x06) is a Track and Object Property.
+It is a varint.  Its semantics are defined in {{delivery-timeouts}}.  As an
+Object Property on the first object in a subgroup, it overrides the Track-level
+value for that subgroup.
 
 ## OBJECT_DELIVERY_TIMEOUT {#object-delivery-timeout-ext}
 
-OBJECT_DELIVERY_TIMEOUT (Property Type 0x02) is a Track Property.  It is a
-varint.  Its semantics are defined in {{delivery-timeouts}}.
+OBJECT_DELIVERY_TIMEOUT (Property Type 0x02) is a Track and Object Property.
+It is a varint.  Its semantics are defined in {{delivery-timeouts}}.  As an
+Object Property on the first object in a subgroup, it overrides the Track-level
+value for that subgroup.
 
 ## MAX CACHE DURATION {#max-cache-duration}
 
@@ -4984,9 +4991,9 @@ Setup Options SHOULD request a provisional registration.
 
 | Type | Name | Scope | Specification |
 |-----:|:-----|:------|:--------------|
-| 0x02 | OBJECT_DELIVERY_TIMEOUT | Track | {{object-delivery-timeout-ext}} |
+| 0x02 | OBJECT_DELIVERY_TIMEOUT | Track, Object | {{object-delivery-timeout-ext}} |
 | 0x04 | MAX_CACHE_DURATION | Track | {{max-cache-duration}} |
-| 0x06 | SUBGROUP_DELIVERY_TIMEOUT | Track | {{subgroup-delivery-timeout-ext}} |
+| 0x06 | SUBGROUP_DELIVERY_TIMEOUT | Track, Object | {{subgroup-delivery-timeout-ext}} |
 | 0x0B | IMMUTABLE_PROPERTIES | Track, Object | {{immutable-properties}} |
 | 0x0E | DEFAULT_PUBLISHER_PRIORITY | Track | {{publisher-priority}} |
 | 0x22 | DEFAULT_PUBLISHER_GROUP_ORDER | Track | {{group-order-pref}} |

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1816,7 +1816,9 @@ there is no timeout set.
 The publisher communicates both timeout values as a Track Property; the
 subscriber communicates them as Message Parameters.  Either timeout value can
 also be set as an Object Property on the first object in a subgroup, overriding
-the Track-level value for that subgroup.  For each type of timeout, the
+the Track-level value for that subgroup.  If either timeout is set as an Object
+Property on any object other than the first in a subgroup, it is ignored.  For
+each type of timeout, the
 publisher's value is the Object Property when present on the first object of the
 subgroup, and the Track Property otherwise.  If both the publisher's value and
 the subscriber's value are non-zero, the smaller of the two is used.
@@ -4420,14 +4422,14 @@ See {{properties}} for usage guidance.
 SUBGROUP_DELIVERY_TIMEOUT (Property Type 0x06) is a Track and Object Property.
 It is a varint.  Its semantics are defined in {{delivery-timeouts}}.  As an
 Object Property on the first object in a subgroup, it overrides the Track-level
-value for that subgroup.
+value for that subgroup; it is ignored on any other object in the subgroup.
 
 ## OBJECT_DELIVERY_TIMEOUT {#object-delivery-timeout-ext}
 
 OBJECT_DELIVERY_TIMEOUT (Property Type 0x02) is a Track and Object Property.
 It is a varint.  Its semantics are defined in {{delivery-timeouts}}.  As an
 Object Property on the first object in a subgroup, it overrides the Track-level
-value for that subgroup.
+value for that subgroup; it is ignored on any other object in the subgroup.
 
 ## MAX CACHE DURATION {#max-cache-duration}
 


### PR DESCRIPTION
 An Object Property on the first object in a subgroup overrides the Track-level value for that subgroup, for both OBJECT_DELIVERY_TIMEOUT and SUBGROUP_DELIVERY_TIMEOUT.
 
Fixes: #606