### PR TITLE
Clarify REQUEST_UPDATE failure behavior for all request types

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2692,8 +2692,8 @@ When a subscriber narrows their subscription (increase the Start Location and/or
 decrease the End Group), it might still receive Objects outside the
 new range if the publisher sent them before the update was processed.
 
-When a subscription
-update is unsuccessful, the publisher MUST also terminate the subscription with
+When a REQUEST_UPDATE is unsuccessful, the publisher MUST also terminate
+the subscription by sending a
 PUBLISH_DONE with error code `UPDATE_FAILED`. When a REQUEST_UPDATE fails for
 a FETCH, the publisher MUST reset the FETCH data stream. When a REQUEST_UPDATE
 fails for a SUBSCRIBE_NAMESPACE or PUBLISH_NAMESPACE, the responder MUST close


### PR DESCRIPTION
Specify what happens when REQUEST_UPDATE fails for request types other than SUBSCRIBE/PUBLISH: FETCH data stream is reset, and SUBSCRIBE_NAMESPACE/PUBLISH_NAMESPACE bidi streams are closed.

Fixes: #1456