### PR TITLE
Add Sender-Side Track Switching (SSTS)

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2299,7 +2299,7 @@ Relays prioritize forwarded Objects as described in {{priorities}}.
 ## Sender Side Track Switching {#sender-side-track-switching}
 
 Sender Side Track Switching (SSTS) is a subscriber-initiated and controlled behavior in which
-relays dynamically select which track to forward from a switching set based on
+a publisher dynamically selects which track to forward from a switching set based on
 various algorithms. Each algorithm defines a set of attributes which are passed in the
 SWITCHING-SET-ASSIGNMENT parameter {{switching-set-assignment-param}} along with a
 complimentary set of rules for subscriber behavior and relay behavior.
@@ -2308,7 +2308,7 @@ This specification defines a default algorithm - type 0. Other algorithms are re
 "SSTS Algorithms" registry {{iana-ssts-algorithms}}.
 
 During SETUP, a relay communicates which SSTS algorithms it supports by passing the
-SSTS_ALGORITHMS option {{ssts-algorithms}}.
+SSTS_ALGORITHMS Setup Option {{ssts-algorithms}}.
 
 ### General behaviors for all SSTS algorithms {#ssts-general-requirements}
 
@@ -2316,10 +2316,10 @@ The subscriber is responsible for grouping tracks into switching sets based on a
 knowledge. A switching set is a collection of tracks representing the same content encoded at
 different throughput levels, typically from a single source. Tracks within a switching set are
 time-aligned at certain group boundaries, allowing the relay to switch between tracks at these
-boundaries without initiating reception errors at the client. The relay selects exactly one track
-per switching set to forward at any given time.
+boundaries while ensuring the subscriber receives uninterrupted content from the set. The relay
+selects exactly one track per switching set to forward at any given time.
 
-Subscribers can create switching sets through two methods. Both support single or multiple
+Subscribers can create switching sets through three methods. All support single or multiple
 switching sets and result in identical relay behavior:
 
 * Individual SUBSCRIBE: - the subscriber sends a separate SUBSCRIBE message for each track,
@@ -2329,12 +2329,14 @@ switching sets and result in identical relay behavior:
   track, the relay will issue a PUBLISH message. The subscriber assigns tracks to switching sets
   by appending the SWITCHING-SET-ASSIGNMENT parameter to the PUBLISH_OK message.
 
-In both cases, tracks are grouped into a switching set by specifying the same switching set ID.
+* PUBLISH: - the publisher sends a PUBLISH message. The subscriber assigns tracks to switching sets
+  by appending the SWITCHING-SET-ASSIGNMENT parameter to the PUBLISH_OK message.
+
+In all cases, tracks are grouped into a switching set by specifying the same switching set ID.
 
 ### Default switching algorithm
 
-This specification defines a default SSTS algorithm and adds it to the "MOQT SSTS Algorithms"
-registry {{iana-ssts-algorithms}} with a type of 0.
+This specification defines a default SSTS algorithm with a type of 0.
 
 #### SWITCHING-SET-ASSIGNMENT fields
 This algorithm extends the base definition of the SWITCHING-SET-ASSIGNMENT parameter
@@ -2344,39 +2346,40 @@ SWITCHING-SET-ASSIGNMENT {
   Switching set ID (vi64),
   Algorithm ID (vi64),
   Throughput threshold (vi64),
-  Set throughput fraction (vi64),
+  Set throughput weight (vi64),
   Activate switching (vi64),
   Set rank (8)
 }
 
 * Throughput threshold: Minimum throughput (kbps) required to select this track.
 
-* Set throughput fraction: Relative weight for bandwidth allocation, expressed as an
-  integer 1 <= N <= 10. Each set receives bandwidth proportional to its fraction:
-  `target = B_total × fraction / sum_F`. Fractions are relative weights, not absolute
-  percentages; for example, fractions of 6, 4, 3 (sum_F=13) allocate 46%, 31%, 23%
+* Set throughput weight: Relative weight for bandwidth allocation, expressed as an
+  integer 1 <= N <= 10. Each set receives bandwidth proportional to its weight:
+  `target = B_total × weight / sum_F`. These are relative weights, not absolute
+  percentages; for example, weights of 6, 4, 3 (sum = 13) allocate 46%, 31%, 23%
   respectively. This allows sets to be added or removed without requiring other sets to
-  update their fractions. When multiple subscriptions in the same switching set specify
-  different fraction values, the relay MUST use the value from the most recently received
+  update their weights. When multiple subscriptions in the same switching set specify
+  different weight values, the publisher MUST use the value from the most recently received
   message for that set.
 
 * Activate switching: Integer, when set to 0, pauses SSTS switching for this set. When set
   to N, the relay activates or resumes switching as soon as the number of tracks assigned to
-  the switching set is >= N.  Activation takes effect at the next group boundary.
+  the switching set is >= N.  Activation takes effect when an Object is received or published
+  on a Group larger than previously largest Group. When multiple subscriptions in the same
+  switching set specify different activate values, the publisher MUST use the value from the
+  most recently received message for that set.
 
