### PR TITLE
Clarify PROPERTIES bit description in transport draft

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -4020,8 +4020,8 @@ in the header:
 
 * The **PROPERTIES** bit (0x01) indicates when the Properties field is present
   in all Objects in this Subgroup. When set to 1, the Object Properties structure
-  defined in {{object-properties}} is present in all Objects. When set to 0, the
-  field is never present. Objects with no properties set Properties Length to 0.
+  defined in {{object-properties}} is present in all Objects; Objects with no
+  properties set Properties Length to 0. When set to 0, the field is never present.
 
 * The **SUBGROUP_ID_MODE** field (bits 1-2, mask 0x06) is a two-bit field that
   determines the encoding of the Subgroup ID. To extract this value, perform a


### PR DESCRIPTION
The ordering of the sentences read in a contradictory way, so it was ambiguous whether to include a 0 length when PROPERTIES is 0.

Fixed it with a semi-colon.