### PR TITLE
Editorial: Move generic URI-scheme prose out of Fragment Identifiers; reorder Session establishment

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -911,6 +911,8 @@ that registers the fragment type.
 Fragment type identifiers are registered in the "MOQT URI Fragment
 Types" registry ({{iana-fragment-types}}).
 
+### Dereferencing a MOQT URI
+
 The default operation for dereferencing a `moqt` URI is to establish a
 MOQT session to the identified server.
 


### PR DESCRIPTION
The Fragment Identifiers subsection contained text generic to the whole moqt URI scheme.

  Two commits:

  1. Fix the misplacement: move every generic line (media type included) back under MOQT URI Scheme, leaving Fragment Identifiers with only fragment-specific text. Pure relocation, no wording changes.
  2. Move Fragment Identifiers to the end: the fragment is the last component of a URI, so it reads more naturally after the transport subsections. Pure move.