### PR TITLE
Fix grease examples to match 0x7f multiplier

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -4285,7 +4285,7 @@ fail when encountering protocol extensions they do not understand, this document
 reserves a range of values for the purpose of greasing; see {{Section 3.3 of ?RFC9170}}.
 
 Grease values follow the pattern `0x7f * N + 0x9D` for non-negative
-integer values of N (that is, 0x9D, 0xBC, ..., 0x3ffffffffffffffe).
+integer values of N (that is, 0x9D, 0x11C, ..., 0x3fffffffffffffde).
 
 The following registries include GREASE reservations:
 


### PR DESCRIPTION
The examples and upper bound did not match the formula 0x7f * N + 0x9D.

Fixes: #1568