### PR TITLE
Add editorial text on bandwidth probing techniques

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -993,8 +993,8 @@ correction to probe for more bandwidth while also limiting the impact of probing
 in case it causes packet loss. Applications wanting to switch to an alternate
 representation of a Track can request that Track at a lower priority to probe.
 Applications can subscribe to additional tracks at the lowest (255) priority
-or use padding streams ({{padding-streams}}) to fill the congestion window
-during probing intervals while minimizing the impact on higher priority media.
+to fill the congestion window during probing intervals while minimizing the
+impact on higher priority media.
 Network-assisted bandwidth estimation mechanisms such as SCONE
 {{?I-D.ietf-scone-protocol}} can provide receivers with sustainable bandwidth hints,
 which subscribers can use to inform track selection decisions and potentially avoid


### PR DESCRIPTION
REMINDER: Retarget this to main instead of padding-streams

Note that applications can use lower-priority tracks or padding streams to probe for bandwidth, and that SCONE can provide network-assisted bandwidth hints to inform track selection.

Fixes: #370