-* Set rank: Degradation priority when bandwidth is constrained, expressed as
-  an 8-bit unsigned integer (1-255). Default is 1. Values outside this range MUST result in
-  a protocol error. Lower values indicate higher priority (protected from degradation).
-  When bandwidth is sufficient, all sets receive their fraction-based allocation. When
-  bandwidth is constrained, lower-ranked sets (higher numeric value) degrade first: they
-  select lower-throughput tracks or receive no bandwidth, while higher-ranked sets maintain
-  their target allocation. See {{allocation-algorithm}} for details.
+* Set rank: Degradation priority when bandwidth is constrained, expressed as an 8-bit unsigned
+  integer (0-255). Default is 0. Lower values indicate higher priority (protected from degradation).
+  See {{allocation-algorithm}} for details. When multiple subscriptions in the same switching set
+  specify different rank values, the publisher MUST use the value from the most recently received
+  message for that set.
 
 #### Subscriber behavior
 
 The subscriber follows the general rules {#ssts-general-requirements} for switching set establishment.
 
-The subscriber sets activate = N, where N is the number of tracks that will be assigned to that
+The subscriber sets activate switching = N, where N is the number of tracks that will be assigned to that
 switching set.
 
 To modify an established switching set, the subscriber can
@@ -2387,58 +2390,61 @@ To modify an established switching set, the subscriber can
 * Pause SSTS: Send REQUEST_UPDATE for any track assigned to that set with a SWITCHING-SET-ASSIGNMENT
   parameter defining activate = 0.
 * Resume SSTS: Send REQUEST_UPDATE for any track assigned to that set with a SWITCHING-SET-ASSIGNMENT
-  parameter defining activate = N, where N is the number of tracks assigned to that switching set.
+  parameter defining activate switching = N, where N is the number of tracks assigned to that switching set.
 
-#### Relay behavior
+#### Publisher behavior
 
-When the relay receives a subscription with SWITCHING-SET-ASSIGNMENT:
+When the publisher receives a subscription with SWITCHING-SET-ASSIGNMENT:
 
 1. Add the subscription to the specified switching set, creating the set if needed.
-2. Set Forward state to 0 for the new subscription.
-3. Store 'throughput' as a property of the subscription.
-4. Store 'fraction', 'rank' and 'activate' as properties of the set.
-5. If the number of tracks assigned to the set is >= the activate switching value, then begin
-   active track selection by applying the bandwidth allocation algorithm {{allocation-algorithm}} at the
-   next group boundary.
+2. Set Forward state to 0 for the new subscription, irrespective of the forward state received from the
+   SUBSCRIBE or PUBLISH_OK.
+4. Store 'throughput threshold' as a property of the subscription.
+5. Store 'Set throughput weight', 'Set rank' and 'Activate switching' as properties of the set.
+6. If the number of tracks assigned to the set with active subscriptions >= the activate switching value,
+   then begin active track selection by applying the bandwidth allocation algorithm {{allocation-algorithm}}
+   when an Object is received or published on a Group larger than previously largest Group.
 
-If the relay receives a PUBLISH_DONE message, or an UNSUBSCRIBE for a subscription that was
+If the publisher receives a PUBLISH_DONE message, or an UNSUBSCRIBE for a subscription that was
 previously added to a switching set, then it must remove that subscription from the switching set
-and continue to process the switching across the remaining subscriptions within that set.
+and continue to process the switching across the remaining subscriptions within that set. The value of
+'activate switching' MUST be decremented by one to enable the swictching to remain active. 
 
 If all tracks are removed from a previously established switching set, then that set is
 considered deleted and is removed from the bandwidth allocation algorithm.
 
-Relays SHOULD maintain a forward=1 upstream state on all tracks within a switching set, irrespective
-of their downstream forwarding state.
+Publishers SHOULD maintain a forward=1 upstream state (if any) on all tracks within a switching set,
+irrespective of their downstream forwarding state.
 
 #### Bandwidth Allocation {#allocation-algorithm}
 
-The relay maintains:
+The publisher maintains:
 
 - `B_total`: Estimated downstream bandwidth capacity for the subscriber connection. The
-  relay MUST maintain a bandwidth estimate for each downstream subscriber. The timebase of this
-  estimate SHOULD be at least the Group duration of the track. The estimate is obtained
-  periodically from the QUIC stack (e.g., congestion window pacing rate, smoothed RTT)
+  publisher maintains a bandwidth estimate for each downstream subscriber. The timebase of this
+  estimate SHOULD be at least the Group duration of the track, if that is known or can be estimated
+  by the publisher, or several seconds if it is unknown. The estimate is obtained
+  periodically from the transport stack (e.g., congestion window pacing rate, smoothed RTT)
   and MAY be supplemented by external sources or application-level feedback. The exact mechanism
-  is not defined by this specification and MAY vary between implementations.
-- `sum_F`: Sum of all set fractions, updated incrementally as subscriptions are added or removed
-- 'set.fraction': for each switching set, the switching set fraction, as defined by the set
-  throughput fraction of the SWITCHING-SET-ASSIGNMENT {{switching-set-assignment-param}} parameter.
-- 'set.rank': for each switching set, the switching set rank, as defined by the optional set
+  is not defined by this algorithm and might vary between implementations.
+- `sum_W`: Sum of all set weights updated incrementally as subscriptions are added or removed
+- 'set.weight': for each switching set, the switching set weight, as defined by the set
+  throughput weight of the SWITCHING-SET-ASSIGNMENT {{switching-set-assignment-param}} parameter.
+- 'set.rank': for each switching set, the switching set rank, as defined by the set
   rank field of the SWITCHING-SET-ASSIGNMENT {{switching-set-assignment-param}} parameter.
 
-On a periodic update interval or at a minimum of a new Group boundary, the relay executes the
-following algorithm:
+On a periodic update interval or at a minimum when an object is received/published on a group
+larger than previously largest group, the relay executes the following algorithm:
 
 ~~~
 B_remaining  = B_total
-for each set in ascending rank order:
-  set.target = B_remaining × set.fraction / sum_F
+for each set in ascending set.rank order:
+  set.target = B_remaining × set.weight / sum_W
   set.allocated = min(set.target, B_remaining)
   set.selected = track in set with highest throughput_threshold where track.throughput_threshold <= set.allocated
   B_remaining -= set.selected.throughput_threshold
 for each track in a switching set:
-  set forward state = track.selected
+  set forward state = (track == set.selected)
 ~~~
 
 The rank ordering ensures higher-priority sets receive their target allocation first; lower-priority sets
@@ -3116,8 +3122,7 @@ a sequence of varints. Returning an empty sequence is acceptable and indicates
 that SSTS is not supported. Algorithms are registered in the SSTS-Algorithms
 {{iana-ssts-algorithms}} registry.
 
-This option is optional. The default value is any empty list which prohibits
-the use of SSTS.
+The default value is any empty list which prohibits the use of SSTS.
 
 #### MAX FILTER RANGES
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2113,22 +2113,28 @@ A relay MUST treat the object payload as opaque.  A relay MUST NOT
 combine, split, or otherwise modify object payloads.  A relay SHOULD
 prioritize sending Objects based on {{priorities}}.
 
-## Dynamic Track Switching {#dynamic-track-switching}
+## Sender Side Track Switching {#sender-side-track-switching}
 
-Dynamic Track Switching (DTS) is a subscriber-initiated and controlled behavior in which
+Sender Side Track Switching (SSTS) is a subscriber-initiated and controlled behavior in which
 relays dynamically select which track to forward from a switching set based on
-available downstream bandwidth.
+various algorithms. Each algorithm defines a set of attributes which are passed in the
+SWITCHING-SET-ASSIGNMENT parameter {{TBD}} along with a complimentary set of rules for subscriber
+operations and relay behavior.
 
-The subscriber is responsible for grouping tracks into switching sets based on
-application-level knowledge. A switching set is a collection of tracks representing
-the same content encoded at different throughput levels, typically from a single source.
-Tracks within a switching set are time-aligned at group boundaries, allowing the relay
-to switch between tracks at group boundaries without initiating reception errors at
-the client. The relay selects exactly one track per switching set to forward at any
-given time.
+This specification defines a default algorithm - type 0. Other algorithms are referenced in the
+"MOQT SSTS Algorithms" registry {{iana-ssts-algorithms}}.
 
+During SETUP, a relay communicates which SSTS algorithms it supports by passing the
+SSTS_ALGORITHMS option {{ssts-algorithms}}.
 
-### Switching set establishment
+### General behaviors for all SSTS algorithms {#ssts-general-requirements}
+
+The subscriber is responsible for grouping tracks into switching sets based on application-level
+knowledge. A switching set is a collection of tracks representing the same content encoded at
+different throughput levels, typically from a single source. Tracks within a switching set are
+time-aligned at certain group boundaries, allowing the relay to switch between tracks at these
+boundaries without initiating reception errors at the client. The relay selects exactly one track
+per switching set to forward at any given time.
 
 Subscribers can create switching sets through two methods. Both support single or multiple
 switching sets and result in identical relay behavior:
@@ -2141,22 +2147,66 @@ switching sets and result in identical relay behavior:
   by appending the SWITCHING-SET-ASSIGNMENT parameter to the PUBLISH_OK message.
 
 In both cases, tracks are grouped into a switching set by specifying the same switching set ID.
+
+### Default switching algorithm
+
+This specification defines a default SSTS algorithm and adds it to the "MOQT SSTS Algorithms"
+registry {{iana-ssts-algorithms}} with a type of 0.
+
+#### SWITCHING-SET-ASSIGNMENT fields
+This algorithm extends the base definition of the SWITCHING-SET-ASSIGNMENT parameter
+{{switching-set-assignment-param}} to add the following fields:
+
+SWITCHING-SET-ASSIGNMENT {
+  Switching set ID (vi64),
+  Algorithm ID (vi64),
+  Throughput threshold (vi64),
+  Set throughput fraction (vi64),
+  Activate switching (vi64),
+  [Set rank (8)]
+}
+
+* Throughput threshold: Minimum throughput (kbps) required to select this track.
+
+* Set throughput fraction: Relative weight for bandwidth allocation, expressed as an
+  integer 1 <= N <= 10. Each set receives bandwidth proportional to its fraction:
+  `target = B_total × fraction / sum_F`. Fractions are relative weights, not absolute
+  percentages; for example, fractions of 6, 4, 3 (sum_F=13) allocate 46%, 31%, 23%
+  respectively. This allows sets to be added or removed without requiring other sets to
+  update their fractions. When multiple subscriptions in the same switching set specify
+  different fraction values, the relay MUST use the value from the most recently received
+  message for that set.
+
+* Activate switching: Integer, when set to 0, pauses DTS switching for this set. When set
+  to N, the relay activates or resumes switching as soon as the number of tracks assigned to
+  the switching set is >= N.  Activation takes effect at the next group boundary.
+
+* Set rank (optional): Degradation priority when bandwidth is constrained, expressed as
+  an 8-bit unsigned integer (1-255). Default is 1. Values outside this range MUST result in
+  a protocol error. Lower values indicate higher priority (protected from degradation).
+  When bandwidth is sufficient, all sets receive their fraction-based allocation. When
+  bandwidth is constrained, lower-ranked sets (higher numeric value) degrade first: they
+  select lower-throughput tracks or receive no bandwidth, while higher-ranked sets maintain
+  their target allocation. See {{allocation-algorithm}} for details.
+
+#### Subscriber behavior
+
+The subscriber follows the general rules {#ssts-general-requirements} for switching set establishment.
+
 The subscriber sets activate = N, where N is the number of tracks that will be assigned to that
 switching set.
-
-### Subscriber operations
 
 To modify an established switching set, the subscriber can
 
 * Add a track to an existing set: send SUBSCRIBE or PUBLISH_OK with a SWITCHING-SET-ASSIGNMENT parameter
   referencing an existing set.
 * Remove a track from a set: unsubscribe from that track.
-* Pause DTS: Send REQUEST_UPDATE for any track assigned to that set with a SWITCHING-SET-ASSIGNMENT
+* Pause SSTS: Send REQUEST_UPDATE for any track assigned to that set with a SWITCHING-SET-ASSIGNMENT
   parameter defining activate = 0.
-* Resume DTS: Send REQUEST_UPDATE for any track assigned to that set with a SWITCHING-SET-ASSIGNMENT
+* Resume SSTS: Send REQUEST_UPDATE for any track assigned to that set with a SWITCHING-SET-ASSIGNMENT
   parameter defining activate = N, where N is the number of tracks assigned to that switching set.
 
-### Relay behavior
+#### Relay behavior
 
 When the relay receives a subscription with SWITCHING-SET-ASSIGNMENT:
 
@@ -2175,7 +2225,10 @@ and continue to process the switching across the remaining subscriptions within 
 If all tracks are removed from a previously established switching set, then that set is
 considered deleted and is removed from the bandwidth allocation algorithm.
 
-### Bandwidth Allocation {#allocation-algorithm}
+Relays SHOULD maintain a forward=1 upstream state on all tracks within a switching set, irrespective
+of their downstream forwarding state.
+
+#### Bandwidth Allocation {#allocation-algorithm}
 
 The relay maintains:
 
@@ -2199,8 +2252,8 @@ B_remaining  = B_total
 for each set in ascending rank order:
   set.target = B_remaining × set.fraction / sum_F
   set.allocated = min(set.target, B_remaining)
-  set.selected = track in set with highest throughput where track.throughput <= set.allocated
-  B_remaining -= set.selected.throughput
+  set.selected = track in set with highest throughput_threshold where track.throughput_threshold <= set.allocated
+  B_remaining -= set.selected.throughput_threshold
 for each track in a switching set:
   set forward state = track.selected
 ~~~
@@ -2705,50 +2758,22 @@ MUST respond with REQUEST_ERROR with error code `PREFIX_OVERLAP`.
 ### SWITCHING_SET_ASSIGNMENT Parameter {#switching-set-assignment-param}
 
 The SWITCHING-SET-ASSIGNMENT parameter (Parameter Type 0x41) MAY appear in a SUBSCRIBE,
-REQUEST_UPDATE, or PUBLISH_OK message. This parameter assigns a subscription to a DTS
-switching set and specifies bandwidth allocation and optional ranking values.
+REQUEST_UPDATE, or PUBLISH_OK message. This parameter assigns a subscription to a SSTS
+switching set and specifies the algorithm to be used for switching. Each algorithm MAY
+extend the serialization to pass additional fields.
 
 ~~~
 SWITCHING-SET-ASSIGNMENT {
   Switching set ID (vi64),
-  Throughput threshold (vi64),
-  Set throughput fraction (vi64),
-  Activate switching (vi64),
-  [Set rank (8)]
+  Algorithm (vi64)
 }
 ~~~
 
 * Switching set ID: Integer identifying the switching set. A track MUST only be assigned
   to one switching set at a time. If a subscription attempts to assign a track that is
   already assigned to a different switching set, the relay MUST reject the subscription
-  with a Parameter Error. If a subscription attempts to assign a track, when the number of
-  tracks already assigned to switching sets within the session is
-  >= MAX_DTS_CONCURRENT_TRACKS {{max-dts-concurrent-tracks}}, then the relay MUST reject
-  the subscription with a Parameter Error.
-
-* Throughput threshold: Minimum throughput (kbps) required to select this track.
-
-* Set throughput fraction: Relative weight for bandwidth allocation, expressed as an
-  integer 1 <= N <= 10. Each set receives bandwidth proportional to its fraction:
-  `target = B_total × fraction / sum_F`. Fractions are relative weights, not absolute
-  percentages; for example, fractions of 6, 4, 3 (sum_F=13) allocate 46%, 31%, 23%
-  respectively. This allows sets to be added or removed without requiring other sets to
-  update their fractions. When multiple subscriptions in the same switching set specify
-  different fraction values, the relay MUST use the value from the most recently received
-  message for that set.
-
-* Activate switching: Integer, when set to 0, pauses DTS switching for this set. When set
-  to N, the relay activates or resumes switching as soon as the number of tracks assigned to
-  the switching set is >= N.  Activation takes effect at the next group boundary.
-
-* Set rank (optional): Degradation priority when bandwidth is constrained, expressed as
-  an 8-bit unsigned integer (1-255). Default is 1. Values outside this range MUST result in
-  a protocol error. Lower values indicate higher priority (protected from degradation).
-  When bandwidth is sufficient, all sets receive their fraction-based allocation. When
-  bandwidth is constrained, lower-ranked sets (higher numeric value) degrade first: they
-  select lower-throughput tracks or receive no bandwidth, while higher-ranked sets maintain
-  their target allocation. See {{allocation-algorithm}} for details.
-
+  with a Parameter Error.
+* Algorithm: integer identifying the SSTS algorithm to be used.
 
 ## SETUP {#message-setup}
 
@@ -2864,14 +2889,16 @@ advertising or other nonessential information. Implementations SHOULD NOT use
 the identifiers of other implementations to declare compatibility, as this
 undermines the usefulness of implementation identification for debugging.
 
-#### MAX_DTS_CONCURRENT_TRACKS {#max-dts-concurrent-tracks}
+#### SSTS_ALGORITHMS {#ssts-algorithms}
 
-The MAX_DTS_CONCURRENT_TRACKS option (Option Type 0x08) communicates the
-maximum number of tracks that can be allocated to Dynamic Track Switching (DTS)
-switching sets within a MOQT session. This maximum is the sum of all tracks
-across all switching sets within the session. This option is optional. The
-default value is 0 which prohibits the use of Dynamic Track Switching.
+The SSTS_ALGORITHMS option (Option Type 0x09) communicates the list of SSTS
+algorithms which the relay supports. Supported algorithms are serialized as
+a sequence of varints. Returning an empty sequence is acceptable and indicates
+that SSTS is not supported. Algorithms are registered in the SSTS-Algorithms
+{{iana-ssts-algorithms}} registry.
 
+This option is optional. The default value is any empty list which prohibits
+the use of SSTS.
 
 ## GOAWAY {#message-goaway}
 
@@ -5285,6 +5312,19 @@ This document does not define any initial entries.
 | EXCESSIVE_LOAD        | 0x9  | {{stream-reset-codes}}   |
 | MALFORMED_TRACK       | 0x12 | {{stream-reset-codes}}   |
 | Reserved for greasing | 0x7f * N + 0x9D | {{grease}} |
+
+### SSTS-Algorithms {#iana-ssts-algorithms}
+
+This document establishes a registry for SSTS algorithms. The
+registration policy is Specification Required (per {{!RFC8126,
+Section 4.6}}).
+
+| Type | Name       | Specification |
+|-----:|:-----------|:--------------|
+| 0x0  | Default  | {{authorization-token}} |
+| 0x7f * N + 0x9D | Reserved for greasing | {{grease}} |
+
+
 
 # Contributors
 {:numbered="false"}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2184,6 +2184,8 @@ The relay maintains:
 - `sum_F`: Sum of all set fractions, updated incrementally as subscriptions are added or removed
 - 'set.fraction': for each switching set, the switching set fraction, as defined by the set
   throughput fraction of the SWITCHING-SET-ASSIGNMENT {{switching-set-assignment-param}} parameter.
+  - 'set.rank': for each switching set, the switching set rank, as defined by the optional set
+  rank field of the SWITCHING-SET-ASSIGNMENT {{switching-set-assignment-param}} parameter.
 
 On a periodic update interval or at a minimum of a new Group boundary, the relay executes the
 following algorithm:

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2122,7 +2122,7 @@ SWITCHING-SET-ASSIGNMENT parameter {{switching-set-assignment-param}} along with
 complimentary set of rules for subscriber behavior and relay behavior.
 
 This specification defines a default algorithm - type 0. Other algorithms are referenced in the
-"MOQT SSTS Algorithms" registry {{iana-ssts-algorithms}}.
+"SSTS Algorithms" registry {{iana-ssts-algorithms}}.
 
 During SETUP, a relay communicates which SSTS algorithms it supports by passing the
 SSTS_ALGORITHMS option {{ssts-algorithms}}.
@@ -5321,7 +5321,7 @@ Section 4.6}}).
 
 | Type | Name       | Specification |
 |-----:|:-----------|:--------------|
