### PR TITLE
Filters with reduced scope, no location or group filter

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1596,6 +1596,17 @@ Objects received with a location lower than the largest received in that track
 are ignored for track filter state updates; however, if the track is already
 selected, they pass the filter.
 
+### Relay Resource Protection in Large Namespaces
+
+Relays SHOULD aggregate and propagate filters upstream on subscriptions,
+especially namespace subscriptions including track selection filters,
+to conserve and protect their resources from excessive load.  They MAY
+also impose limits on the number of publishers in a namespace, by rejecting
+or closing namespace subscriptions with the error NAMESPACE_TOO_LARGE, or
+CONFLICTING_FILTERS if a track selection filter has non-uniform parameter
+values across a large number of subscribers, or PREFIX_OVERLAP if different
+subscribers force an aggregated upstream subscription to overlap.
+
 # Priorities {#priorities}
 
 MoQ priorities allow a subscriber and original publisher to influence
@@ -2791,6 +2802,11 @@ publishers than the relay is willing to enumerate.
 INVALID_JOINING_REQUEST_ID:
 : In response to a Joining FETCH, the referenced Request ID is not an
 `Established` Subscription.
+
+CONFLICTING_FILTERS:
+: In response to SUBSCRIBE_NAMESPACE, the filter parameters conflict among
+too many subscribers to aggregate the subscription upstream or otherwise
+efficiently service it.
 
 ## SUBSCRIBE {#message-subscribe-req}
 
@@ -4666,6 +4682,7 @@ the length field.
 | PREFIX_OVERLAP             | 0x30 | {{message-request-error}} |
 | NAMESPACE_TOO_LARGE        | 0x31 | {{message-request-error}} |
 | INVALID_JOINING_REQUEST_ID | 0x32 | {{message-request-error}} |
+| CONFLICTING_FILTERS        | 0x33 | {{message-request-error}} |
 | Reserved for greasing      | 0x7f * N + 0x9D | {{grease}} |
 
 ### PUBLISH_DONE Codes {#iana-publish-done}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3925,9 +3925,11 @@ Object in the Subgroup if at least one of the following is true:
    stream.
  * The Object was received on the same upstream Subgroup stream as the
    previously sent Object on the downstream Subgroup stream, with no other
-   Objects in between.
+   Objects in between, unless the intervening Objects did not pass the
+   subscriber's filters.
  * It determined all Object IDs between the current and previous Object IDs
-   on the Subgroup stream belong to different Subgroups or do not exist.
+   on the Subgroup stream belong to different Subgroups or do not exist,
+   or do not pass the subscriber's filters.
 
 If the relay does not know if an Object is the next Object, it MUST reset the
 Subgroup stream and open a new one to forward it.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1297,32 +1297,37 @@ Range Filters are parameters in subscriptions or fetches that tell a publisher
 to filter tracks and objects according to subscriber criteria which are
 allowed ranges of integer values in Track and Object Properties and other
 object header fields (Subgroup ID, Object ID, and Publisher Priority).
-
-There are four Range Filter parameter types, 0x25-0x28, each with a Length
-prefix in bytes and similar structures and behavior as summarized below.
+There are four Range Filter parameter types, 0x25-0x28, as shown below.
 
 ~~~
-SUBGROUP_FILTER { Type=0x25, Length, AndSet, Range... }
-  OBJECT_FILTER { Type=0x26, Length, AndSet, Range... }
-PRIORITY_FILTER { Type=0x27, Length, AndSet, Range... }
-PROPERTY_FILTER { Type=0x28, Length, AndSet, Property Type, Range... }
-          Range { Start (..), [End (..)] }
+SUBGROUP_FILTER { Type=0x25, Length, Set, Range... }
+OBJECTID_FILTER { Type=0x26, Length, Set, Range... }
+PRIORITY_FILTER { Type=0x27, Length, Set, Range... }
+PROPERTY_FILTER { Type=0x28, Length, Set, Property Type, Range... }
+          Range { Start, End }
 ~~~
 
-Each Range Filter is a Length (vi64) prefixed sequence of AndSet (8 bits) followed
-by Start/End inclusive Range pairs.
-Start is delta encoded from the prior Range's End (or from 0
-for the first Range), and End is delta encoded from the current Range's Start.
-The final End in a sequence of Ranges MAY be omitted to indicate no end.
+Each Range Filter is a sequence of Start/End (vi64) inclusive Range pairs
+prefixed with a Length (vi64) in bytes and a Set (8 bits).
+The Property Filter includes an additional prefix for Property Type (vi64).
+The final End in a sequence of Ranges can be omitted to indicate no end.
+
+Start is delta encoded from the prior Range's End or from 0
+for the first Range, and End is delta encoded from the current Range's Start.
 For example, to express ranges 3-5 and 10-15: the first Start is 3
 (delta from 0), the first End is 2 (5 minus 3), the second Start is 5
 (10 minus 5), and the second End is 5 (15 minus 10).
-All filter parameters with the same AndSet value are combined using logical
-"and" operations, then all the resulting sets are combined using logical "or"
-operations.
 
-These parameters MAY appear in a FETCH, SUBSCRIBE, SUBSCRIBE_NAMESPACE,
-PUBLISH_OK, or REQUEST_UPDATE (from a subscriber) message.
+All filter parameters with the same Set value are combined using logical
+"AND" operations, then all the resulting Sets are combined using logical
+"OR" operations.  The final result is Set=0 OR Set=1 OR ... Set=255,
+where each Set=i is the AND of filters with Set=i.
+
+These parameters MAY appear multiple times in a FETCH, SUBSCRIBE,
+SUBSCRIBE_NAMESPACE, PUBLISH_OK, or REQUEST_UPDATE (from a subscriber)
+message.  If the same combination of Parameter Type, Property Type
+(only in the Property Filter), and Set repeat in any message,
+an endpoint MUST close the session with a `PROTOCOL_VIOLATION`.
 
 A filter parameter with zero length indicates no filter, which can
 be used in REQUEST_UPDATE to remove the filter.  If a filter parameter
@@ -1337,12 +1342,16 @@ If this limit is exceeded, an endpoint MUST close the session with a
 
 ### Combining Filters
 
-All filter types are combined using logical "and" operations
+All filter types are combined using logical "AND" operations
 to further restrict which tracks and objects pass all filter criteria.
 This includes all Range Filters {{range-filters}}, Subscription Location
 Filters {{subscription-filters}}, and Track Filters {{track-filters}}.
 Track Filters always evaluate first before all other filters which can be
-evaluated in any order.
+evaluated in any order. The Forward parameter is also a type of filter.
+
+~~~
+Pass = Forward AND Location Filter AND Track Filter AND Range Filters
+~~~
 
 ### Joining an Ongoing Track
 
