### PR TITLE
Clarify Joining Fetch ordering with Forward State transitions

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2955,11 +2955,10 @@ with a certain number of groups prior to the live edge of a track.
 A Joining Fetch is only permitted when the associated subscription has
 Forward State 1; otherwise the publisher MUST close the session with a
 `PROTOCOL_VIOLATION`. A publisher MUST process any pending REQUEST_UPDATE
-messages for the associated subscription before evaluating
-the current request. Relays with an upstream subscription in Forward State 0 can
-either send a Joining Fetch upstream or buffer the Joining Fetch until
-the upstream subscription transitions to Forward State 1 and serve from
-cache.
+messages for the associated subscription before evaluating the current
+request. Relays with an upstream subscription in transition from Forward State 0
+to 1 can either send a Joining Fetch upstream or buffer the Joining Fetch until
+the upstream subscription returns REQUEST_OK with the new Largest Object.
 
 If no Objects have been published for the track the publisher MUST
 respond with a REQUEST_ERROR with error code `INVALID_RANGE`.


### PR DESCRIPTION
When a subscriber uses REQUEST_UPDATE to transition Forward State from 0 to 1 before sending a Joining FETCH, the FETCH MUST set its Required Request ID to the REQUEST_UPDATE or later. Publishers MUST process pending Forward State transitions before evaluating the Forward State 1 requirement on Joining Fetches. Relays can either send a Joining Fetch upstream or buffer until the upstream subscription transitions and serve from cache.

Fixes: #1500