### PR TITLE
Forbid relays from lying about LARGEST_OBJECT

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2446,11 +2446,11 @@ have been published on this Track the Publisher MUST include this parameter.
 If omitted from a message, the sending endpoint has not published or received
 any Objects in the Track.
 
-A relay MUST NOT populate the LARGEST_OBJECT parameter from the contents
-of its cache. A relay MUST set LARGEST_OBJECT to the largest of the
-LARGEST_OBJECT values received from the upstream publisher in SUBSCRIBE_OK,
-PUBLISH, or REQUEST_UPDATE_OK, or the Location of an Object received on
-the upstream subscription, whichever is largest.
+A relay MUST set LARGEST_OBJECT to the largest of the following:
+
+1. Any LARGEST_OBJECT value received from the upstream publisher in SUBSCRIBE_OK,
+PUBLISH, or REQUEST_UPDATE_OK
+2. The largest Location of an Object received on an upstream subscription
 
 ### FORWARD Parameter {#forward-parameter}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1819,7 +1819,8 @@ relay authorizes a user are outside the scope of this specification.
 The relay MUST have an `Established` upstream subscription before sending
 SUBSCRIBE_OK in response to a downstream SUBSCRIBE.  If a relay does not have
 sufficient information to send a FETCH_OK immediately in response to a FETCH, it
-MUST withhold sending FETCH_OK until it does.
+MUST withhold sending FETCH_OK until it does.  Relays MUST follow the
+constraints on LARGEST_OBJECT defined in {{largest-param}}.
 
 Publishers maintain a list of `Established` downstream subscriptions for
 each Track. Relays use the Track Alias ({{track-alias}}) of an incoming Object
@@ -2444,6 +2445,12 @@ have been published on this Track the Publisher MUST include this parameter.
 
 If omitted from a message, the sending endpoint has not published or received
 any Objects in the Track.
+
+A relay MUST NOT populate the LARGEST_OBJECT parameter from the contents
+of its cache. A relay MUST set LARGEST_OBJECT to the largest of the
+LARGEST_OBJECT values received from the upstream publisher in SUBSCRIBE_OK,
+PUBLISH, or REQUEST_UPDATE_OK, or the Location of an Object received on
+the upstream subscription, whichever is largest.
 
 ### FORWARD Parameter {#forward-parameter}
 


### PR DESCRIPTION
If we want to serve cached objects in response to SUBSCRIBE, lying is not the correct approach.

Fixes: #1386