### PR TITLE
Allow coalescing REQUEST_UPDATE processing

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2696,6 +2696,13 @@ When a subscription
 update is unsuccessful, the publisher MUST also terminate the subscription with
 PUBLISH_DONE with error code `UPDATE_FAILED`.
 
+A receiver of multiple REQUEST_UPDATE messages on the same stream MAY
+coalesce their processing by applying only the cumulative result.
+Parameter values from later REQUEST_UPDATE messages override values
+from earlier ones. The receiver MUST still send a REQUEST_OK or
+REQUEST_ERROR in response to each REQUEST_UPDATE, but it is not
+required to process intermediate states individually.
+
 ## PUBLISH {#message-publish}
 
 The publisher sends PUBLISH as the first message on a new bidirectional stream

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2707,9 +2707,12 @@ the bidi stream.
 A receiver of multiple REQUEST_UPDATE messages on the same stream MAY
 coalesce their processing by applying only the cumulative result.
 Parameter values from later REQUEST_UPDATE messages override values
-from earlier ones. The receiver MUST still send a REQUEST_OK or
-REQUEST_ERROR in response to each REQUEST_UPDATE, but it is not
-required to process intermediate states individually.
+from earlier ones. The receiver MUST still send a REQUEST_OK for
+each successful update, but it is not required to process
+intermediate states individually. If the coalesced REQUEST_UPDATE
+results in REQUEST_ERROR, only a single REQUEST_ERROR will be
+sent and the sender of the REQUEST_UPDATEs will not always be
+able to determine which caused an error.
 
 ## PUBLISH {#message-publish}
 


### PR DESCRIPTION
Clarify that a receiver of multiple REQUEST_UPDATE messages may coalesce their processing by applying only the cumulative result, since parameter values are last-one-wins. Each REQUEST_UPDATE still requires its own REQUEST_OK or REQUEST_ERROR response.

Fixes: #1433