### PR TITLE
Add Timeout field to GOAWAY message

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -948,10 +948,10 @@ MOQT enables proactively draining sessions via the GOAWAY message ({{message-goa
 The server sends a GOAWAY message, signaling the client to establish a new
 session and migrate any `Established` subscriptions. The GOAWAY message optionally
 contains a new URI for the new session, otherwise the current URI is
-reused. The GOAWAY message contains a Timeout indicating how long the server
-intends to wait before closing the session. The server SHOULD close the session
-with `GOAWAY_TIMEOUT` after the indicated timeout if there are still open
-subscriptions or fetches on a connection.
+reused. The GOAWAY message contains a Timeout indicating how long, in
+milliseconds, the sender intends to wait before closing the session. The sender
+SHOULD close the session with `GOAWAY_TIMEOUT` after the indicated timeout if
+there are still open subscriptions or fetches on a connection.
 
 When the server is a subscriber, it SHOULD send a GOAWAY message to downstream
 subscribers prior to any UNSUBSCRIBE messages to upstream publishers.
@@ -961,8 +961,8 @@ there are no more `Established` subscriptions before closing the session with NO
 Ideally this is transparent to the application using MOQT, which involves
 establishing a new session in the background and migrating `Established` subscriptions
 and published namespaces. The client can choose to delay closing the session if
-it expects more OBJECTs to be delivered. The server closes the session with a
-`GOAWAY_TIMEOUT` if the client doesn't close the session within the
+it expects more OBJECTs to be delivered. The sender closes the session with a
+`GOAWAY_TIMEOUT` if the peer doesn't close the session within the
 indicated Timeout.
 
 ## Congestion Control
@@ -2227,8 +2227,9 @@ that created the text.
 ## GOAWAY {#message-goaway}
 
 An endpoint sends a `GOAWAY` message to inform the peer it intends to close
-the session soon.  Servers can use GOAWAY to initiate session migration
-({{session-migration}}) with an optional URI.
+the session soon.  When sent by a server, it can initiate session migration
+({{session-migration}}) with an optional URI.  When sent by a client, the New
+Session URI MUST be zero length.
 
 The GOAWAY message does not impact subscription state. A subscriber
 SHOULD individually UNSUBSCRIBE for each existing subscription, while a
@@ -2273,8 +2274,7 @@ GOAWAY Message {
   gracefully closed before closing the session with `GOAWAY_TIMEOUT`. A value of
   0 indicates the sender has no specific timeout, and the recipient SHOULD still
   close the session as quickly as possible. This is a hint; the sender of the
-  GOAWAY MAY close the session before the indicated timeout has elapsed for
-  implementation specific reasons.
+  GOAWAY MAY close the session before the indicated timeout has elapsed.
 
 ## MAX_REQUEST_ID {#message-max-request-id}
 


### PR DESCRIPTION
Allow the sender of a GOAWAY to indicate how long it intends to wait before closing the session with GOAWAY_TIMEOUT. This lets the recipient pace its migration rather than racing to close the session.

Fixes: #1245