@@ -1566,7 +1575,8 @@ elapses before the track delivers an object that remains in the top N,
 either of which deselect the track.  The publisher MUST send a
 REQUEST_UPDATE message with Forward=0 when a track is deselected.
 The publisher MUST send a REQUEST_UPDATE message with Forward=1 when a
-deselected track is reselected, which also updates the Joining Location.
+deselected track is reselected, which also updates the Joining Location
+as described in {{joining-fetch-range-calculation}}.
 
 Recently deselected tracks SHOULD be kept in a list to avoid more PUBLISH
 messages in case a deselected track is reselected.  A relay SHOULD limit
@@ -2384,9 +2394,9 @@ unfiltered.  If omitted from REQUEST_UPDATE, the value is unchanged.
 The SUBGROUP_FILTER parameter (Type 0x25) selects objects with specified
 Ranges of Subgroup ID.  See {{range-filters}}.
 
-### OBJECT FILTER
+### OBJECTID FILTER
 
-The OBJECT_FILTER parameter (Type 0x26) selects objects with specified
+The OBJECTID_FILTER parameter (Type 0x26) selects objects with specified
 Ranges of Object ID.  See {{range-filters}}.
 
 ### PRIORITY FILTER
@@ -2401,7 +2411,7 @@ If a decoded value exceeds 255, the endpoint MUST close the session with a
 The PROPERTY_FILTER parameter (Type 0x28) selects tracks or objects with
 specified Ranges of Property Value for a specified Track or Object Property
 Type which MUST be even, i.e. a single integer value
-(see {{moq-key-value-pair}}).  The Length prefixed sequence contains AndSet
+(see {{moq-key-value-pair}}).  The Length prefixed sequence contains Set
 then Property Type followed by Property Value Range pairs.
 See {{range-filters}}.
 Range MAY be omitted to indicate no filter for the specified Property Type.
@@ -4600,7 +4610,7 @@ Setup Options SHOULD request a provisional registration.
 | 0x21 | SUBSCRIPTION_LOCATION_FILTER | {{subscription-filter}} |
 | 0x22 | GROUP_ORDER | {{group-order}} |
 | 0x25 | SUBGROUP_FILTER | {{subgroup-filter}} |
-| 0x26 | OBJECT_FILTER | {{object-filter}} |
+| 0x26 | OBJECTID_FILTER | {{objectid-filter}} |
 | 0x27 | PRIORITY_FILTER | {{priority-filter}} |
 | 0x28 | PROPERTY_FILTER | {{property-filter}} |
 | 0x29 | TRACK_FILTER | {{track-filter}} |

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -571,7 +571,7 @@ by doing a Fetch upstream, if necessary.
 
 Applications that cannot produce Group IDs that increase with time are limited
 to the subset of MOQT that does not compare group IDs. Subscribers to these
-Tracks SHOULD NOT use range filters which span multiple Groups in FETCH or
+Tracks SHOULD NOT use Location filters which span multiple Groups in FETCH or
 SUBSCRIBE.  SUBSCRIBE and FETCH delivery use Group Order, so they could have
 an unexpected delivery order if Group IDs do not increase with time.
 
@@ -1182,27 +1182,27 @@ A REQUEST_ERROR indicates no objects will be delivered, and both endpoints can
 immediately destroy relevant state. Objects MUST NOT be sent for requests that
 end with an error.
 
-### Subscription Filters {#subscription-filters}
+### Subscription Location Filters {#subscription-filters}
 
-Subscribers can specify a filter on a subscription indicating to the publisher
+Subscribers can specify a Location filter on a subscription indicating to the publisher
 which Objects to send.  Subscriptions without a filter pass all Objects
 published or received via upstream subscriptions.
 
-All filters have a Start Location and an optional End Group Delta.  Only objects
+All Location filters have a Start Location and an optional End Group Delta.  Only objects
 published or received via a subscription having Locations greater than or
 equal to Start Location and strictly less than or equal to the End Group (when
 present) pass the filter.
 
