### PR TITLE
Add Track Properties to REQUEST_OK

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2482,7 +2482,9 @@ REQUEST_OK Message {
   length of Track Properties is the remaining length of the message
   after parsing all previous fields. Track Properties are populated in
   response to TRACK_STATUS messages; they are empty in response to
-  REQUEST_UPDATE, SUBSCRIBE_NAMESPACE and PUBLISH_NAMESPACE.
+  REQUEST_UPDATE, SUBSCRIBE_NAMESPACE and PUBLISH_NAMESPACE.  If an
+  endpoint receives Track Properties in response to one of these messages
+  it MUST close the session with a `PROTOCOL_VIOLATION`.
 
 ## REQUEST_ERROR {#message-request-error}
 


### PR DESCRIPTION
This allows Track Properties to be conveyed in response to TRACK_STATUS requests, which was previously not possible since REQUEST_OK did not include them.

Track Properties are populated in response to TRACK_STATUS messages and empty in response to REQUEST_UPDATE,
SUBSCRIBE_NAMESPACE, and PUBLISH_NAMESPACE.

Fixes: #1563