### PR TITLE
Clarify track name text format parsing rules

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -422,6 +422,12 @@ example.2enet-team2-project_x--report
   Track name: report
 ~~~
 
+When parsing this format, implementations MUST accept both upper and lowercase
+hex digits (e.g., `.2E` and `.2e` are equivalent). Implementations MUST also
+accept hex-encoded bytes for characters that could be represented literally
+(e.g., `.61` for `a`). This ensures the encoding is canonical for output while
+remaining permissive for input.
+
 # Object Data Model {#model}
 
 MOQT has a hierarchical data model, comprised of tracks which contain


### PR DESCRIPTION
Add text specifying that when parsing the recommended text format for track names, implementations must accept both upper and lowercase hex digits and must accept hex-encoded bytes even when they could be represented literally. This makes encoding canonical but parsing permissive.

Fixes: #1501