### PR TITLE
Clarify Required Request ID ordering semantics

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1891,10 +1891,11 @@ is computed as:
 ~~~
 
 A Required Request ID Delta of 0 indicates no dependency. When
-a dependency exists, the receiver MUST deliver the referenced
-request to the application before delivering the dependent
-request. If the required request does not arrive, the receiver
-will time out the dependent request.
+a dependency exists, the receiver MUST NOT process the dependent
+request before the referenced request. This is an ordering
+constraint only; the referenced request does not need to complete
+successfully. If the referenced request does not arrive, the
+receiver will time out the dependent request.
 
 The delta is scaled by two because request IDs from each endpoint
 use alternating parity (odd or even), so valid dependencies always


### PR DESCRIPTION
Replace "deliver to the application" with "process" to remove ambiguity about what it means to handle a required request. Add clarification that the dependency is an ordering constraint only and the referenced request does not need to succeed.

Fixes: #1522
Fixes: #1523