### PR TITLE
Add internationalization statement for moqt URI scheme

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -906,16 +906,16 @@ TODO: Add URI scheme security considerations per RFC 7595 Section 3.7
 
 Characters in the `authority` component that are excluded by the syntax
 defined above MUST be converted from Unicode to ASCII as specified
-in {{!RFC3987}}.  For the purposes of scheme-based
-normalization, Internationalized Domain Name (IDN) forms of the
-`authority` component and their conversions to punycode are considered
-equivalent (see Section 5.3.3 of {{!RFC3987}}).
+in {{!RFC3987}}.  For the purposes of scheme-based normalization,
+Internationalized Domain Name (IDN) forms of the `authority` component
+and their conversions to punycode are considered equivalent
+(see Section 5.3.3 of {{!RFC3987}}).
 
-Characters in other components that are excluded by the syntax
-defined above MUST be converted from Unicode to ASCII by first
-encoding the characters as UTF-8 and then replacing the
-corresponding bytes using their percent-encoded form as defined in
-the URI {{!RFC3986}} and IRI {{!RFC3987}} specifications.
+Characters in other components that are excluded by the syntax defined
+above MUST be converted from Unicode to ASCII by first encoding the
+characters as UTF-8 and then replacing the corresponding bytes using
+their percent-encoded form as defined in the URI {{!RFC3986}} and
+IRI {{!RFC3987}} specifications.
 
 If the port is omitted in the URI, a default port of 443 is used.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -904,7 +904,18 @@ MOQT session to the identified server.
 TODO: Add URI scheme security considerations per RFC 7595 Section 3.7
 (e.g., authority in SNI, path/query exposure).
 
-TODO: Add internationalization statement per RFC 7595 Section 3.6.
+Characters in the `authority` component that are excluded by the syntax
+defined above MUST be converted from Unicode to ASCII as specified
+in {{!RFC3987}}.  For the purposes of scheme-based
+normalization, Internationalized Domain Name (IDN) forms of the
+`authority` component and their conversions to punycode are considered
+equivalent (see Section 5.3.3 of {{!RFC3987}}).
+
+Characters in other components that are excluded by the syntax
+defined above MUST be converted from Unicode to ASCII by first
+encoding the characters as UTF-8 and then replacing the
+corresponding bytes using their percent-encoded form as defined in
+the URI {{!RFC3986}} and IRI {{!RFC3987}} specifications.
 
 If the port is omitted in the URI, a default port of 443 is used.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -912,18 +912,35 @@ MOQT session to the identified server.
 TODO: Add URI scheme security considerations per RFC 7595 Section 3.7
 (e.g., authority in SNI, path/query exposure).
 
-Characters in the `authority` component that are excluded by the syntax
-defined above MUST be converted from Unicode to ASCII as specified
-in {{!RFC3987}}.  For the purposes of scheme-based normalization,
-Internationalized Domain Name (IDN) forms of the `authority` component
-and their conversions to punycode are considered equivalent
-(see Section 5.3.3 of {{!RFC3987}}).
+The `moqt` URI scheme is ASCII-only; the `authority`, `path-abempty`, and
+`query` components use the syntax defined in {{!RFC3986}}.  An
+Internationalized Resource Identifier (IRI) {{!RFC3987}} that uses the
+`moqt` scheme MUST be converted to a `moqt` URI before use, as follows:
 
-Characters in other components that are excluded by the syntax defined
-above MUST be converted from Unicode to ASCII by first encoding the
-characters as UTF-8 and then replacing the corresponding bytes using
-their percent-encoded form as defined in the URI {{!RFC3986}} and
-IRI {{!RFC3987}} specifications.
+* A `host` that contains non-ASCII characters MUST be converted to its
+  A-label form {{!RFC5890}}, as specified in Section 5 of {{!RFC5891}}.
+* Characters in the other components that are excluded by the syntax
+  defined above MUST be converted from Unicode to ASCII by first encoding
+  the characters as UTF-8 and then replacing the corresponding bytes with
+  their percent-encoded form, as defined in the URI {{!RFC3986}} and
+  IRI {{!RFC3987}} specifications.
+
+Two `moqt` URIs are equivalent if, after the syntax-based normalization
+defined in Section 6.2.2 of {{!RFC3986}}, their normalized forms are
+identical when compared character by character.  The following
+scheme-based normalization rules (Section 6.2.3 of {{!RFC3986}}) apply:
+
+* The scheme and host are case-insensitive and are normalized to
+  lowercase; all other components are compared case-sensitively.
+* An omitted port is equivalent to a port of 443.
+* An empty path is equivalent to a path of "/".
+
+The fragment component ({{moqt-fragment}}) is not included in the
+comparison, since it is not transmitted to the server.
+
+These rules match those for `https` URIs (see Section 4.2.3 of
+{{!RFC9110}}), so that a `moqt` URI and the `https` URI derived from it by
+scheme replacement ({{webtransport}}) compare consistently.
 
 If the port is omitted in the URI, a default port of 443 is used.
 


### PR DESCRIPTION
🎯 **What:** Replaced the TODO comment regarding the RFC 7595 Section 3.6 internationalization statement with the standard IETF boilerplate text for URI schemes.

💡 **Why:** RFC 7595 dictates that new URI schemes must specify their internationalization and character encoding considerations (how they map to IRIs/RFC3987). This resolves the TODO and completes the `moqt` URI scheme registration template.

✅ **Verification:** Verified that the document builds properly using `make` (`xml2rfc` and `kramdown-rfc` pass without errors).

✨ **Result:** The `draft-ietf-moq-transport.md` specification now contains the proper internationalization rules for the `moqt` URI scheme.

---
*PR created automatically by Jules for task [5263480566833271922](https://jules.google.com/task/5263480566833271922) started by @ianswett*

Fixes: #1680