-| 0x0  | Default  | {{authorization-token}} |
+| 0x0  | Default  | this |
 | 0x7f * N + 0x9D | Reserved for greasing | {{grease}} |
 
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2163,7 +2163,7 @@ SWITCHING-SET-ASSIGNMENT {
   Throughput threshold (vi64),
   Set throughput fraction (vi64),
   Activate switching (vi64),
-  [Set rank (8)]
+  Set rank (8)
 }
 
 * Throughput threshold: Minimum throughput (kbps) required to select this track.
@@ -2181,7 +2181,7 @@ SWITCHING-SET-ASSIGNMENT {
   to N, the relay activates or resumes switching as soon as the number of tracks assigned to
   the switching set is >= N.  Activation takes effect at the next group boundary.
 
-* Set rank (optional): Degradation priority when bandwidth is constrained, expressed as
+* Set rank: Degradation priority when bandwidth is constrained, expressed as
   an 8-bit unsigned integer (1-255). Default is 1. Values outside this range MUST result in
   a protocol error. Lower values indicate higher priority (protected from degradation).
   When bandwidth is sufficient, all sets receive their fraction-based allocation. When

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2113,6 +2113,97 @@ A relay MUST treat the object payload as opaque.  A relay MUST NOT
 combine, split, or otherwise modify object payloads.  A relay SHOULD
 prioritize sending Objects based on {{priorities}}.
 
+## Dynamic Track Switching {#dynamic-track-switching}
+
+Dynamic Track Switching (DTS) is a subscriber-initiated and controlled behavior in which
+relays dynamically select which track to forward from a switching set based on
+available downstream bandwidth.
+
+The subscriber is responsible for grouping tracks into switching sets based on
+application-level knowledge. A switching set is a collection of tracks representing
+the same content encoded at different throughput levels, typically from a single source.
+Tracks within a switching set are time-aligned at group boundaries, allowing the relay
+to switch between tracks at group boundaries without initiating reception errors at
+the client. The relay selects exactly one track per switching set to forward at any
+given time.
+
+
+### Switching set establishment 
+
+Subscribers can create switching sets through two methods. Both support single or multiple
+switching sets and result in identical relay behavior:
+
+* Individual SUBSCRIBE: - the subscriber sends a separate SUBSCRIBE message for each track,
+  and appends the SWITCHING-SET-ASSIGNMENT parameter to assign the track to a switching set. 
+
+* SUBSCRIBE_NAMESPACE: - the subscriber sends a SUBSCRIBE_NAMESPACE message. For each matching
+  track, the relay will issue a PUBLISH message. The subscriber assigns tracks to switching sets
+  by appending the SWITCHING-SET-ASSIGNMENT parameter to the PUBLISH_OK message. 
+
+In both cases, tracks are grouped into a switching set by specifying the same switching set ID.
+The subscriber sets activate=0 for all tracks except the last one in each set, then sets
+activate=1 on the final track to signal that the set is complete and the relay should
+begin active track selection.
+
+### Subscriber operations
+
+To modify and established switching set, the subscriber can
+
+* Add track to existing set: send SUBSCRIBE or PUBLISH_OK with a SWITCHING-SET-ASSIGNMENT parameter
+  referencing an existing set.
+* Remove track: Unsubscribe from that track
+* Pause DTS: Send REQUEST_UPDATE with a SWITCHING-SET-ASSIGNMENT parameter defining activate = 0
+* Resume DTS: Send REQUEST_UPDATE with a SWITCHING-SET-ASSIGNMENT parameter defining activate = 1
+
+### Relay behavior
+
+When the relay receives a subscription with SWITCHING-SET-ASSIGNMENT:
+
+1. Add subscription to the specified switching set, creating the set if needed.
+2. Set Forward state to 0 for the new subscription
+3. Store the Set throughput fraction and rank as properties of the set
+4. If Activate switching = 1, begin active track selection
+
+If the relay receives a PUBLISH_DONE message, or an UNSUBSCRIBE for a subscription that was
+previously added to a switching set, then it must remove that subscription from the switching set
+and continue to process the switching across the remaining subscriptions within that set.
+
+If all tracks are removed from a previously established switching set, then that set is
+considered deleted and is removed from the bandwidth allocation algorithm. 
+
+### Bandwidth Allocation {#allocation-algorithm}
+
+The relay maintains:
+
+- `B_total`: Estimated downstream bandwidth capacity for the subscriber connection. The
+  relay MUST maintain a bandwidth estimate for each downstream subscriber. The timebase of this
+  estimate SHOULD be at least the Group duration of the track. The estimate is obtained
+  periodically from the QUIC stack (e.g., congestion window pacing rate, smoothed RTT)
+  and MAY be supplemented by external sources or application-level feedback. The exact mechanism
+  is not defined by this specification and MAY vary between implementations. 
+- `sum_F`: Sum of all set fractions, updated incrementally as subscriptions are added or removed
+- 'set.fraction': for each switching set, the switching set fraction, as defined by the set
+  throughput fraction of the SWITCHING-SET-ASSIGNMENT {{switching-set-assignment-param}} parameter.
+
+On a periodic update interval or at a minimum of a new Group boundary, the relay executes the
+following algorithm:
+
+~~~
+B_remaining  = B_total
+for each set in ascending rank order:
+  set.target = B_remaining × set.fraction / sum_F
+  set.allocated = min(set.target, B_remaining)
+  set.selected = track in set with highest throughput where track.throughput <= set.allocated
+  B_remaining -= set.selected.throughput
+for each track in a switching set:
+  set forward state = track.selected
+~~~
+
+The rank ordering ensures higher-priority sets receive their target allocation first; lower-priority sets
+absorb any bandwidth shortfall. When bandwidth is sufficient, all sets receive `allocated = target`.
+When bandwidth is constrained, higher-priority sets (lower rank value) are protected while
+lower-priority sets receive less than their target or nothing.
+
 # Control Messages {#message}
 
 MOQT uses a pair of unidirectional streams to exchange control messages, as
@@ -2605,6 +2696,52 @@ Namespace Prefix for that subscription.  If the new prefix would share a common 
 another active subscription of the same type in the same session, the receiver
 MUST respond with REQUEST_ERROR with error code `PREFIX_OVERLAP`.
 
+### SWITCHING_SET_ASSIGNMENT Parameter {#switching-set-assignment-param}
+
+The SWITCHING-SET-ASSIGNMENT parameter (Parameter Type 0x41) MAY appear in a SUBSCRIBE,
+REQUEST_UPDATE, or PUBLISH_OK message. This parameter assigns a subscription to a DTS
+switching set and specifies bandwidth allocation and optional ranking values.
+
+~~~
+SWITCHING-SET-ASSIGNMENT {
+  Switching set ID (vi64),
+  Throughput threshold (vi64),
+  Set throughput fraction (vi64),
+  Activate switching (1),
+  [Set rank (8)]
+}
+~~~
+
+* Switching set ID: Integer identifying the switching set. A track MUST only be assigned
+  to one switching set at a time. If a subscription attempts to assign a track that is
+  already assigned to a different switching set, the relay MUST reject the subscription
+  with a Parameter Error.
+
+* Throughput threshold: Minimum throughput (kbps) required to select this track.
+
+* Set throughput fraction: Relative weight for bandwidth allocation, expressed as an
+  integer 1 <= N <= 10. Each set receives bandwidth proportional to its fraction:
+  `target = B_total × fraction / sum_F`. Fractions are relative weights, not absolute
+  percentages; for example, fractions of 6, 4, 3 (sum_F=13) allocate 46%, 31%, 23%
+  respectively. This allows sets to be added or removed without requiring other sets to
+  update their fractions. When multiple subscriptions in the same switching set specify
+  different fraction values, the relay MUST use the value from the most recently received
+  message for that set.
+
+* Activate switching: When set to 0, DTS switching is paused for this set (use when
+  more subscriptions will be added, or to temporarily freeze the current selection).
+  When set to 1, the relay activates or resumes switching. Changes to the selected
+  track take effect at the next group boundary.
+
+* Set rank (optional): Degradation priority when bandwidth is constrained, expressed as
+  an 8-bit unsigned integer (1-255). Default is 1. Values outside this range MUST result in
+  a protocol error. Lower values indicate higher priority (protected from degradation).
+  When bandwidth is sufficient, all sets receive their fraction-based allocation. When
+  bandwidth is constrained, lower-ranked sets (higher numeric value) degrade first: they
+  select lower-throughput tracks or receive no bandwidth, while higher-ranked sets maintain
+  their target allocation. See {{allocation-algorithm}} for details.
+
+
 ## SETUP {#message-setup}
 
 The `SETUP` message is the first message each endpoint sends on its control
@@ -2718,6 +2855,14 @@ Senders SHOULD limit the value to the implementation name and version, avoiding
 advertising or other nonessential information. Implementations SHOULD NOT use
 the identifiers of other implementations to declare compatibility, as this
 undermines the usefulness of implementation identification for debugging.
+
+#### MAX_DTS_CONCURRENT_TRACKS {#max-dts-concurrent-tracks}
+
+The MAX_DTS_CONCURRENT_TRACKS option (Option Type 0x08) communicates the
+maximum number of tracks that can be allocated to Dynamic Track Switching (DTS)
+switching sets within a MOQT session. This maximum is the sum of all tracks
+across all switching sets within the session. This option is optional. The
+default value is 0 which prohibits the use of Dynamic Track Switching.
 
 
 ## GOAWAY {#message-goaway}
@@ -4932,6 +5077,7 @@ This registry is initially empty.
 | 0x04 | MAX_AUTH_TOKEN_CACHE_SIZE | {{max-auth-token-cache-size}} |
 | 0x05 | AUTHORITY | {{authority}} |
 | 0x07 | MOQT_IMPLEMENTATION | {{moqt-implementation}} |
+| 0x08 | MAX_DTS_CONCURRENT_TRACKS| {{max-dts-concurrent-tracks}} |
 | 0x7f * N + 0x9D | Reserved for greasing | {{grease}} |
 
 Endpoints MUST ignore unknown Setup Options as specified in
@@ -4977,6 +5123,7 @@ Setup Options SHOULD request a provisional registration.
 | 0x22 | GROUP_ORDER | {{group-order}} |
 | 0x32 | NEW_GROUP_REQUEST | {{new-group-request}} |
 | 0x34 | TRACK_NAMESPACE_PREFIX | {{track-namespace-prefix-param}} |
+| 0x41 | SWITCHING-SET-ASSIGNMENT | {{switching-set-assignment-param}} |
 
 * Message Parameters - List which params can be repeated in the table.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2141,28 +2141,32 @@ switching sets and result in identical relay behavior:
   by appending the SWITCHING-SET-ASSIGNMENT parameter to the PUBLISH_OK message.
 
 In both cases, tracks are grouped into a switching set by specifying the same switching set ID.
-The subscriber sets activate=0 for all tracks except the last one in each set, then sets
-activate=1 on the final track to signal that the set is complete and the relay should
-begin active track selection.
+The subscriber sets activate = N, where N is the number of tracks that will be assigned to that
+switching set.
 
 ### Subscriber operations
 
-To modify and established switching set, the subscriber can
+To modify an established switching set, the subscriber can
 
-* Add track to existing set: send SUBSCRIBE or PUBLISH_OK with a SWITCHING-SET-ASSIGNMENT parameter
+* Add a track to an existing set: send SUBSCRIBE or PUBLISH_OK with a SWITCHING-SET-ASSIGNMENT parameter
   referencing an existing set.
-* Remove track: Unsubscribe from that track
-* Pause DTS: Send REQUEST_UPDATE with a SWITCHING-SET-ASSIGNMENT parameter defining activate = 0
-* Resume DTS: Send REQUEST_UPDATE with a SWITCHING-SET-ASSIGNMENT parameter defining activate = 1
+* Remove a track from a set: unsubscribe from that track.
+* Pause DTS: Send REQUEST_UPDATE for any track assigned to that set with a SWITCHING-SET-ASSIGNMENT
+  parameter defining activate = 0.
+* Resume DTS: Send REQUEST_UPDATE for any track assigned to that set with a SWITCHING-SET-ASSIGNMENT
+  parameter defining activate = N, where N is the number of tracks assigned to that switching set. 
 
 ### Relay behavior
 
 When the relay receives a subscription with SWITCHING-SET-ASSIGNMENT:
 
-1. Add subscription to the specified switching set, creating the set if needed.
-2. Set Forward state to 0 for the new subscription
-3. Store the Set throughput fraction and rank as properties of the set
-4. If Activate switching = 1, begin active track selection, forwarding objects for selected track.
+1. Add the subscription to the specified switching set, creating the set if needed.
+2. Set Forward state to 0 for the new subscription.
+3. Store 'throughput' as a property of the subscription.
+4. Store 'fraction', 'rank' and 'activate' as properties of the set.
+5. If the number of tracks assigned to the set is >= the activate switching value, then begin
+   active track selection by applying the bandwidth allocation algorithm {{allocation-algorithm}} at the
+   next group boundary.
 
 If the relay receives a PUBLISH_DONE message, or an UNSUBSCRIBE for a subscription that was
 previously added to a switching set, then it must remove that subscription from the switching set
@@ -2184,7 +2188,7 @@ The relay maintains:
 - `sum_F`: Sum of all set fractions, updated incrementally as subscriptions are added or removed
 - 'set.fraction': for each switching set, the switching set fraction, as defined by the set
   throughput fraction of the SWITCHING-SET-ASSIGNMENT {{switching-set-assignment-param}} parameter.
-  - 'set.rank': for each switching set, the switching set rank, as defined by the optional set
+- 'set.rank': for each switching set, the switching set rank, as defined by the optional set
   rank field of the SWITCHING-SET-ASSIGNMENT {{switching-set-assignment-param}} parameter.
 
 On a periodic update interval or at a minimum of a new Group boundary, the relay executes the
@@ -2709,7 +2713,7 @@ SWITCHING-SET-ASSIGNMENT {
   Switching set ID (vi64),
   Throughput threshold (vi64),
   Set throughput fraction (vi64),
-  Activate switching (1),
+  Activate switching (vi64),
   [Set rank (8)]
 }
 ~~~
@@ -2717,7 +2721,10 @@ SWITCHING-SET-ASSIGNMENT {
 * Switching set ID: Integer identifying the switching set. A track MUST only be assigned
   to one switching set at a time. If a subscription attempts to assign a track that is
   already assigned to a different switching set, the relay MUST reject the subscription
-  with a Parameter Error.
+  with a Parameter Error. If a subscription attempts to assign a track, when the number of
+  tracks already assigned to switching sets within the session is
+  >= MAX_DTS_CONCURRENT_TRACKS {{max-dts-concurrent-tracks}}, then the relay MUST reject
+  the subscription with a Parameter Error.
 
 * Throughput threshold: Minimum throughput (kbps) required to select this track.
 
@@ -2730,10 +2737,9 @@ SWITCHING-SET-ASSIGNMENT {
   different fraction values, the relay MUST use the value from the most recently received
   message for that set.
 
-* Activate switching: When set to 0, DTS switching is paused for this set (use when
-  more subscriptions will be added, or to temporarily freeze the current selection).
-  When set to 1, the relay activates or resumes switching. Changes to the selected
-  track take effect at the next group boundary.
+* Activate switching: Integer, when set to 0, pauses DTS switching for this set. When set
+  to N, the relay activates or resumes switching as soon as the number of tracks assigned to
+  the switching set is >= N.  Activation takes effect at the next group boundary.
 
 * Set rank (optional): Degradation priority when bandwidth is constrained, expressed as
   an 8-bit unsigned integer (1-255). Default is 1. Values outside this range MUST result in

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2128,17 +2128,17 @@ the client. The relay selects exactly one track per switching set to forward at 
 given time.
 
 
-### Switching set establishment 
+### Switching set establishment
 
 Subscribers can create switching sets through two methods. Both support single or multiple
 switching sets and result in identical relay behavior:
 
 * Individual SUBSCRIBE: - the subscriber sends a separate SUBSCRIBE message for each track,
-  and appends the SWITCHING-SET-ASSIGNMENT parameter to assign the track to a switching set. 
+  and appends the SWITCHING-SET-ASSIGNMENT parameter to assign the track to a switching set.
 
 * SUBSCRIBE_NAMESPACE: - the subscriber sends a SUBSCRIBE_NAMESPACE message. For each matching
   track, the relay will issue a PUBLISH message. The subscriber assigns tracks to switching sets
-  by appending the SWITCHING-SET-ASSIGNMENT parameter to the PUBLISH_OK message. 
+  by appending the SWITCHING-SET-ASSIGNMENT parameter to the PUBLISH_OK message.
 
 In both cases, tracks are grouped into a switching set by specifying the same switching set ID.
 The subscriber sets activate=0 for all tracks except the last one in each set, then sets
@@ -2169,7 +2169,7 @@ previously added to a switching set, then it must remove that subscription from 
 and continue to process the switching across the remaining subscriptions within that set.
 
 If all tracks are removed from a previously established switching set, then that set is
-considered deleted and is removed from the bandwidth allocation algorithm. 
+considered deleted and is removed from the bandwidth allocation algorithm.
 
 ### Bandwidth Allocation {#allocation-algorithm}
 
@@ -2180,7 +2180,7 @@ The relay maintains:
   estimate SHOULD be at least the Group duration of the track. The estimate is obtained
   periodically from the QUIC stack (e.g., congestion window pacing rate, smoothed RTT)
   and MAY be supplemented by external sources or application-level feedback. The exact mechanism
-  is not defined by this specification and MAY vary between implementations. 
+  is not defined by this specification and MAY vary between implementations.
 - `sum_F`: Sum of all set fractions, updated incrementally as subscriptions are added or removed
 - 'set.fraction': for each switching set, the switching set fraction, as defined by the set
   throughput fraction of the SWITCHING-SET-ASSIGNMENT {{switching-set-assignment-param}} parameter.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2136,7 +2136,7 @@ switching sets and result in identical relay behavior:
 * Individual SUBSCRIBE: - the subscriber sends a separate SUBSCRIBE message for each track,
   and appends the SWITCHING-SET-ASSIGNMENT parameter to assign the track to a switching set.
 
-* SUBSCRIBE_NAMESPACE: - the subscriber sends a SUBSCRIBE_NAMESPACE message. For each matching
+* SUBSCRIBE_TRACKS: - the subscriber sends a SUBSCRIBE_TRACKS message. For each matching
   track, the relay will issue a PUBLISH message. The subscriber assigns tracks to switching sets
   by appending the SWITCHING-SET-ASSIGNMENT parameter to the PUBLISH_OK message.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2408,7 +2408,7 @@ When the publisher receives a subscription with SWITCHING-SET-ASSIGNMENT:
 If the publisher receives a PUBLISH_DONE message, or an UNSUBSCRIBE for a subscription that was
 previously added to a switching set, then it must remove that subscription from the switching set
 and continue to process the switching across the remaining subscriptions within that set. The value of
-'activate switching' MUST be decremented by one to enable the swictching to remain active. 
+'activate switching' MUST be decremented by one to enable the swictching to remain active.
 
 If all tracks are removed from a previously established switching set, then that set is
 considered deleted and is removed from the bandwidth allocation algorithm.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2154,7 +2154,7 @@ To modify an established switching set, the subscriber can
 * Pause DTS: Send REQUEST_UPDATE for any track assigned to that set with a SWITCHING-SET-ASSIGNMENT
   parameter defining activate = 0.
 * Resume DTS: Send REQUEST_UPDATE for any track assigned to that set with a SWITCHING-SET-ASSIGNMENT
-  parameter defining activate = N, where N is the number of tracks assigned to that switching set. 
+  parameter defining activate = N, where N is the number of tracks assigned to that switching set.
 
 ### Relay behavior
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2118,8 +2118,8 @@ prioritize sending Objects based on {{priorities}}.
 Sender Side Track Switching (SSTS) is a subscriber-initiated and controlled behavior in which
 relays dynamically select which track to forward from a switching set based on
 various algorithms. Each algorithm defines a set of attributes which are passed in the
-SWITCHING-SET-ASSIGNMENT parameter {{TBD}} along with a complimentary set of rules for subscriber
-operations and relay behavior.
+SWITCHING-SET-ASSIGNMENT parameter {{switching-set-assignment-param}} along with a
+complimentary set of rules for subscriber behavior and relay behavior.
 
 This specification defines a default algorithm - type 0. Other algorithms are referenced in the
 "MOQT SSTS Algorithms" registry {{iana-ssts-algorithms}}.
@@ -2177,7 +2177,7 @@ SWITCHING-SET-ASSIGNMENT {
   different fraction values, the relay MUST use the value from the most recently received
   message for that set.
 
-* Activate switching: Integer, when set to 0, pauses DTS switching for this set. When set
+* Activate switching: Integer, when set to 0, pauses SSTS switching for this set. When set
   to N, the relay activates or resumes switching as soon as the number of tracks assigned to
   the switching set is >= N.  Activation takes effect at the next group boundary.
 
@@ -5112,7 +5112,7 @@ This registry is initially empty.
 | 0x04 | MAX_AUTH_TOKEN_CACHE_SIZE | {{max-auth-token-cache-size}} |
 | 0x05 | AUTHORITY | {{authority}} |
 | 0x07 | MOQT_IMPLEMENTATION | {{moqt-implementation}} |
-| 0x08 | MAX_DTS_CONCURRENT_TRACKS| {{max-dts-concurrent-tracks}} |
+| 0x09 | SSTS_ALGORITHMS | {{ssts-algorithms}} |
 | 0x7f * N + 0x9D | Reserved for greasing | {{grease}} |
 
 Endpoints MUST ignore unknown Setup Options as specified in

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2162,7 +2162,7 @@ When the relay receives a subscription with SWITCHING-SET-ASSIGNMENT:
 1. Add subscription to the specified switching set, creating the set if needed.
 2. Set Forward state to 0 for the new subscription
 3. Store the Set throughput fraction and rank as properties of the set
-4. If Activate switching = 1, begin active track selection
+4. If Activate switching = 1, begin active track selection, forwarding objects for selected track.
 
 If the relay receives a PUBLISH_DONE message, or an UNSUBSCRIBE for a subscription that was
 previously added to a switching set, then it must remove that subscription from the switching set


### PR DESCRIPTION
Adds the Sender-Side Track Switching (SSTS) feature, detailing subscriber operations, relay behavior, and bandwidth allocation algorithm.

Adds a new SWITCHING-SET-ASSIGNMENT parameter. 

Fixes #259 