### PR TITLE
RFC: Add SEND_RATE parameter for paced FETCH delivery

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2303,9 +2303,9 @@ The subscriber can update the send rate during an active fetch by
 sending a REQUEST_UPDATE with a new SEND_RATE value.
 
 The publisher SHOULD pace Object delivery to approximately the requested
-rate.  The publisher MAY exceed the requested rate in short bursts, for
-example at the beginning of a Group, to allow the subscriber to build
-an initial buffer.  The publisher MUST NOT use SEND_RATE to pace below
+rate.  The rate limit is a request only and is not guaranteed. The publisher MAY
+exceed the requested rate in short bursts.  The publisher MUST NOT use SEND_RATE
+to pace below
 the congestion controller's minimum rate; the congestion controller's
 behavior takes precedence.
 


### PR DESCRIPTION
Add a SEND_RATE Message Parameter for FETCH and REQUEST_UPDATE that allows a subscriber to request the publisher pace Object delivery at a specified rate in kbps. This reduces bufferbloat and packet loss for VoD/catch-up content where the congestion controller would otherwise burst data far above the needed rate. A value of 0 or absence of the parameter means no pacing constraint.

Fixes: #1453