### PR TITLE
Fix SUBSCRIBE_NAMESPACE response message name

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1587,7 +1587,7 @@ in a namespace without having received a PUBLISH_NAMESPACE for it.
 
 If a publisher is authoritative for a given namespace, or is a relay that has
 received an authorized PUBLISH_NAMESPACE for that namespace from an upstream
-publisher, it MUST send a PUBLISH_NAMESPACE to any subscriber that has
+publisher, it MUST send a NAMESPACE to any subscriber that has
 subscribed via SUBSCRIBE_NAMESPACE for that namespace, or a prefix of that
 namespace. A publisher MAY send the PUBLISH_NAMESPACE to any other subscriber.
 


### PR DESCRIPTION
The response to SUBSCRIBE_NAMESPACE should be NAMESPACE, not PUBLISH_NAMESPACE. PUBLISH_NAMESPACE is an unsolicited message, while NAMESPACE is sent on the response stream of
SUBSCRIBE_NAMESPACE.

Fixes: #1616