### PR TITLE
Fix "SUBSCRIBE_NAMESPACE with short prefixes"

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -4096,10 +4096,8 @@ maintenance for the session to be excessive.
 A Relay can use authorization rules in order to prevent subscriptions closer
 to the root of a large prefix tree. Otherwise, if an entity sends a relay a
 SUBSCRIBE_NAMESPACE message with a short prefix, it can cause the relay to send
-a large volume of PUBLISH_NAMESPACE messages. As churn continues in the tree of
-prefixes, the relay would have to continue to send
-PUBLISH_NAMESPACE/PUBLISH_NAMESPACE_DONE messages to the entity that had sent
-the SUBSCRIBE_NAMESPACE.
+a large volume of NAMESPACE messages. As changes occur in the tree of namespaces,
+the relay would have to send matching NAMESPACE/NAMESPACE_DONE messages.
 
 TODO: Security/Privacy Considerations of MOQT_IMPLEMENTATION parameter
 


### PR DESCRIPTION
I mostly wanted to fix the incorrect use of NAMESPACE and PUBLISH_NAMESPACE, but tried to improve the text as well.