### PR TITLE
Add MAX_REQUEST_UPDATES setup option and TOO_MANY_REQUEST_UPDATES error

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1193,6 +1193,11 @@ INVALID_AUTHORITY (0x19):
 MALFORMED_AUTHORITY (0x1A):
 : The AUTHORITY value is syntactically invalid.
 
+TOO_MANY_REQUEST_UPDATES (0x1B):
+: The endpoint received a REQUEST_UPDATE that exceeded the per-stream limit
+  communicated via the MAX_REQUEST_UPDATES Setup Option
+  ({{max-request-updates}}).
+
 An endpoint MAY choose to treat a subscription or request specific error as a
 session error under certain circumstances, closing the entire session in
 response to a condition with a single subscription or message. Implementations
@@ -2618,6 +2623,26 @@ advertising or other nonessential information. Implementations SHOULD NOT use
 the identifiers of other implementations to declare compatibility, as this
 undermines the usefulness of implementation identification for debugging.
 
+#### MAX_REQUEST_UPDATES {#max-request-updates}
+
+The MAX_REQUEST_UPDATES option (Option Type 0x08) communicates the maximum
+number of unacknowledged REQUEST_UPDATE messages per request stream that
+the endpoint is willing to receive.
+
+A REQUEST_UPDATE is considered outstanding from when it is sent until the
+sender receives the corresponding REQUEST_OK or REQUEST_ERROR response.
+The sender MUST NOT have more than MAX_REQUEST_UPDATES outstanding
+REQUEST_UPDATEs on any single request stream at a time. Each REQUEST_OK
+or REQUEST_ERROR response restores one unit of capacity on that stream.
+
+The value is encoded as a variable-length integer. If not present, the default
+value is 1. A value of 0 means the endpoint will not accept any
+REQUEST_UPDATEs.
+
+If an endpoint receives a REQUEST_UPDATE on a stream that already has
+MAX_REQUEST_UPDATES outstanding REQUEST_UPDATEs, it MUST close the session
+with `TOO_MANY_REQUEST_UPDATES`.
+
 
 ## GOAWAY {#message-goaway}
 
@@ -2890,6 +2915,9 @@ REQUEST_UPDATE to modify parameters of a subscription established with PUBLISH.
 
 The receiver of a REQUEST_UPDATE MUST respond with exactly one REQUEST_OK
 or REQUEST_ERROR message indicating if the update was successful.
+
+The number of outstanding REQUEST_UPDATEs on a single request stream is
+limited by the MAX_REQUEST_UPDATES Setup Option ({{max-request-updates}}).
 
 If a parameter previously set on the request is not present in
 `REQUEST_UPDATE`, its value remains unchanged.
@@ -4623,6 +4651,7 @@ This registry is initially empty.
 | 0x04 | MAX_AUTH_TOKEN_CACHE_SIZE | {{max-auth-token-cache-size}} |
 | 0x05 | AUTHORITY | {{authority}} |
 | 0x07 | MOQT_IMPLEMENTATION | {{moqt-implementation}} |
+| 0x08 | MAX_REQUEST_UPDATES | {{max-request-updates}} |
 | 0x7f * N + 0x9D | Reserved for greasing | {{grease}} |
 
 Endpoints MUST ignore unknown Setup Options as specified in
@@ -4751,6 +4780,7 @@ This document does not define any initial entries.
 | EXPIRED_AUTH_TOKEN         | 0x18 | {{session-termination}} |
 | INVALID_AUTHORITY          | 0x19 | {{session-termination}} |
 | MALFORMED_AUTHORITY        | 0x1A | {{session-termination}} |
+| TOO_MANY_REQUEST_UPDATES   | 0x1B | {{session-termination}} |
 | Reserved for greasing      | 0x7f * N + 0x9D | {{grease}} |
 
 ### REQUEST_ERROR Codes {#iana-request-error}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2633,7 +2633,11 @@ A REQUEST_UPDATE is considered outstanding from when it is sent until the
 sender receives the corresponding REQUEST_OK or REQUEST_ERROR response.
 The sender MUST NOT have more than MAX_REQUEST_UPDATES outstanding
 REQUEST_UPDATEs on any single request stream at a time. Each REQUEST_OK
-or REQUEST_ERROR response restores one unit of capacity on that stream.
+or REQUEST_ERROR response restores one credit on that stream. An
+implementation that processes and responds to a REQUEST_UPDATE immediately
+might not detect when a peer has pipelined messages exceeding its limit;
+coalescing REQUEST_UPDATE processing (see {{message-request-update}}) can be
+more effective at enforcing MAX_REQUEST_UPDATES.
 
 The value is encoded as a variable-length integer. A value of 0 means the
 endpoint does not limit REQUEST_UPDATE concurrency. If not present, the default

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2636,7 +2636,7 @@ REQUEST_UPDATEs on any single request stream at a time. Each REQUEST_OK
 or REQUEST_ERROR response restores one unit of capacity on that stream.
 
 The value is encoded as a variable-length integer. If not present, the default
-value is 1. A value of 0 means the endpoint will not accept any
+value is 2^64 - 1. A value of 0 means the endpoint will not accept any
 REQUEST_UPDATEs.
 
 If an endpoint receives a REQUEST_UPDATE on a stream that already has

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2635,9 +2635,9 @@ The sender MUST NOT have more than MAX_REQUEST_UPDATES outstanding
 REQUEST_UPDATEs on any single request stream at a time. Each REQUEST_OK
 or REQUEST_ERROR response restores one unit of capacity on that stream.
 
-The value is encoded as a variable-length integer. If not present, the default
-value is 2^64 - 1. A value of 0 means the endpoint will not accept any
-REQUEST_UPDATEs.
+The value is encoded as a variable-length integer. A value of 0 means the
+endpoint does not limit REQUEST_UPDATE concurrency. If not present, the default
+value is 0.
 
 If an endpoint receives a REQUEST_UPDATE on a stream that already has
 MAX_REQUEST_UPDATES outstanding REQUEST_UPDATEs, it MUST close the session


### PR DESCRIPTION
Add per-stream flow control for REQUEST_UPDATE messages via a new MAX_REQUEST_UPDATES Setup Option. Each REQUEST_OK or REQUEST_ERROR response restores one unit of capacity. Default is 1 if not present.

Fixes: #1063