-Some filters are defined to be relative to the `Largest Object`. The `Largest
+Some Location filters are defined to be relative to the `Largest Object`. The `Largest
 Object` is the Object with the largest Location ({{location-structure}}) in the
 Track from the perspective of the publisher processing the message. Largest
 Object updates when the first byte of an Object with a Location larger than the
 previous value is published or received through a subscription.
 
-A Subscription Filter has the following structure:
+A Subscription Location Filter has the following structure:
 
 ~~~
-Subscription Filter {
+Subscription Location Filter {
   Filter Type (vi64),
   [Start Location (Location),]
   [End Group Delta (vi64),]
@@ -1240,6 +1240,49 @@ delivered will the Group ID in 'Start Location' plus the 'End Group Delta'.
 
 An endpoint that receives a filter type other than the above MUST close the
 session with `PROTOCOL_VIOLATION`.
+
+### Range Filters
+
+Range Filters are parameters in subscriptions or fetches that tell a publisher
+to filter tracks and objects according to subscriber criteria which are
+allowed ranges of integer values in Track and Object Properties and other
+object header fields (Subgroup ID, Object ID, and Publisher Priority).
+
+There are four Range Filter types, with odd values between 0x25-0x2B
+(length prefixed), with similar structures and behavior as summarized below.
+
+~~~
+SUBGROUP_FILTER { Type=0x25, Length, Range... }
+  OBJECT_FILTER { Type=0x26, Length, Range... }
+PRIORITY_FILTER { Type=0x27, Length, Range... }
+PROPERTY_FILTER { Type=0x28, Length, Property Type, Range... }
+          Range { Start (..), [End (..)] }
+~~~
+
+Range Filters use a common Range structure of Start and End values, delta encoded
+from the prior End and Start values, respectively, or from 0 if no prior value.
+The final End in a sequence of Ranges MAY be omitted to indicate no end.
+
+These parameters MAY appear in a FETCH, SUBSCRIBE, SUBSCRIBE_NAMESPACE,
+PUBLISH_OK, or REQUEST_UPDATE (from a subscriber) message.
+
+A filter parameter with zero length indicates no filter, which can
+be used in REQUEST_UPDATE to remove the filter.  If a filter parameter
+is omitted from REQUEST_UPDATE, the value is unchanged.  If omitted
+from other messages, the default is no filter.
+
+Range Filters are only allowed if the setup option MAX_FILTER_RANGES
+is non-zero, which limits the total number of Ranges allowed concurrently
+in all Range Filter parameters for a given subscription or fetch.
+If this limit is exceeded, an endpoint MUST close the session with a
+`PROTOCOL_VIOLATION`.
+
+### Combining Filters
+
+All filter types are combined using logical "and" operations
+to further restrict which tracks and objects pass all filter criteria.
+This includes all Range Filters {{range-filters}}, Subscription Location
+Filters {{subscription-filters}}, and Track Filters {{track-filters}}.
 
 ### Joining an Ongoing Track
 
@@ -1389,6 +1432,82 @@ has accepted a PUBLISH_NAMESPACE with a namespace that exactly matches the
 namespace for that track, it SHOULD only request it from the senders of those
 PUBLISH_NAMESPACE messages.
 
+# Filtering Namespaces
+
+Range Filters {{range-filters}} and Track Filters {{track-filters}} can be used
+in SUBSCRIBE_NAMESPACE (or REQUEST_UPDATE for SUBSCRIBE_NAMESPACE) to filter
+tracks and objects in a namespace.
+
+### Track Filters
+
+The TRACK_FILTER parameter {{track-filter}} selects a specified number of tracks
+within a namespace with the highest Property Values for a specified Track or
+Object Property Type which MUST be even (single integer value).
+
+It is encoded with a Length prefix which MAY be zero to indicate no filter,
+which can be used to remove the filter in REQUEST_UPDATE.
+
+~~~
+TRACK_FILTER Parameter {
+  Type (vi64) = 0x29,
+  Length (vi64),
+  Property Type (vi64),
+  MaxTracksSelected (vi64),
+  MaxTracksDeselected (vi64),
+  MaxTimeSelected (vi64)
+}
+~~~
+
+MaxTracksSelected limits the number of tracks selected concurrently,
+which MUST NOT exceed the MAX_TRACKS_SELECTED setup option value sent
+by the peer.
+
+MaxTracksDeselected limits the number of tracks to keep in a list
+of deselected tracks, which MUST NOT exceed the MAX_TRACKS_DESELECTED
+setup option value sent by the peer.
+
+MaxTimeSelected limits the number of milliseconds a selected track
+can remain selected without publishing an object with Property Type.
+
+#### Track Selection
+
+A track is selected if it publishes an object with the top N highest
+value for Property Type, where N = MaxTracksSelected.  The publisher
+MUST send a PUBLISH message for each newly selected track.  For tracks
+with the same value, the earliest delivered object wins the tie
+breaker, so a selected track remains selected until another track
+delivers a higher value that drops it from the top N, or
+MaxTimeSelected elapses before the track delivers an object that remains
+in the top N, either of which deselect the track.  The last M deselected
+tracks are kept in a list, where M = MaxTracksDeselected, to avoid more
+PUBLISH messages in case a deselected track is reselected.  When a track
+drops from this list because it is older than the last M, the publisher
+MUST send a PUBLISH_DONE message to avoid excess old subscription state.
+If a track is reselected after this, it is considered newly selected
+so the publisher MUST send a PUBLISH message again.
+Endpoints should set MaxTracksDeselected and MAX_TRACKS_DESELECTED
+high enough to avoid excessive control messages but low enough to
+avoid excessive old subscription state.
+
+If the TRACK_FILTER parameter is updated, the publisher evaluates the
+new filter to determine the new list of top N selected and last M deselected
+tracks, and follows the same rules above for newly selected tracks in the
+top N (send PUBLISH) and old deselected tracks that drop from the last M
+(send PUBLISH_DONE).
+
+If a track filter for a namespace overlaps with a direct subscription
+to a track in the same namespace, the publisher MUST deliver the
+direct track subscription unaltered by track filter actions.
+The direct track subscription MAY be in the top N or last M lists,
+but MUST NOT stop object delivery upon track filter deselection nor
+send PUBLISH_DONE upon dropping from the last M list.
+
+The track filter evaluates both Track and Object Properties.
+If a track has a Track Property of the specified Property Type, then its
+PUBLISH message must pass the filter, and each of its published objects
+lacking that Property Type are evaluated as if they included it.
+If the PUBLISH message failed to pass the filter, no objects from
+that track can be delivered.
 
 # Priorities {#priorities}
 
@@ -2125,14 +2244,58 @@ close the session with `PROTOCOL_VIOLATION`.
 If omitted from SUBSCRIBE, the publisher's preference from
 the Track is used. If omitted from FETCH, the receiver uses Ascending (0x1).
 
-### SUBSCRIPTION FILTER Parameter {#subscription-filter}
+### SUBSCRIPTION LOCATION FILTER Parameter {#subscription-filter}
 
-The SUBSCRIPTION_FILTER parameter (Parameter Type 0x21) uses length-prefixed
+The SUBSCRIPTION_LOCATION_FILTER parameter (Parameter Type 0x21) uses length-prefixed
 encoding. It MAY appear in a SUBSCRIBE, PUBLISH_OK or REQUEST_UPDATE (for a
-subscription) message. It is a Subscription Filter (see {{subscription-filters}}).
+subscription) message. It is a Subscription Location Filter (see {{subscription-filters}}).
 
 If omitted from SUBSCRIBE or PUBLISH_OK, the subscription is
 unfiltered.  If omitted from REQUEST_UPDATE, the value is unchanged.
+
+### SUBGROUP FILTER
+
+The SUBGROUP_FILTER parameter (Type 0x25) selects objects with specified
+Ranges of Subgroup ID.  It is a Length (vi64) prefixed sequence of
+Subgroup ID (vi64) Start/End inclusive Range pairs.  See {{range-filters}}.
+
+### OBJECT FILTER
+
+The OBJECT_FILTER parameter (Type 0x26) selects objects with specified
+Ranges of Object ID.  It is a Length (vi64) prefixed sequence of
+Object ID (vi64) Start/End inclusive Range pairs.  See {{range-filters}}.
+
+### PRIORITY FILTER
+
+The PRIORITY_FILTER parameter (Type 0x27) selects objects with specified
+Ranges of Publisher Priority.  It is a Length (vi64) prefixed sequence of
+Publisher Priority (8 bit) Start/End inclusive Range pairs.  See {{range-filters}}.
+
+### PROPERTY FILTER
+
+The PROPERTY_FILTER parameter (Type 0x28) selects tracks or objects with
+specified Ranges of Property Value for a specified Track or Object Property
+Type which MUST be even (single integer Value).  It is a Length (vi64)
+prefixed sequence of Property Type (vi64) followed by Property Value (vi64)
+Start/End inclusive Range pairs.  See {{range-filters}}.
+Range MAY be omitted to indicate no filter for the specified Property Type.
+Length MAY be zero to indicate no filter for all Property Types.
+This parameter MAY be repeated within a message with different values for
+Property Type.
+
+If a track has a Track Property of the specified Property Type, then its
+PUBLISH message must pass the filter, and each of its published objects
+lacking that Property Type are evaluated as if they included it.
+If the PUBLISH message failed to pass the filter, no objects from
+that track can be delivered.
+
+### TRACK FILTER
+
+The TRACK_FILTER parameter (Type=0x29) MAY appear in a SUBSCRIBE_NAMESPACE
+or REQUEST_UPDATE (for SUBSCRIBE_NAMESPACE) message. It selects a specified
+number of tracks within a namespace with the highest Property Values for a
+specified Track or Object Property Type which MUST be even (single integer value).
+See {{track-filters}} and {{max-tracks-selected}}.
 
 ### EXPIRES Parameter {#expires}
 
@@ -2339,6 +2502,28 @@ advertising or other nonessential information. Implementations SHOULD NOT use
 the identifiers of other implementations to declare compatibility, as this
 undermines the usefulness of implementation identification for debugging.
 
+#### MAX FILTER RANGES
+
+The MAX_FILTER_RANGES option (Type 0x06) limits the peer's total number of Ranges
+(Start/End pairs) allowed concurrently in all Range filter {{range-filters}}
+parameters for a given subscription or fetch.  The default value is 0, so if not
+specified, the peer MUST NOT send any such filter parameters.  If this limit is
+exceeded, an endpoint MUST close the session with a `PROTOCOL_VIOLATION`.
+
+#### MAX TRACKS SELECTED
+
+The MAX_TRACKS_SELECTED option (Type 0x08) limits the peer's value of
+MaxTracksSelected in the TRACK_FILTER {{track-filter}} parameter.
+The default value is 0, so if not specified, the peer MUST NOT send any
+TRACK_FILTER parameter.  If this limit is exceeded, an endpoint MUST close the
+session with a `PROTOCOL_VIOLATION`.
+
+#### MAX TRACKS DESELECTED
+
+The MAX_TRACKS_DESELECTED option (Type 0x0A) limits the peer's value of
+MaxTracksDeselected in the TRACK_FILTER {{track-filter}} parameter.
+The default value is 0.  If this limit is exceeded, an endpoint MUST close the
+session with a `PROTOCOL_VIOLATION`.
 
 ## GOAWAY {#message-goaway}
 
@@ -2601,7 +2786,7 @@ On successful subscription, the publisher MUST reply with a SUBSCRIBE_OK,
 allowing the subscriber to determine the start group/object when not explicitly
 specified, and start sending objects.
 
-If the publisher cannot satisfy the requested Subscription Filter (see
+If the publisher cannot satisfy the requested Subscription Location Filter (see
 {{subscription-filter}}) or if the entire End Group has already been published
 it SHOULD send a REQUEST_ERROR with code `INVALID_RANGE`.  A publisher MUST
 NOT send objects from outside the requested range.
@@ -2683,7 +2868,7 @@ REQUEST_UPDATE Message {
 
 ### Updating Subscriptions
 
-When a subscriber decreases the Start Location of the Subscription Filter
+When a subscriber decreases the Start Location of the Subscription Location Filter
 (see {{subscription-filters}}), the Start Location can be smaller than the Track's
 Largest Location, similar to a new Subscription. FETCH can be used to retrieve
 any necessary Objects smaller than the current Largest Location.
@@ -4364,6 +4549,11 @@ TODO: register the URI scheme and the ALPN
 | 0x20 | SUBSCRIBER_PRIORITY | {{subscriber-priority}} |
 | 0x21 | SUBSCRIPTION_FILTER | {{subscription-filter}} |
 | 0x22 | GROUP_ORDER | {{group-order}} |
+| 0x25 | SUBGROUP_FILTER | {{subgroup-filter}} |
+| 0x26 | OBJECT_FILTER | {{object-filter}} |
+| 0x27 | PRIORITY_FILTER | {{priority-filter}} |
+| 0x28 | PROPERTY_FILTER | {{property-filter}} |
+| 0x29 | TRACK_FILTER | {{track-filter}} |
 | 0x32 | NEW_GROUP_REQUEST | {{new-group-request}} |
 
 * Message Parameters - List which params can be repeated in the table.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1302,20 +1302,24 @@ There are four Range Filter parameter types, 0x25-0x28, each with a Length
 prefix in bytes and similar structures and behavior as summarized below.
 
 ~~~
-SUBGROUP_FILTER { Type=0x25, Length, Range... }
-  OBJECT_FILTER { Type=0x26, Length, Range... }
-PRIORITY_FILTER { Type=0x27, Length, Range... }
-PROPERTY_FILTER { Type=0x28, Length, Property Type, Range... }
+SUBGROUP_FILTER { Type=0x25, Length, AndSet, Range... }
+  OBJECT_FILTER { Type=0x26, Length, AndSet, Range... }
+PRIORITY_FILTER { Type=0x27, Length, AndSet, Range... }
+PROPERTY_FILTER { Type=0x28, Length, AndSet, Property Type, Range... }
           Range { Start (..), [End (..)] }
 ~~~
 
-Each Range Filter is a Length (vi64) prefixed sequence of Start/End inclusive
-Range pairs. Start is delta encoded from the prior Range's End (or from 0
+Each Range Filter is a Length (vi64) prefixed sequence of AndSet (8 bits) followed
+by Start/End inclusive Range pairs.
+Start is delta encoded from the prior Range's End (or from 0
 for the first Range), and End is delta encoded from the current Range's Start.
 The final End in a sequence of Ranges MAY be omitted to indicate no end.
 For example, to express ranges 3-5 and 10-15: the first Start is 3
 (delta from 0), the first End is 2 (5 minus 3), the second Start is 5
 (10 minus 5), and the second End is 5 (15 minus 10).
+All filter parameters with the same AndSet value are combined using logical
+"and" operations, then all the resulting sets are combined using logical "or"
+operations.
 
 These parameters MAY appear in a FETCH, SUBSCRIBE, SUBSCRIBE_NAMESPACE,
 PUBLISH_OK, or REQUEST_UPDATE (from a subscriber) message.
@@ -2397,8 +2401,8 @@ If a decoded value exceeds 255, the endpoint MUST close the session with a
 The PROPERTY_FILTER parameter (Type 0x28) selects tracks or objects with
 specified Ranges of Property Value for a specified Track or Object Property
 Type which MUST be even, i.e. a single integer value
-(see {{moq-key-value-pair}}).  The Length prefixed sequence contains
-Property Type followed by Property Value Range pairs.
+(see {{moq-key-value-pair}}).  The Length prefixed sequence contains AndSet
+then Property Type followed by Property Value Range pairs.
 See {{range-filters}}.
 Range MAY be omitted to indicate no filter for the specified Property Type.
 Length MAY be zero to indicate no filter for all Property Types.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3265,7 +3265,8 @@ The publisher responding to a FETCH is
 responsible for delivering all available Objects in the requested range in the
 requested order (see {{group-order}}). The Objects in the response are delivered on a single
 unidirectional stream. Any gaps in the Group and Object IDs in the response
-stream indicate objects that do not exist.  For Ascending Group Order this
+stream indicate objects that do not exist unless filters were requested.
+For Ascending Group Order this
 includes ranges between the first requested object and the first object in the
 stream; between objects in the stream; and between the last object in the
 stream and the Largest Group/Object indicated in FETCH_OK, so long as the fetch

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1248,8 +1248,8 @@ to filter tracks and objects according to subscriber criteria which are
 allowed ranges of integer values in Track and Object Properties and other
 object header fields (Subgroup ID, Object ID, and Publisher Priority).
 
-There are four Range Filter types, with odd values between 0x25-0x2B
-(length prefixed), with similar structures and behavior as summarized below.
+There are four Range Filter parameter types, 0x25-0x28, each with a Length
+prefix and similar structures and behavior as summarized below.
 
 ~~~
 SUBGROUP_FILTER { Type=0x25, Length, Range... }

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1560,7 +1560,7 @@ elapses before the track delivers an object that remains in the top N,
 either of which deselect the track.  The publisher MUST send a 
 REQUEST_UPDATE message with Forward=0 when a track is deselected.
 The publisher MUST send a REQUEST_UPDATE message with Forward=1 when a
-deselected track is reselected.
+deselected track is reselected, which also updates the Joining Location.
 
 Recently deselected tracks SHOULD be kept in a list to avoid more PUBLISH
 messages in case a deselected track is reselected.  A relay SHOULD limit
@@ -2613,13 +2613,6 @@ The MAX_TRACKS_SELECTED option (Type 0x08) limits the peer's value of
 MaxTracksSelected in the TRACK_FILTER {{track-filter}} parameter.
 The default value is 0, so if not specified, the peer MUST NOT send any
 TRACK_FILTER parameter.  If this limit is exceeded, an endpoint MUST close the
-session with a `PROTOCOL_VIOLATION`.
-
-#### MAX TRACKS DESELECTED
-
-The MAX_TRACKS_DESELECTED option (Type 0x0A) limits the peer's value of
-MaxTracksDeselected in the TRACK_FILTER {{track-filter}} parameter.
-The default value is 0.  If this limit is exceeded, an endpoint MUST close the
 session with a `PROTOCOL_VIOLATION`.
 
 ## GOAWAY {#message-goaway}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1576,8 +1576,8 @@ limit state  |    +---> REQ UPD FWD=1 --->|   Tracks   |
 A track is selected if it publishes an object with the top N highest
 value for Property Type, where N = MaxTracksSelected.  The publisher
 MUST send a PUBLISH message for each newly selected track.  For tracks
-with the same value, the earliest delivered object wins the tie
-breaker, so a selected track remains selected until another track
+with the same value, the track with the earliest delivered object wins
+the tie breaker, so a selected track remains selected until another track
 publishes a higher value that demotes it out of the top N, or Timeout
 elapses before the track delivers an object that remains in the top N,
 either of which deselect the track.  The publisher MUST send a

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1337,6 +1337,8 @@ All filter types are combined using logical "and" operations
 to further restrict which tracks and objects pass all filter criteria.
 This includes all Range Filters {{range-filters}}, Subscription Location
 Filters {{subscription-filters}}, and Track Filters {{track-filters}}.
+Track Filters always evaluate first before all other filters which can be
+evaluated in any order.
 
 ### Joining an Ongoing Track
 
@@ -1589,6 +1591,10 @@ If a track has a Track Property of the specified Property Type, its value
 is used for filtering both the PUBLISH message and any Objects from that track
 that lack their own value for that Property Type.  If the Track Property value
 does not pass the filter, no Objects from that track are delivered.
+
+Objects received with a location lower than the largest received in that track
+are ignored for track filter state updates; however, if the track is already
+selected, they pass the filter.
 
 # Priorities {#priorities}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1259,9 +1259,13 @@ PROPERTY_FILTER { Type=0x28, Length, Property Type, Range... }
           Range { Start (..), [End (..)] }
 ~~~
 
-Range Filters use a common Range structure of Start and End values, delta encoded
-from the prior End and Start values, respectively, or from 0 if no prior value.
+Each Range Filter is a Length (vi64) prefixed sequence of Start/End inclusive
+Range pairs. Start is delta encoded from the prior Range's End (or from 0
+for the first Range), and End is delta encoded from the current Range's Start.
 The final End in a sequence of Ranges MAY be omitted to indicate no end.
+For example, to express ranges 3-5 and 10-15: the first Start is 3
+(delta from 0), the first End is 2 (5 minus 3), the second Start is 5
+(10 minus 5), and the second End is 5 (15 minus 10).
 
 These parameters MAY appear in a FETCH, SUBSCRIBE, SUBSCRIBE_NAMESPACE,
 PUBLISH_OK, or REQUEST_UPDATE (from a subscriber) message.
@@ -1442,7 +1446,8 @@ tracks and objects in a namespace.
 
 The TRACK_FILTER parameter {{track-filter}} selects a specified number of tracks
 within a namespace with the highest Property Values for a specified Track or
-Object Property Type which MUST be even (single integer value).
+Object Property Type which MUST be even, i.e. a single integer value
+(see {{moq-key-value-pair}}).
 
 It is encoded with a Length prefix which MAY be zero to indicate no filter,
 which can be used to remove the filter in REQUEST_UPDATE.
@@ -1460,7 +1465,7 @@ TRACK_FILTER Parameter {
 
 MaxTracksSelected limits the number of tracks selected concurrently,
 which MUST NOT exceed the MAX_TRACKS_SELECTED setup option value sent
-by the peer.
+by the peer.  A value of 0 is a `PROTOCOL_VIOLATION`.
 
 MaxTracksDeselected limits the number of tracks to keep in a list
 of deselected tracks, which MUST NOT exceed the MAX_TRACKS_DESELECTED
@@ -1485,7 +1490,7 @@ drops from this list because it is older than the last M, the publisher
 MUST send a PUBLISH_DONE message to avoid excess old subscription state.
 If a track is reselected after this, it is considered newly selected
 so the publisher MUST send a PUBLISH message again.
-Endpoints should set MaxTracksDeselected and MAX_TRACKS_DESELECTED
+Endpoints SHOULD set MaxTracksDeselected and MAX_TRACKS_DESELECTED
 high enough to avoid excessive control messages but low enough to
 avoid excessive old subscription state.
 
@@ -1503,11 +1508,10 @@ but MUST NOT stop object delivery upon track filter deselection nor
 send PUBLISH_DONE upon dropping from the last M list.
 
 The track filter evaluates both Track and Object Properties.
-If a track has a Track Property of the specified Property Type, then its
-PUBLISH message must pass the filter, and each of its published objects
-lacking that Property Type are evaluated as if they included it.
-If the PUBLISH message failed to pass the filter, no objects from
-that track can be delivered.
+If a track has a Track Property of the specified Property Type, its value
+is used for filtering both the PUBLISH message and any Objects from that track
+that lack their own value for that Property Type.  If the Track Property value
+does not pass the filter, no Objects from that track are delivered.
 
 # Priorities {#priorities}
 
@@ -2256,45 +2260,46 @@ unfiltered.  If omitted from REQUEST_UPDATE, the value is unchanged.
 ### SUBGROUP FILTER
 
 The SUBGROUP_FILTER parameter (Type 0x25) selects objects with specified
-Ranges of Subgroup ID.  It is a Length (vi64) prefixed sequence of
-Subgroup ID (vi64) Start/End inclusive Range pairs.  See {{range-filters}}.
+Ranges of Subgroup ID.  See {{range-filters}}.
 
 ### OBJECT FILTER
 
 The OBJECT_FILTER parameter (Type 0x26) selects objects with specified
-Ranges of Object ID.  It is a Length (vi64) prefixed sequence of
-Object ID (vi64) Start/End inclusive Range pairs.  See {{range-filters}}.
+Ranges of Object ID.  See {{range-filters}}.
 
 ### PRIORITY FILTER
 
 The PRIORITY_FILTER parameter (Type 0x27) selects objects with specified
-Ranges of Publisher Priority.  It is a Length (vi64) prefixed sequence of
-Publisher Priority (8 bit) Start/End inclusive Range pairs.  See {{range-filters}}.
+Ranges of Publisher Priority.  See {{range-filters}}.
+If a decoded value exceeds 255, the endpoint MUST close the session with a
+`PROTOCOL_VIOLATION` since Publisher Priority is an 8-bit field.
 
 ### PROPERTY FILTER
 
 The PROPERTY_FILTER parameter (Type 0x28) selects tracks or objects with
 specified Ranges of Property Value for a specified Track or Object Property
-Type which MUST be even (single integer Value).  It is a Length (vi64)
-prefixed sequence of Property Type (vi64) followed by Property Value (vi64)
-Start/End inclusive Range pairs.  See {{range-filters}}.
+Type which MUST be even, i.e. a single integer value
+(see {{moq-key-value-pair}}).  The Length prefixed sequence contains
+Property Type followed by Property Value Range pairs.
+See {{range-filters}}.
 Range MAY be omitted to indicate no filter for the specified Property Type.
 Length MAY be zero to indicate no filter for all Property Types.
 This parameter MAY be repeated within a message with different values for
-Property Type.
+Property Type.  If the Property Type is odd, the endpoint MUST close the
+session with a `PROTOCOL_VIOLATION`.
 
-If a track has a Track Property of the specified Property Type, then its
-PUBLISH message must pass the filter, and each of its published objects
-lacking that Property Type are evaluated as if they included it.
-If the PUBLISH message failed to pass the filter, no objects from
-that track can be delivered.
+If a track has a Track Property of the specified Property Type, its value
+is used for filtering both the PUBLISH message and any Objects from that track
+that lack their own value for that Property Type.  If the Track Property value
+does not pass the filter, no Objects from that track are delivered.
 
 ### TRACK FILTER
 
 The TRACK_FILTER parameter (Type=0x29) MAY appear in a SUBSCRIBE_NAMESPACE
 or REQUEST_UPDATE (for SUBSCRIBE_NAMESPACE) message. It selects a specified
 number of tracks within a namespace with the highest Property Values for a
-specified Track or Object Property Type which MUST be even (single integer value).
+specified Track or Object Property Type which MUST be even, i.e. a single
+integer value (see {{moq-key-value-pair}}).
 See {{track-filters}} and {{max-tracks-selected}}.
 
 ### EXPIRES Parameter {#expires}
@@ -4547,7 +4552,7 @@ TODO: register the URI scheme and the ALPN
 | 0x09 | LARGEST_OBJECT | {{largest-param}} |
 | 0x10 | FORWARD | {{forward-parameter}} |
 | 0x20 | SUBSCRIBER_PRIORITY | {{subscriber-priority}} |
-| 0x21 | SUBSCRIPTION_FILTER | {{subscription-filter}} |
+| 0x21 | SUBSCRIPTION_LOCATION_FILTER | {{subscription-filter}} |
 | 0x22 | GROUP_ORDER | {{group-order}} |
 | 0x25 | SUBGROUP_FILTER | {{subgroup-filter}} |
 | 0x26 | OBJECT_FILTER | {{object-filter}} |

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1533,8 +1533,7 @@ TRACK_FILTER Parameter {
   Type (vi64) = 0x29,
   Length (vi64),
   Property Type (vi64),
-  MaxTracksSelected (vi64),
-  Timeout (vi64)
+  MaxTracksSelected (vi64)
 }
 ~~~
 
@@ -1542,8 +1541,9 @@ MaxTracksSelected limits the number of tracks selected concurrently,
 which MUST NOT exceed the MAX_TRACKS_SELECTED setup option value sent
 by the peer.  A value of 0 is a `PROTOCOL_VIOLATION`.
 
-Timeout limits the number of milliseconds a selected track can remain
-selected without publishing an object with Property Type.
+TrackFilterTimeout is a Track Property that limits the number of
+milliseconds a selected track can remain selected without publishing
+an object with Property Type.
 
 #### Track Selection
 
@@ -4290,6 +4290,11 @@ for this Track. If an endpoint receives a value larger than 1, it MUST close
 the session with `PROTOCOL_VIOLATION`.
 
 If omitted, the value is 0.
+
+## TRACK FILTER TIMEOUT {#track-filter-timeout}
+
+TRACK_FILTER_TIMEOUT (Property Type 0x32) is a Track Property.
+See {{track-filter}}. If omitted, the value is 1 second.
 
 ## Immutable Properties
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1314,6 +1314,7 @@ The final End in a sequence of Ranges can be omitted to indicate no end.
 
 Start is delta encoded from the prior Range's End or from 0
 for the first Range, and End is delta encoded from the current Range's Start.
+Any delta encoding that exceeds 2^64-1 is a `PROTOCOL_VIOLATION`.
 For example, to express ranges 3-5 and 10-15: the first Start is 3
 (delta from 0), the first End is 2 (5 minus 3), the second Start is 5
 (10 minus 5), and the second End is 5 (15 minus 10).

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1341,6 +1341,13 @@ in all Range Filter parameters for a given subscription or fetch.
 If this limit is exceeded, an endpoint MUST close the session with a
 `PROTOCOL_VIOLATION`.
 
+The Property Filter {{property-filter}} and Track Filter {{track-filters}}
+evaluate both Track and Object Properties.
+If a track has a Track Property of the specified Property Type, its value
+is used for filtering both the PUBLISH message and any Objects from that track
+that lack their own value for that Property Type.  If the Track Property value
+does not pass the filter, no Objects from that track are delivered.
+
 ### Combining Filters
 
 All filter types are combined using logical "AND" operations
@@ -1581,7 +1588,7 @@ as described in {{joining-fetch-range-calculation}}.
 
 Recently deselected tracks SHOULD be kept in a list to avoid more PUBLISH
 messages in case a deselected track is reselected.  A relay SHOULD limit
-this list size if it consumes excessive resources by sending PUBLISH_DONE
+this list size to protect its resources by sending PUBLISH_DONE
 messages to purge state for the oldest deselected tracks, putting them
 back in the unknown state.  If a track is reselected after this, it is
 considered newly selected so the publisher MUST send a PUBLISH message
@@ -1600,12 +1607,6 @@ If a track filter for a namespace overlaps with a direct subscription
 to a track name in the same namespace, it is considered to pass the
 track filter whether or not it is counted in the top N list, and MUST NOT
 be subject to track filter state changes or actions.
-
-The track filter evaluates both Track and Object Properties.
-If a track has a Track Property of the specified Property Type, its value
-is used for filtering both the PUBLISH message and any Objects from that track
-that lack their own value for that Property Type.  If the Track Property value
-does not pass the filter, no Objects from that track are delivered.
 
 Objects received with a location lower than the largest received in that track
 are ignored for track filter state updates; however, if the track is already
@@ -2414,11 +2415,6 @@ specified Ranges of Property Value for a specified Track or Object Property
 Type which MUST be even, i.e. a single integer value
 (see {{moq-key-value-pair}}), otherwise the endpoint MUST close the
 session with a `PROTOCOL_VIOLATION`. See {{range-filters}}.
-
-If a track has a Track Property of the specified Property Type, its value
-is used for filtering both the PUBLISH message and any Objects from that track
-that lack their own value for that Property Type.  If the Track Property value
-does not pass the filter, no Objects from that track are delivered.
 
 ### TRACK FILTER
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1548,7 +1548,7 @@ limit state  |    +---> REQ UPD FWD=1 --->|   Tracks   |
              |    |       Reselected      +------------+
              |    |                             |
         +--------------+                        |
-        |  DESELECTED  |<---- REQ UPD FWD=0 <---+ 
+        |  DESELECTED  |<---- REQ UPD FWD=0 <---+
         | out of Top N |     Demoted/Timeout
         +--------------+
 
@@ -1563,7 +1563,7 @@ with the same value, the earliest delivered object wins the tie
 breaker, so a selected track remains selected until another track
 publishes a higher value that demotes it out of the top N, or Timeout
 elapses before the track delivers an object that remains in the top N,
-either of which deselect the track.  The publisher MUST send a 
+either of which deselect the track.  The publisher MUST send a
 REQUEST_UPDATE message with Forward=0 when a track is deselected.
 The publisher MUST send a REQUEST_UPDATE message with Forward=1 when a
 deselected track is reselected, which also updates the Joining Location.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1299,7 +1299,7 @@ allowed ranges of integer values in Track and Object Properties and other
 object header fields (Subgroup ID, Object ID, and Publisher Priority).
 
 There are four Range Filter parameter types, 0x25-0x28, each with a Length
-prefix and similar structures and behavior as summarized below.
+prefix in bytes and similar structures and behavior as summarized below.
 
 ~~~
 SUBGROUP_FILTER { Type=0x25, Length, Range... }
@@ -1492,8 +1492,8 @@ PUBLISH_NAMESPACE messages.
 ## Filtering Namespaces
 
 Range Filters {{range-filters}} and Track Filters {{track-filters}} can be used
-in SUBSCRIBE_NAMESPACE (or REQUEST_UPDATE for SUBSCRIBE_NAMESPACE) to filter
-tracks and objects in a namespace.
+in SUBSCRIBE_NAMESPACE (or REQUEST_UPDATE for it) to filter tracks and objects
+in a namespace.
 
 ### Track Filters
 
@@ -1502,8 +1502,8 @@ within a namespace with the highest Property Values for a specified Track or
 Object Property Type which MUST be even, i.e. a single integer value
 (see {{moq-key-value-pair}}).
 
-It is encoded with a Length prefix which MAY be zero to indicate no filter,
-which can be used to remove the filter in REQUEST_UPDATE.
+It is encoded with a Length prefix in bytes which MAY be zero to indicate
+no filter, which can be used to remove the filter in REQUEST_UPDATE.
 
 ~~~
 TRACK_FILTER Parameter {
@@ -1511,8 +1511,7 @@ TRACK_FILTER Parameter {
   Length (vi64),
   Property Type (vi64),
   MaxTracksSelected (vi64),
-  MaxTracksDeselected (vi64),
-  MaxTimeSelected (vi64)
+  Timeout (vi64)
 }
 ~~~
 
@@ -1520,45 +1519,70 @@ MaxTracksSelected limits the number of tracks selected concurrently,
 which MUST NOT exceed the MAX_TRACKS_SELECTED setup option value sent
 by the peer.  A value of 0 is a `PROTOCOL_VIOLATION`.
 
-MaxTracksDeselected limits the number of tracks to keep in a list
-of deselected tracks, which MUST NOT exceed the MAX_TRACKS_DESELECTED
-setup option value sent by the peer.
-
-MaxTimeSelected limits the number of milliseconds a selected track
-can remain selected without publishing an object with Property Type.
+Timeout limits the number of milliseconds a selected track can remain
+selected without publishing an object with Property Type.
 
 #### Track Selection
+
+Tracks are promoted to the selected state, demoted to the
+deselected state, or purged back to the unknown state as
+shown in the following diagram. Objects only pass the filter
+for tracks in the selected state.
+
+~~~
+        +--------------+
+        +   UNKNOWN    |
+        +  name/alias  |
+        +--------------+
+             ^    |
+             |    |     Newly Selected    +------------+
+PUBLISH_DONE |    +---> PUBLISH FWD=1 --->|  SELECTED  |
+as needed to |             Promoted       |  in Top N  |
+limit state  |    +---> REQ UPD FWD=1 --->|   Tracks   |
+             |    |       Reselected      +------------+
+             |    |                             |
+        +--------------+                        |
+        |  DESELECTED  |<---- REQ UPD FWD=0 <---+ 
+        | out of Top N |     Demoted/Timeout
+        +--------------+
+
+          Objects FAIL                     Objects PASS
+           the filter                       the filter
+~~~
 
 A track is selected if it publishes an object with the top N highest
 value for Property Type, where N = MaxTracksSelected.  The publisher
 MUST send a PUBLISH message for each newly selected track.  For tracks
 with the same value, the earliest delivered object wins the tie
 breaker, so a selected track remains selected until another track
-delivers a higher value that drops it from the top N, or
-MaxTimeSelected elapses before the track delivers an object that remains
-in the top N, either of which deselect the track.  The last M deselected
-tracks are kept in a list, where M = MaxTracksDeselected, to avoid more
-PUBLISH messages in case a deselected track is reselected.  When a track
-drops from this list because it is older than the last M, the publisher
-MUST send a PUBLISH_DONE message to avoid excess old subscription state.
-If a track is reselected after this, it is considered newly selected
-so the publisher MUST send a PUBLISH message again.
-Endpoints SHOULD set MaxTracksDeselected and MAX_TRACKS_DESELECTED
-high enough to avoid excessive control messages but low enough to
-avoid excessive old subscription state.
+publishes a higher value that demotes it out of the top N, or Timeout
+elapses before the track delivers an object that remains in the top N,
+either of which deselect the track.  The publisher MUST send a 
+REQUEST_UPDATE message with Forward=0 when a track is deselected.
+The publisher MUST send a REQUEST_UPDATE message with Forward=1 when a
+deselected track is reselected.
+
+Recently deselected tracks SHOULD be kept in a list to avoid more PUBLISH
+messages in case a deselected track is reselected.  A relay SHOULD limit
+this list size if it consumes excessive resources by sending PUBLISH_DONE
+messages to purge state for the oldest deselected tracks, putting them
+back in the unknown state.  If a track is reselected after this, it is
+considered newly selected so the publisher MUST send a PUBLISH message
+again.  Relays SHOULD keep a list size large enough to avoid excessive
+control messages but small enough to avoid excessive old subscription state.
 
 If the TRACK_FILTER parameter is updated, the publisher evaluates the
-new filter to determine the new list of top N selected and last M deselected
-tracks, and follows the same rules above for newly selected tracks in the
-top N (send PUBLISH) and old deselected tracks that drop from the last M
-(send PUBLISH_DONE).
+new filter to determine the new list of top N selected tracks and follows
+the same rules above for newly selected tracks in the top N (send PUBLISH),
+reselected tracks in the top N (send REQUEST_UPDATE with Forward=1), and
+newly deselected tracks demoted out of the top N (send REQUEST_UPDATE
+with Forward=0).  It can also purge excessive old deselected tracks as
+needed (send PUBLISH_DONE).
 
 If a track filter for a namespace overlaps with a direct subscription
-to a track in the same namespace, the publisher MUST deliver the
-direct track subscription unaltered by track filter actions.
-The direct track subscription MAY be in the top N or last M lists,
-but MUST NOT stop object delivery upon track filter deselection nor
-send PUBLISH_DONE upon dropping from the last M list.
+to a track name in the same namespace, it is considered to pass the
+track filter whether or not it is counted in the top N list, and MUST NOT
+be subject to track filter state changes or actions.
 
 The track filter evaluates both Track and Object Properties.
 If a track has a Track Property of the specified Property Type, its value

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1330,8 +1330,8 @@ message.  If the same combination of Parameter Type, Property Type
 (only in the Property Filter), and Set repeat in any message,
 an endpoint MUST close the session with a `PROTOCOL_VIOLATION`.
 
-A filter parameter with zero length indicates no filter, which can
-be used in REQUEST_UPDATE to remove the filter.  If a filter parameter
+Length can be 0 or 1 in REQUEST_UPDATE to remove a filter parameter
+for all Sets or a specified Set, respectively.  If a filter parameter
 is omitted from REQUEST_UPDATE, the value is unchanged.  If omitted
 from other messages, the default is no filter.
 
@@ -2412,14 +2412,8 @@ If a decoded value exceeds 255, the endpoint MUST close the session with a
 The PROPERTY_FILTER parameter (Type 0x28) selects tracks or objects with
 specified Ranges of Property Value for a specified Track or Object Property
 Type which MUST be even, i.e. a single integer value
-(see {{moq-key-value-pair}}).  The Length prefixed sequence contains Set
-then Property Type followed by Property Value Range pairs.
-See {{range-filters}}.
-Range MAY be omitted to indicate no filter for the specified Property Type.
-Length MAY be zero to indicate no filter for all Property Types.
-This parameter MAY be repeated within a message with different values for
-Property Type.  If the Property Type is odd, the endpoint MUST close the
-session with a `PROTOCOL_VIOLATION`.
+(see {{moq-key-value-pair}}), otherwise the endpoint MUST close the
+session with a `PROTOCOL_VIOLATION`. See {{range-filters}}.
 
 If a track has a Track Property of the specified Property Type, its value
 is used for filtering both the PUBLISH message and any Objects from that track
@@ -2432,7 +2426,8 @@ The TRACK_FILTER parameter (Type=0x29) MAY appear in a SUBSCRIBE_NAMESPACE
 or REQUEST_UPDATE (for SUBSCRIBE_NAMESPACE) message. It selects a specified
 number of tracks within a namespace with the highest Property Values for a
 specified Track or Object Property Type which MUST be even, i.e. a single
-integer value (see {{moq-key-value-pair}}).
+integer value (see {{moq-key-value-pair}}), otherwise the endpoint MUST
+close the session with a `PROTOCOL_VIOLATION`.
 See {{track-filters}} and {{max-tracks-selected}}.
 
 ### EXPIRES Parameter {#expires}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1432,7 +1432,7 @@ has accepted a PUBLISH_NAMESPACE with a namespace that exactly matches the
 namespace for that track, it SHOULD only request it from the senders of those
 PUBLISH_NAMESPACE messages.
 
-# Filtering Namespaces
+## Filtering Namespaces
 
 Range Filters {{range-filters}} and Track Filters {{track-filters}} can be used
 in SUBSCRIBE_NAMESPACE (or REQUEST_UPDATE for SUBSCRIBE_NAMESPACE) to filter


### PR DESCRIPTION
Rename existing subscription filter to subscription location filter to disambiguate from new range filters and track filter.
Add range filters for subgroup ID, object ID, priority, and property under subscribe section.
Add track filter under subscribe namespace section.
Add setup options and parameters for new filters.