### PR TITLE
Replace Joining FETCH with fill fetch streams

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2222,7 +2222,7 @@ one publisher is available, the Relay MAY send the FETCH to any of them.
 
 When a Relay receives a SUBSCRIBE with a fill filter type, it serves the fill
 portion from its cache and retrieves any missing objects upstream using
-SUBSCRIBE or FETCHes (see {{fill-semantics}}).
+a SUBSCRIBE with fill or FETCHes (see {{fill-semantics}}).
 
 When a Relay receives an authorized SUBSCRIBE for a Track with one or more
 `Established` upstream subscriptions, it MUST reply with SUBSCRIBE_OK.  If the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1542,7 +1542,8 @@ A publisher MUST NOT send objects from outside the requested range.
 
 Fill filter types (AbsoluteStartFill, AbsoluteRangeFill, and
 RelativeStartFill) cause the publisher to open a unidirectional stream beginning
-with a FETCH_HEADER (see {{fetch-header}}). This is called a fill fetch stream.
+with a FETCH_HEADER (see {{fetch-header}}) and delivered as a FETCH response (see
+{{message-fetch}}). This is called a fill fetch stream.
 
 The fill fetch stream carries the fill range: the objects from the fill Start
 Location up to and including the fill boundary. The fill boundary
@@ -1572,7 +1573,9 @@ fill fetch stream.
 
 An object delivered on the fill fetch stream is **fill-delivered**. Because the
 subscription filter necessarily overlaps the fill range, an object can be both
-fill-delivered and subscription-delivered.
+fill-delivered and subscription-delivered. A subscriber can avoid duplicate
+delivery by setting FILL_TIMEOUT to 0 in FILL_PARAMETERS (see {{fill-timeout}}):
+the fill fetch stream then carries only objects that are immediately available.
 
 #### Opening and Closing Fill Fetch Streams
 
@@ -2636,10 +2639,11 @@ The following parameters MAY appear inside FILL_PARAMETERS:
 A parameter that is omitted from FILL_PARAMETERS takes the value it has for the
 subscription; FILL_PARAMETERS therefore carries only the settings that
 differ. An endpoint that receives a parameter inside FILL_PARAMETERS that is not
-permitted above MUST close the session with `PROTOCOL_VIOLATION`.
+listed above MUST close the session with `PROTOCOL_VIOLATION`.
 
-FILL_PARAMETERS is meaningful only with a fill filter type. If it is present
-without a fill filter type, it is ignored.
+FILL_PARAMETERS is meaningful only with a fill filter type. An endpoint that
+receives FILL_PARAMETERS in a message that specifies a non-fill filter type MUST
+close the session with `PROTOCOL_VIOLATION`.
 
 ### EXPIRES Parameter {#expires}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1639,9 +1639,8 @@ fill filter type) while Forward State is 1.
   one whose Start Location does not add objects beyond an earlier fill (for
   example, one that only decreases the End Group), does not open a new fill fetch
   stream.
-- When Forward State transitions to 0, or the subscription is cancelled with
-  STOP_SENDING on the bidi stream, the publisher MUST reset any open fill fetch
-  streams.
+- When the subscription is cancelled with STOP_SENDING on the bidi stream, the
+  publisher MUST reset any open fill fetch streams.
 
 The publisher signals that the fill is complete by closing the stream with a FIN
 once all objects up to and including the fill boundary have been
@@ -3322,8 +3321,9 @@ REQUEST_UPDATE Message {
 
 When a subscriber decreases the Start Location of the Subscription Filter
 (see {{subscription-filters}}), the Start Location can be smaller than the Track's
-Largest Location, similar to a new Subscription. The publisher delivers the new
-fill range by opening a new fill fetch stream (see {{fill-semantics}}).
+Largest Location, similar to a new Subscription. If a fill filter is specified,
+the publisher delivers the new fill range by opening a new fill fetch stream
+(see {{fill-semantics}}).
 
 When a subscriber increases the End Location, the Largest Object at
 the publisher might already be larger than the previous End Location. This will

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1593,7 +1593,7 @@ RelativeStartFill) cause the publisher to open a unidirectional stream beginning
 with a FETCH_HEADER (see {{fetch-header}}) and delivered as a FETCH response (see
 {{message-fetch}}). This is called a fill fetch stream.
 
-The fill fetch stream carries the fill range: the objects from the fill Start
+The fill fetch stream carries the objects from the fill Start
 Location up to and including the fill boundary. The fill boundary
 is the Largest Object, or the End Group when one is specified with a Location
 less than the Largest Object. The subscriber

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1411,9 +1411,7 @@ PUBLISH_DONE ({{message-publish-done}}) are sent regardless of the forward state
 
 A publisher MUST save the Largest Location communicated in SUBSCRIBE_OK, PUBLISH
 or REQUEST_UPDATE_OK that changes the Forward State
-from 0 to 1.  This value is called the Joining Location and can be used in a
-Joining FETCH (see {{joining-fetches}}) while the subscription is in the
-`Established` state.
+from 0 to 1.
 
 Either endpoint can initiate a subscription to a track without exchanging any
 prior messages other than SETUP.  Relays MUST NOT send any PUBLISH messages
@@ -1492,6 +1490,7 @@ Subscription Filter {
   Filter Type (vi64),
   [Start Location (Location),]
   [End Group Delta (vi64),]
+  [Relative Previous (vi64),]
 }
 ~~~
 
@@ -1509,30 +1508,96 @@ Next Group Start (0x1): The filter Start Location is `{Largest Object.Group + 1,
 0}` and `Largest Object` is communicated in SUBSCRIBE_OK. If no content has been
 delivered yet, the filter Start Location is {0, 0}.  There is no End Group -
 the subscription is open ended. For scenarios where the subscriber intends to
-start from more than one group in the future, it can use an AbsoluteStart filter
-instead.
+start from more than one group in the future, it can use an AbsoluteStartFill
+filter instead.
 
-AbsoluteStart (0x3): The filter Start Location is specified explicitly. The
-specified `Start Location` MAY be less than the `Largest Object` observed at the
-publisher. There is no End Group - the subscription is open ended.  An
-AbsoluteStart filter with `Start` = {0, 0} is equivalent to an unfiltered
-subscription.
+AbsoluteStartFill (0x3): The filter Start Location is specified explicitly.
+There is no End Group - the subscription is open ended. The subscription opens a
+fill fetch stream for already-published objects (see {{fill-semantics}}).
 
-AbsoluteRange (0x4): The filter Start Location and End Group are specified
-explicitly. The specified `Start Location` MAY be less than the `Largest Object`
-observed at the publisher. If the specified `End Group Delta` is zero, the
-remainder of that Group passes the filter. Otherwise, the last Group ID to be
-delivered will be the Group ID in `Start Location` plus the `End Group Delta`.
-If the resulting Group ID would be greater than 2^64 - 1, the endpoint MUST
-close the session with a `PROTOCOL_VIOLATION`.
+AbsoluteRangeFill (0x4): The filter Start Location and End Group Delta are
+specified explicitly. If the specified `End Group Delta` is zero, the remainder
+of the Start Location's Group passes the filter. Otherwise, the last Group ID to
+be delivered is the Group ID in `Start Location` plus the `End Group Delta`. If
+the resulting Group ID would be greater than 2^64 - 1, the endpoint MUST close
+the session with a `PROTOCOL_VIOLATION`. The subscription opens a fill fetch
+stream for already-published objects (see {{fill-semantics}}).
+
+RelativeStartFill (0x5): Relative Previous is present. The value N in
+Relative Previous determines the Start Location: `{Largest Object.Group - N, 0}`
+(N = 0 starts at Largest Object.Group). If N is greater than Largest
+Object.Group, the Start Location is `{0, 0}`. There is no End Group - the
+subscription is open ended. The subscription opens a fill fetch stream for
+already-published objects (see {{fill-semantics}}).
 
 An endpoint that receives a filter type other than the above MUST close the
 session with `PROTOCOL_VIOLATION`.
 
-If the publisher cannot satisfy the requested Subscription Filter (see
-{{subscription-filter}}) or if the entire End Group has already been published
-it SHOULD send a REQUEST_ERROR with code `INVALID_RANGE`.  A publisher MUST
-NOT send objects from outside the requested range.
+A publisher MUST NOT send objects from outside the requested range. Every
+subscription filter type yields a satisfiable range (see {{fill-semantics}}).
+
+### Fill Semantics {#fill-semantics}
+
+Fill filter types (AbsoluteStartFill, AbsoluteRangeFill, and
+RelativeStartFill) cause the publisher to open a unidirectional stream beginning
+with a FETCH_HEADER (see {{fetch-header}}) to deliver already-published objects.
+This is called a fill fetch stream.
+
+The fill fetch stream carries objects from the fill Start Location up to and
+including the fill boundary. The fill boundary is the Largest Object, or the End
+Group if one is specified and it precedes the Largest Object. The subscriber
+learns the Largest Object from the `LARGEST_OBJECT` parameter in SUBSCRIBE_OK or
+REQUEST_UPDATE_OK. For RelativeStartFill, both sides compute the fill Start
+Location as `{Largest Object.Group - N, 0}`. For any fill filter type, if the
+Start Location is after the Largest Object the fill range is empty, the
+publisher does not open a fill fetch stream, and the subscription proceeds
+live-only. If the End Group precedes the Largest Object, only the fill fetch
+stream delivers objects and the subscription remains open (for example, for a
+later REQUEST_UPDATE).
+
+The fill fetch stream inherits the subscription's parameters, including
+subscriber priority and authorization; a FILL_PARAMETERS parameter (see
+{{fill-parameters}}) MAY override individual parameters for the fill fetch
+stream. FILL_TIMEOUT (see {{fill-timeout}}) applies to fill fetch streams in the
+same way it applies to a FETCH.
+
+The FETCH_HEADER on the fill fetch stream carries the Request ID of the message
+that initiated it: the SUBSCRIBE Request ID for the initial fill, or the
+REQUEST_UPDATE Request ID for a subsequent fill. A subscription can have
+multiple fill fetch streams open at once, each identified by its Request ID;
+opening a new fill fetch stream does not implicitly cancel any previously opened
+fill fetch stream.
+
+Because the subscription filter necessarily overlaps the fill fetch range, an
+object can be delivered both on the fill fetch stream and via subgroups or
+datagrams.
+
+#### Opening and Closing Fill Fetch Streams
+
+A publisher opens a fill fetch stream when it processes a SUBSCRIBE or
+REQUEST_UPDATE that specifies a fill filter type (a SUBSCRIPTION_FILTER with a
+fill filter type) while Forward State is 1.
+
+- A fill filter specified while Forward State is 0 opens no fill fetch stream.
+  Transitioning to Forward State 1 without re-specifying the fill filter does
+  not open one either.
+- A REQUEST_UPDATE that does not specify a fill filter type, or that specifies
+  one whose Start Location does not add objects beyond an earlier fill (for
+  example, one that only changes the End Group), does not open a new fill fetch
+  stream.
+- When Forward State transitions to 0, or the subscription is cancelled with
+  STOP_SENDING on the bidi stream, the publisher MUST reset any open fill fetch
+  streams.
+
+The publisher signals that the fill is complete by closing the stream with a FIN
+once all objects up to and including the fill boundary have been
+delivered. Because there is no REQUEST_ERROR associated with a fill fetch
+stream, the publisher signals a fill failure by resetting the stream; it can
+open a fill fetch stream and reset it immediately after the FETCH_HEADER if
+necessary. A subscriber can cancel a fill fetch stream independently by sending
+STOP_SENDING on it. Resetting or cancelling a fill fetch stream, by either
+endpoint, does not affect the subscription, which continues to deliver objects
+using subscribe subgroups and datagrams.
 
 ### Joining an Ongoing Track
 
@@ -1541,9 +1606,18 @@ is a join point, so in order for a subscriber to join a Track, it needs to
 request an existing Group or wait for a future Group.  Different applications
 will have different approaches for when to begin a new Group.
 
-To join a Track at a past Group, the subscriber sends a SUBSCRIBE, PUBLISH_OK or
-REQUEST_UPDATE with Forward State 1 followed by a Joining FETCH (see
-{{joining-fetches}}) for the intended start Group, which can be relative.
+To join a Track immediately, the subscriber sends a SUBSCRIBE with Filter Type
+`Largest Object`. Delivery begins with the next Object and can begin mid-group.
+
+To join a Track at the current Group, the subscriber sends a SUBSCRIBE with
+Filter Type `RelativeStartFill` and Relative Previous N = 0, which fills the
+current Group from its start.
+
+To join a Track at a past Group, the subscriber sends a SUBSCRIBE with a fill
+filter type (AbsoluteStartFill, AbsoluteRangeFill, or RelativeStartFill). The
+publisher fills already-published objects and delivers newer objects live (see
+{{fill-semantics}}).
+
 To join a Track at the next Group, the subscriber sends a SUBSCRIBE with
 Filter Type `Next Group Start`.
 
@@ -1552,9 +1626,9 @@ Filter Type `Next Group Start`.
 While some publishers will deterministically create new Groups, other
 applications might want to only begin a new Group when needed.  A subscriber
 joining a Track might detect that it is more efficient to request the Original
-Publisher create a new group than issue a Joining FETCH.  Publishers indicate a
-Track supports dynamic group creation using the DYNAMIC_GROUPS parameter
-({{dynamic-groups}}).
+Publisher create a new group than to fill the current group.  Publishers
+indicate a Track supports dynamic group creation using the DYNAMIC_GROUPS
+parameter ({{dynamic-groups}}).
 
 One possible subscriber pattern is to SUBSCRIBE to a Track using Filter Type
 `Largest Object` and observe the `Largest Location` in the response.  If the
@@ -1592,7 +1666,6 @@ A REQUEST_ERROR indicates that both endpoints can immediately destroy state.
 Since a relay can start delivering FETCH Objects from cache before determining
 the result of the request, some Objects could be received even if the FETCH
 results in error.
-
 
 # Namespace Discovery {#track-discovery}
 
@@ -1750,16 +1823,25 @@ the objects SHOULD be selected as follows:
 1. If two objects have the same subscriber priority, but different publisher
    priorities, the one with **the highest publisher priority** is scheduled to be
    sent first.
-2. If two objects in response to the same request have the same subscriber
-   and publisher priority, but belong to two different groups of the same track,
-   **the group order** of the associated subscription is used to
-   decide the one that is scheduled to be sent first.
-3. If two objects in response to the same request have the same subscriber
-   and publisher priority and belong to the same group of the same track, the
-   one with **the lowest Subgroup ID** (for objects with forwarding preference
+
+2. If two objects in the same subscription have the same subscriber and
+   publisher priority, but belong to two different groups of the same track,
+   **the group order** of the subscription is used to decide the one that is
+   scheduled to be sent first. When a subscription fill's Group Order differs
+   from the subscription's Group Order, the live-delivered object is scheduled
+   first.
+3. If two objects in the same subscription have the same subscriber
+   and publisher priority and belong to the same group of the same track, and
+   one is delivered by the fill fetch stream while the other is delivered by the
+   live subscription, the fill-delivered object is scheduled first. Otherwise,
+   the one with **the lowest Subgroup ID** (for objects with forwarding preference
    Subgroup), or **the lowest Object ID** (for objects with forwarding preference
    Datagram) is scheduled to be sent first.  If the two objects have
    different Forwarding Preferences the order is implementation dependent.
+
+Within the same group, fill-delivered objects win the tie-break over
+live-delivered objects (rule 3) because objects before the fill boundary are
+assumed to be needed before those after it.
 
 The definition of "scheduled to be sent first" in the algorithm is implementation
 dependent and is constrained by the prioritization interface of the underlying
@@ -2056,6 +2138,10 @@ When a Relay needs to make an upstream FETCH request, it determines the
 available publishers using the same matching rules as SUBSCRIBE. When more than
 one publisher is available, the Relay MAY send the FETCH to any of them.
 
+When a Relay receives a SUBSCRIBE with a fill filter type, it serves the fill
+portion from its cache and retrieves any missing objects upstream using
+SUBSCRIBE or FETCHes (see {{fill-semantics}}).
+
 When a Relay receives an authorized SUBSCRIBE for a Track with one or more
 `Established` upstream subscriptions, it MUST reply with SUBSCRIBE_OK.  If the
 SUBSCRIBE has Forward State=1 and the upstream subscriptions are in Forward
@@ -2201,8 +2287,8 @@ the length of the Message Payload, the receiver MUST close the session with a
 ## Request ID {#request-id}
 
 Request ID is included in request messages and is used to identify
-requests across messages. For example, Joining Fetch references
-the Request ID of a SUBSCRIBE.
+requests across messages. For example, fetch streams reference
+the Request ID of a SUBSCRIBE, PUBLISH, FETCH, or REQUEST_UPDATE.
 
 The client generates even numbered Request IDs, starting at 0, and the
 server generates odd numbered Request IDs, starting at 1.  Each
@@ -2431,7 +2517,10 @@ for the same track.
 
 ### FILL TIMEOUT Parameter {#fill-timeout}
 
-The FILL_TIMEOUT parameter (Parameter Type 0x0A) MAY appear in a FETCH message.
+The FILL_TIMEOUT parameter (Parameter Type 0x0A) MAY appear in a FETCH message,
+or inside a FILL_PARAMETERS parameter (see {{fill-parameters}}) in a SUBSCRIBE
+or REQUEST_UPDATE (for a subscription), where it applies to the fill fetch
+stream.
 
 It is the maximum total duration in milliseconds a relay SHOULD spend waiting
 for upstream sources to provide Objects that are not immediately available
@@ -2492,12 +2581,15 @@ the value 128.
 ### GROUP ORDER Parameter {#group-order}
 
 The GROUP_ORDER parameter (Parameter Type 0x22) is a uint8. It MAY appear in a
-SUBSCRIBE, PUBLISH_OK, or FETCH.
+SUBSCRIBE, PUBLISH_OK, or FETCH, or inside a FILL_PARAMETERS parameter (see
+{{fill-parameters}}).
 
 Its value indicates how to prioritize Objects from different groups within
 the same subscription (see {{priorities}}), or how to order Groups in a Fetch
-response (see {{fetch-handling}}). The allowed values are Ascending (0x1) or
-Descending (0x2). If an endpoint receives a value outside this range, it MUST
+response (see {{message-fetch}}). When it appears inside FILL_PARAMETERS, it
+governs the fill fetch stream and its ordering relative to the live subscription
+(see {{priorities}}). The allowed values are Ascending (0x1) or Descending
+(0x2). If an endpoint receives a value outside this range, it MUST
 close the session with `PROTOCOL_VIOLATION`.
 
 If omitted from SUBSCRIBE, the publisher's preference from
@@ -2509,8 +2601,44 @@ The SUBSCRIPTION_FILTER parameter (Parameter Type 0x21) uses length-prefixed
 encoding. It MAY appear in a SUBSCRIBE, PUBLISH_OK or REQUEST_UPDATE (for a
 subscription) message. It is a Subscription Filter (see {{subscription-filters}}).
 
-If omitted from SUBSCRIBE or PUBLISH_OK, the subscription is
-unfiltered.  If omitted from REQUEST_UPDATE, the value is unchanged.
+Fill filter types (AbsoluteStartFill, AbsoluteRangeFill, RelativeStartFill)
+MUST NOT appear in PUBLISH_OK. A publisher that receives a
+PUBLISH_OK with one of these filter types MUST close the session with
+`PROTOCOL_VIOLATION`. The LARGEST_OBJECT in PUBLISH may be stale by the time
+PUBLISH_OK is processed, making the fill boundary unreliable.
+To fill-join a track initiated via PUBLISH, the
+subscriber SHOULD respond with PUBLISH_OK with Forward State 0, then send
+REQUEST_UPDATE with Forward State 1 and a fill filter type. The
+REQUEST_UPDATE_OK will contain a fresh LARGEST_OBJECT establishing the correct
+fill boundary.
+
+If omitted from SUBSCRIBE or PUBLISH_OK, the subscription is unfiltered: it
+passes all Objects published or received from the time of subscription. If
+omitted from REQUEST_UPDATE, the value is unchanged.
+
+### FILL PARAMETERS Parameter {#fill-parameters}
+
+The FILL_PARAMETERS parameter (Parameter Type 0x23) uses length-prefixed
+encoding. It MAY appear in a SUBSCRIBE or REQUEST_UPDATE (for a subscription)
+message. Its value is a block of Key-Value Pairs (see {{moq-key-value-pair}})
+that apply to the fill fetch stream of a subscription using a fill filter type
+(see {{fill-semantics}}).
+
+The following parameters MAY appear inside FILL_PARAMETERS:
+
+| Parameter Type | Parameter Name | Specification |
+|----------------|----------------|---------------|
+| 0x0A | FILL_TIMEOUT | {{fill-timeout}} |
+| 0x20 | SUBSCRIBER_PRIORITY | {{subscriber-priority}} |
+| 0x22 | GROUP_ORDER | {{group-order}} |
+
+A parameter that is omitted from FILL_PARAMETERS takes the value it has for the
+live subscription; FILL_PARAMETERS therefore carries only the settings that
+differ. An endpoint that receives a parameter inside FILL_PARAMETERS that is not
+permitted above MUST close the session with `PROTOCOL_VIOLATION`.
+
+FILL_PARAMETERS is meaningful only with a fill filter type. If it is present
+without a fill filter type, it is ignored.
 
 ### EXPIRES Parameter {#expires}
 
@@ -2962,8 +3090,7 @@ DOES_NOT_EXIST:
 : The track or namespace is not available at the publisher.
 
 INVALID_RANGE:
-: In response to SUBSCRIBE or FETCH, specified Filter or range of Locations
-cannot be satisfied.
+: In response to FETCH, the specified range of Locations cannot be satisfied.
 
 MALFORMED_TRACK:
 : In response to a FETCH, a relay publisher detected the track was
@@ -2987,16 +3114,13 @@ NAMESPACE_TOO_LARGE:
 : In response to SUBSCRIBE_NAMESPACE or SUBSCRIBE_TRACKS, the namespace prefix
 matches more publishers than the relay is willing to enumerate.
 
-INVALID_JOINING_REQUEST_ID:
-: In response to a Joining FETCH, the referenced Request ID is not an
-`Established` Subscription.
-
 ## SUBSCRIBE {#message-subscribe-req}
 
-A subscription causes the publisher to send newly published objects for a track.
-
-Subscribe only requests newly published or received Objects.  Objects from the
-past are retrieved using FETCH ({{message-fetch}}).
+SUBSCRIBE initiates a subscription to a track.  The associated parameters
+determine the range and mechanism of object delivery; the Subscription Filter
+(see {{subscription-filters}}) selects which Objects are sent, and a fill filter
+type additionally retrieves already-published Objects on a fill fetch stream
+(see {{fill-semantics}}).
 
 The format of SUBSCRIBE is as follows:
 
@@ -3085,12 +3209,12 @@ REQUEST_UPDATE Message {
 
 * Parameters: The parameters are defined in {{message-params}}.
 
-### Updating Subscriptions
+### Updating Subscriptions {#updating-subscriptions}
 
 When a subscriber decreases the Start Location of the Subscription Filter
 (see {{subscription-filters}}), the Start Location can be smaller than the Track's
-Largest Location, similar to a new Subscription. FETCH can be used to retrieve
-any necessary Objects smaller than the current Largest Location.
+Largest Location, similar to a new Subscription. The publisher delivers the new
+fill range by opening a new fill fetch stream (see {{fill-semantics}}).
 
 When a subscriber increases the End Location, the Largest Object at
 the publisher might already be larger than the previous End Location. This will
@@ -3178,7 +3302,8 @@ A publisher that sends the FORWARD parameter ({{forward-parameter}}) equal to 0
 indicates that it will not transmit any objects until the subscriber sets the
 Forward State to 1. If the FORWARD parameter is omitted or equal to 1, the
 publisher will start transmitting objects immediately, possibly before
-PUBLISH_OK.
+PUBLISH_OK. Delivery starts at the Largest Object at the time the publisher
+begins sending.
 
 
 ## PUBLISH_DONE {#message-publish-done}
@@ -3205,6 +3330,11 @@ A sender MUST NOT destroy subscription state until it sends PUBLISH_DONE, though
 it can choose to stop sending objects (and thus send PUBLISH_DONE) for any
 reason. A sender SHOULD send FIN on the subscription's bidi stream immediately
 after sending PUBLISH_DONE.
+
+A publisher MAY delay sending PUBLISH_DONE after the end of a Track if it
+intends to allow subscribers to request fills (see {{fill-semantics}}) of the
+completed Track. PUBLISH_DONE ends the subscription, after which no further fill
+fetch streams can be opened.
 
 A subscriber that receives PUBLISH_DONE SHOULD set a timer of at least the
 larger of SUBGROUP_DELIVERY_TIMEOUT or OBJECT_DELIVERY_TIMEOUT in case some
@@ -3234,7 +3364,8 @@ PUBLISH_DONE Message {
 
 * Stream Count: An integer indicating the number of data streams the publisher
 opened for this subscription, including streams that contained no Objects (e.g.,
-an empty Subgroup).  This helps the subscriber know if it has received
+an empty Subgroup) and including any fill fetch streams (see
+{{fill-semantics}}).  This helps the subscriber know if it has received
 all of the data published in this subscription by comparing the number of
 streams received.  The subscriber can immediately remove all subscription state
 once the same number of streams have been processed.  If the publisher did not open any streams
@@ -3290,31 +3421,25 @@ EXCESSIVE_LOAD (0x9):
 A subscriber sends FETCH as the first message on a new bidi stream to a
 publisher to request a range of already published objects within a track.
 
-There are three types of Fetch messages.
-
-Code | Fetch Type
-0x1 | Standalone Fetch
-0x2 | Relative Joining Fetch
-0x3 | Absolute Joining Fetch
-
-An endpoint that receives a Fetch Type other than 0x1, 0x2 or 0x3 MUST close
-the session with a `PROTOCOL_VIOLATION`.
-
-### Standalone Fetch
-
-A Fetch of Objects performed independently of any Subscribe.
-
-A Standalone Fetch includes this structure:
+The format of FETCH is as follows:
 
 ~~~
-Standalone Fetch {
+FETCH Message {
+  Type (vi64) = 0x16,
+  Length (16),
+  Request ID (vi64),
   Track Namespace (..),
   Track Name Length (vi64),
   Track Name (..),
   Start Location (Location),
-  End Location (Location)
+  End Location (Location),
+  Number of Parameters (vi64),
+  Parameters (..) ...
 }
 ~~~
+{: #moq-transport-fetch-format title="MOQT FETCH Message"}
+
+* Request ID: See {{request-id}}.
 
 * Track Namespace: Identifies the namespace of the track as defined in
 ({{track-name}}).
@@ -3325,103 +3450,6 @@ Standalone Fetch {
 
 * End Location: The end Location, plus 1. A Location.Object value of 0
   means the entire group is requested.
-
-### Joining Fetches
-
-A Joining Fetch is associated with a Subscribe request by
-specifying the Request ID of a subscription in the `Established` or
-`Pending (subscriber)` state. Because Joining Fetch references an existing
-subscription, if that subscription has not yet been established, the Publisher
-receiving the Joining Fetch buffers the pending Joining Fetch until either
-the Subscription is established or the request times out.
-
-A publisher receiving a Joining Fetch uses properties of the associated
-subscription to determine the Track Namespace, Track Name
-and End Location such that it is contiguous with the associated
-subscription.  The subscriber can set the Start Location to an absolute
-Location or a Location relative to the Largest group.
-
-A Subscriber can use a Joining Fetch to, for example, fill a playback buffer
-with a certain number of groups prior to the live edge of a track.
-
-A Joining Fetch is only permitted when the associated subscription has
-Forward State 1; otherwise the publisher MUST respond with a
-REQUEST_ERROR with error code `INVALID_RANGE`. A publisher MUST process
-any pending REQUEST_UPDATE
-messages for the associated subscription before evaluating the current
-request. Relays with an upstream subscription in transition from Forward State 0
-to 1 can either send a Joining Fetch upstream or buffer the Joining Fetch until
-the upstream subscription returns REQUEST_UPDATE_OK with the new Largest Object.
-Changing the Forward State of the associated subscription to 0 after the Joining
-Fetch has been accepted has no effect on the Joining Fetch.
-
-If no Objects have been published for the track the publisher MUST
-respond with a REQUEST_ERROR with error code `INVALID_RANGE`.
-
-A Joining Fetch includes this structure:
-
-~~~
-Joining Fetch {
-  Joining Request ID (vi64),
-  Joining Start (vi64)
-}
-~~~
-
-* Joining Request ID: The Request ID of the subscription to be joined. If a
-  publisher receives a Joining Fetch with a Request ID that does not correspond
-  to a subscription in the same session in the `Established` or `Pending
-  (subscriber)` states, it MUST return a REQUEST_ERROR with error code
-  `INVALID_JOINING_REQUEST_ID`.
-
-* Joining Start : A relative or absolute value used to determine the Start
-  Location, described below.
-
-#### Joining Fetch Range Calculation
-
-The Joining Location value from the corresponding
-subscription is used to calculate the end of a Joining Fetch, so the
-Objects retrieved by the FETCH and SUBSCRIBE are contiguous and non-overlapping.
-
-The publisher receiving a Joining Fetch sets the End Location to
-{Joining Location.Group, Joining Location.Object + 1} (see {{subscriptions}}.
-
-Note: the last Object included in the Joining FETCH response is the Object
-at the Joining Location.  The `+ 1` above indicates the equivalent Standalone
-Fetch encoding.
-
-For a Relative Joining Fetch, the publisher sets the Start Location to
-{Joining Location.Group - Joining Start, 0}.
-
-For an Absolute Joining Fetch, the publisher sets the Start Location to
-{Joining Start, 0}.
-
-
-### Fetch Handling
-
-The format of FETCH is as follows:
-
-~~~
-FETCH Message {
-  Type (vi64) = 0x16,
-  Length (16),
-  Request ID (vi64),
-  Fetch Type (vi64),
-  [Standalone (Standalone Fetch),]
-  [Joining (Joining Fetch),]
-  Number of Parameters (vi64),
-  Parameters (..) ...
-}
-~~~
-{: #moq-transport-fetch-format title="MOQT FETCH Message"}
-
-* Request ID: See {{request-id}}.
-
-* Fetch Type: Identifies the type of Fetch, whether Standalone, Relative
-  Joining or Absolute Joining.
-
-* Standalone: Standalone Fetch structure included when Fetch Type is 0x1
-
-* Joining: Joining Fetch structure included when Fetch Type is 0x2 or 0x3.
 
 * Parameters: The parameters are defined in {{message-params}}.
 
@@ -3454,7 +3482,7 @@ The Object Forwarding Preference does not apply to fetches.
 
 Fetch specifies an inclusive range of Objects starting at Start Location and
 ending at End Location. End Location MUST specify the same or a larger Location
-than Start Location for Standalone and Absolute Joining Fetches.
+than Start Location.
 
 Objects larger than the Largest Object will not be retrieved by a FETCH.  If the
 requested End Location exceeds the Largest available Object, the actual end of
@@ -3504,8 +3532,6 @@ FETCH_OK Message {
   the requested range extends beyond published data:
    - If the requested FETCH End Location was beyond the Largest known (possibly
      final) Object, End Location is {Largest.Group, Largest.Object + 1}
-  Where Fetch.End Location is either Fetch.Standalone.End Location or the computed
-  End Location described in {{joining-fetch-range-calculation}}.
 
   If End Location is smaller than the Start Location in the corresponding FETCH
   the receiver MUST close the session with a `PROTOCOL_VIOLATION`.
@@ -4194,7 +4220,7 @@ as defined in {{stream-reset-codes}}.
 ### Fetch Header {#fetch-header}
 
 When a stream begins with `FETCH_HEADER`, all objects on the stream belong to the
-track requested in the Fetch message identified by `Request ID`.
+track requested in the message identified by `Request ID`.
 
 ~~~
 FETCH_HEADER {
@@ -4987,6 +5013,7 @@ Setup Options SHOULD request a provisional registration.
 | 0x20 | SUBSCRIBER_PRIORITY | {{subscriber-priority}} |
 | 0x21 | SUBSCRIPTION_FILTER | {{subscription-filter}} |
 | 0x22 | GROUP_ORDER | {{group-order}} |
+| 0x23 | FILL_PARAMETERS | {{fill-parameters}} |
 | 0x32 | NEW_GROUP_REQUEST | {{new-group-request}} |
 | 0x34 | TRACK_NAMESPACE_PREFIX | {{track-namespace-prefix-param}} |
 
@@ -5106,7 +5133,6 @@ This document does not define any initial entries.
 | UNINTERESTED               | 0x20 | {{message-request-error}} |
 | PREFIX_OVERLAP             | 0x30 | {{message-request-error}} |
 | NAMESPACE_TOO_LARGE        | 0x31 | {{message-request-error}} |
-| INVALID_JOINING_REQUEST_ID | 0x32 | {{message-request-error}} |
 | UNSUPPORTED_EXTENSION      | 0x33 | {{message-request-error}} |
 | REDIRECT                   | 0x34 | {{message-request-error}} |
 | Reserved for greasing      | 0x7f * N + 0x9D | {{grease}} |

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1533,8 +1533,7 @@ already-published objects (see {{fill-semantics}}).
 An endpoint that receives a filter type other than the above MUST close the
 session with `PROTOCOL_VIOLATION`.
 
-A publisher MUST NOT send objects from outside the requested range. Every
-subscription filter type yields a satisfiable range (see {{fill-semantics}}).
+A publisher MUST NOT send objects from outside the requested range.
 
 ### Fill Semantics {#fill-semantics}
 
@@ -1583,7 +1582,7 @@ fill filter type) while Forward State is 1.
   not open one either.
 - A REQUEST_UPDATE that does not specify a fill filter type, or that specifies
   one whose Start Location does not add objects beyond an earlier fill (for
-  example, one that only changes the End Group), does not open a new fill fetch
+  example, one that only decreases the End Group), does not open a new fill fetch
   stream.
 - When Forward State transitions to 0, or the subscription is cancelled with
   STOP_SENDING on the bidi stream, the publisher MUST reset any open fill fetch
@@ -1820,17 +1819,16 @@ the objects SHOULD be selected as follows:
 
 1. If two objects have different subscriber priorities associated with them,
    the one with **the highest subscriber priority** is scheduled to be sent first.
-1. If two objects have the same subscriber priority, but different publisher
+2. If two objects have the same subscriber priority, but different publisher
    priorities, the one with **the highest publisher priority** is scheduled to be
    sent first.
-
-2. If two objects in the same subscription have the same subscriber and
+3. If two objects in the same subscription have the same subscriber and
    publisher priority, but belong to two different groups of the same track,
    **the group order** of the subscription is used to decide the one that is
    scheduled to be sent first. When a subscription fill's Group Order differs
    from the subscription's Group Order, the live-delivered object is scheduled
    first.
-3. If two objects in the same subscription have the same subscriber
+4. If two objects in the same subscription have the same subscriber
    and publisher priority and belong to the same group of the same track, and
    one is delivered by the fill fetch stream while the other is delivered by the
    live subscription, the fill-delivered object is scheduled first. Otherwise,
@@ -1840,7 +1838,7 @@ the objects SHOULD be selected as follows:
    different Forwarding Preferences the order is implementation dependent.
 
 Within the same group, fill-delivered objects win the tie-break over
-live-delivered objects (rule 3) because objects before the fill boundary are
+live-delivered objects (rule 4) because objects before the fill boundary are
 assumed to be needed before those after it.
 
 The definition of "scheduled to be sent first" in the algorithm is implementation

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1523,7 +1523,7 @@ published or received via upstream subscriptions.
 All filters have a Start Location and an optional End Group Delta.  Only objects
 published or received via a subscription having Locations greater than or
 equal to Start Location and strictly less than or equal to the End Group (when
-present) pass the filter.
+present) pass the filter.  A publisher MUST NOT send objects from outside the requested range.
 
 An object published or received in a subgroup or datagram is
 **subscription-delivered**. Objects delivered via a fill-fetch stream
@@ -1565,7 +1565,7 @@ filter instead.
 
 AbsoluteStartFill (0x3): The filter Start Location is specified explicitly.
 There is no End Group - the subscription is open ended. The subscription opens a
-fill fetch stream for the fill range (see {{fill-semantics}}).
+fill fetch stream for the fill range, if any (see {{fill-semantics}}).
 
 AbsoluteRangeFill (0x4): The filter Start Location and End Group Delta are
 specified explicitly. If the specified `End Group Delta` is zero, the remainder
@@ -1573,7 +1573,7 @@ of the Start Location's Group passes the filter. Otherwise, the last Group ID to
 be delivered is the Group ID in `Start Location` plus the `End Group Delta`. If
 the resulting Group ID would be greater than 2^64 - 1, the endpoint MUST close
 the session with a `PROTOCOL_VIOLATION`. The subscription opens a fill fetch
-stream for the fill range (see {{fill-semantics}}).
+stream for the fill range, if any (see {{fill-semantics}}).
 
 RelativeStartFill (0x5): Relative Previous is present. The value N in
 Relative Previous determines the Start Location: `{Largest Object.Group - N, 0}`
@@ -1585,8 +1585,6 @@ fill range (see {{fill-semantics}}).
 An endpoint that receives a filter type other than the above MUST close the
 session with `PROTOCOL_VIOLATION`.
 
-A publisher MUST NOT send objects from outside the requested range.
-
 ### Fill Semantics {#fill-semantics}
 
 Fill filter types (AbsoluteStartFill, AbsoluteRangeFill, and
@@ -1596,7 +1594,7 @@ with a FETCH_HEADER (see {{fetch-header}}) and delivered as a FETCH response (se
 
 The fill fetch stream carries the objects from the fill Start
 Location up to and including the fill boundary. The fill boundary
-is the Largest Object, or the End Group when one is specified with a Location
+is the Largest Object at the time the Location Filter is received, or the End Group when one is specified with a Location
 less than the Largest Object. The subscriber
 learns the Largest Object from the `LARGEST_OBJECT` parameter in SUBSCRIBE_OK or
 REQUEST_UPDATE_OK. For RelativeStartFill, both sides compute the fill Start
@@ -1618,7 +1616,7 @@ that initiated it: the SUBSCRIBE Request ID for the initial fill, or the
 REQUEST_UPDATE Request ID for a subsequent fill. A subscription can have
 multiple fill fetch streams open at once, each identified by its Request ID;
 opening a new fill fetch stream does not implicitly cancel any previously opened
-fill fetch stream.
+fill fetch streams.
 
 An object delivered on the fill fetch stream is **fill-delivered**. Because the
 subscription filter necessarily overlaps the fill range, an object can be both
@@ -1668,7 +1666,7 @@ current Group from its start.
 
 To join a Track at a past Group, the subscriber sends a SUBSCRIBE with a fill
 filter type (AbsoluteStartFill, AbsoluteRangeFill, or RelativeStartFill). The
-publisher delivers the fill range, and objects with larger Locations in a
+publisher delivers the fill range via a fill-fetch stream, and newly published or received objects in a
 subgroup or datagram (see {{fill-semantics}}).
 
 To join a Track at the next Group, the subscriber sends a SUBSCRIBE with

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1526,7 +1526,8 @@ equal to Start Location and strictly less than or equal to the End Group (when
 present) pass the filter.
 
 An object published or received in a subgroup or datagram is
-**subscription-delivered**.
+**subscription-delivered**. Objects delivered via a fill-fetch stream
+{fill-semantics} are **fill-delivered**.
 
 Some filters are defined to be relative to the `Largest Object`. The `Largest
 Object` is the Object with the largest Location ({{location-structure}}) in the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1477,6 +1477,9 @@ published or received via a subscription having Locations greater than or
 equal to Start Location and strictly less than or equal to the End Group (when
 present) pass the filter.
 
+An object published or received in a subgroup or datagram is
+**subscription-delivered**.
+
 Some filters are defined to be relative to the `Largest Object`. The `Largest
 Object` is the Object with the largest Location ({{location-structure}}) in the
 Track from the perspective of the publisher processing the message. Largest
@@ -1513,7 +1516,7 @@ filter instead.
 
 AbsoluteStartFill (0x3): The filter Start Location is specified explicitly.
 There is no End Group - the subscription is open ended. The subscription opens a
-fill fetch stream for already-published objects (see {{fill-semantics}}).
+fill fetch stream for the fill range (see {{fill-semantics}}).
 
 AbsoluteRangeFill (0x4): The filter Start Location and End Group Delta are
 specified explicitly. If the specified `End Group Delta` is zero, the remainder
@@ -1521,14 +1524,14 @@ of the Start Location's Group passes the filter. Otherwise, the last Group ID to
 be delivered is the Group ID in `Start Location` plus the `End Group Delta`. If
 the resulting Group ID would be greater than 2^64 - 1, the endpoint MUST close
 the session with a `PROTOCOL_VIOLATION`. The subscription opens a fill fetch
-stream for already-published objects (see {{fill-semantics}}).
+stream for the fill range (see {{fill-semantics}}).
 
 RelativeStartFill (0x5): Relative Previous is present. The value N in
 Relative Previous determines the Start Location: `{Largest Object.Group - N, 0}`
 (N = 0 starts at Largest Object.Group). If N is greater than Largest
 Object.Group, the Start Location is `{0, 0}`. There is no End Group - the
-subscription is open ended. The subscription opens a fill fetch stream for
-already-published objects (see {{fill-semantics}}).
+subscription is open ended. The subscription opens a fill fetch stream for the
+fill range (see {{fill-semantics}}).
 
 An endpoint that receives a filter type other than the above MUST close the
 session with `PROTOCOL_VIOLATION`.
@@ -1539,18 +1542,18 @@ A publisher MUST NOT send objects from outside the requested range.
 
 Fill filter types (AbsoluteStartFill, AbsoluteRangeFill, and
 RelativeStartFill) cause the publisher to open a unidirectional stream beginning
-with a FETCH_HEADER (see {{fetch-header}}) to deliver already-published objects.
-This is called a fill fetch stream.
+with a FETCH_HEADER (see {{fetch-header}}). This is called a fill fetch stream.
 
-The fill fetch stream carries objects from the fill Start Location up to and
-including the fill boundary. The fill boundary is the Largest Object, or the End
-Group if one is specified and it precedes the Largest Object. The subscriber
+The fill fetch stream carries the fill range: the objects from the fill Start
+Location up to and including the fill boundary. The fill boundary
+is the Largest Object, or the End Group when one is specified with a Location
+less than the Largest Object. The subscriber
 learns the Largest Object from the `LARGEST_OBJECT` parameter in SUBSCRIBE_OK or
 REQUEST_UPDATE_OK. For RelativeStartFill, both sides compute the fill Start
 Location as `{Largest Object.Group - N, 0}`. For any fill filter type, if the
-Start Location is after the Largest Object the fill range is empty, the
-publisher does not open a fill fetch stream, and the subscription proceeds
-live-only. If the End Group precedes the Largest Object, only the fill fetch
+Start Location is greater than the Largest Object the fill range is empty, the
+publisher does not open a fill fetch stream. If the End Group has a Location
+less than the Largest Object, only the fill fetch
 stream delivers objects and the subscription remains open (for example, for a
 later REQUEST_UPDATE).
 
@@ -1567,9 +1570,9 @@ multiple fill fetch streams open at once, each identified by its Request ID;
 opening a new fill fetch stream does not implicitly cancel any previously opened
 fill fetch stream.
 
-Because the subscription filter necessarily overlaps the fill fetch range, an
-object can be delivered both on the fill fetch stream and via subgroups or
-datagrams.
+An object delivered on the fill fetch stream is **fill-delivered**. Because the
+subscription filter necessarily overlaps the fill range, an object can be both
+fill-delivered and subscription-delivered.
 
 #### Opening and Closing Fill Fetch Streams
 
@@ -1614,8 +1617,8 @@ current Group from its start.
 
 To join a Track at a past Group, the subscriber sends a SUBSCRIBE with a fill
 filter type (AbsoluteStartFill, AbsoluteRangeFill, or RelativeStartFill). The
-publisher fills already-published objects and delivers newer objects live (see
-{{fill-semantics}}).
+publisher delivers the fill range, and objects with larger Locations in a
+subgroup or datagram (see {{fill-semantics}}).
 
 To join a Track at the next Group, the subscriber sends a SUBSCRIBE with
 Filter Type `Next Group Start`.
@@ -1826,20 +1829,20 @@ the objects SHOULD be selected as follows:
    publisher priority, but belong to two different groups of the same track,
    **the group order** of the subscription is used to decide the one that is
    scheduled to be sent first. When a subscription fill's Group Order differs
-   from the subscription's Group Order, the live-delivered object is scheduled
+   from the subscription's Group Order, the subscription-delivered object is scheduled
    first.
 4. If two objects in the same subscription have the same subscriber
    and publisher priority and belong to the same group of the same track, and
-   one is delivered by the fill fetch stream while the other is delivered by the
-   live subscription, the fill-delivered object is scheduled first. Otherwise,
+   one is delivered by the fill fetch stream while the other is
+   subscription-delivered, the fill-delivered object is scheduled first. Otherwise,
    the one with **the lowest Subgroup ID** (for objects with forwarding preference
    Subgroup), or **the lowest Object ID** (for objects with forwarding preference
    Datagram) is scheduled to be sent first.  If the two objects have
    different Forwarding Preferences the order is implementation dependent.
 
 Within the same group, fill-delivered objects win the tie-break over
-live-delivered objects (rule 4) because objects before the fill boundary are
-assumed to be needed before those after it.
+subscription-delivered objects (rule 4) because objects with smaller Locations
+are assumed to be needed before those with larger Locations.
 
 The definition of "scheduled to be sent first" in the algorithm is implementation
 dependent and is constrained by the prioritization interface of the underlying
@@ -2585,8 +2588,8 @@ SUBSCRIBE, PUBLISH_OK, or FETCH, or inside a FILL_PARAMETERS parameter (see
 Its value indicates how to prioritize Objects from different groups within
 the same subscription (see {{priorities}}), or how to order Groups in a Fetch
 response (see {{message-fetch}}). When it appears inside FILL_PARAMETERS, it
-governs the fill fetch stream and its ordering relative to the live subscription
-(see {{priorities}}). The allowed values are Ascending (0x1) or Descending
+governs the fill fetch stream and its ordering relative to subscription-delivered
+Objects (see {{priorities}}). The allowed values are Ascending (0x1) or Descending
 (0x2). If an endpoint receives a value outside this range, it MUST
 close the session with `PROTOCOL_VIOLATION`.
 
@@ -2631,7 +2634,7 @@ The following parameters MAY appear inside FILL_PARAMETERS:
 | 0x22 | GROUP_ORDER | {{group-order}} |
 
 A parameter that is omitted from FILL_PARAMETERS takes the value it has for the
-live subscription; FILL_PARAMETERS therefore carries only the settings that
+subscription; FILL_PARAMETERS therefore carries only the settings that
 differ. An endpoint that receives a parameter inside FILL_PARAMETERS that is not
 permitted above MUST close the session with `PROTOCOL_VIOLATION`.
 
@@ -3117,7 +3120,7 @@ matches more publishers than the relay is willing to enumerate.
 SUBSCRIBE initiates a subscription to a track.  The associated parameters
 determine the range and mechanism of object delivery; the Subscription Filter
 (see {{subscription-filters}}) selects which Objects are sent, and a fill filter
-type additionally retrieves already-published Objects on a fill fetch stream
+type additionally retrieves the fill range on a fill fetch stream
 (see {{fill-semantics}}).
 
 The format of SUBSCRIBE is as follows:

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1601,8 +1601,14 @@ EndGroup and EndObject are `Largest Object`.
 
 When EndObject is omitted, the filter includes all objects in the End Group.
 
+A Location Filter on a subscription is always valid, even if it specifies a range
+entirely before Largest Object.
+
 A publisher MUST NOT send subscription-delivered objects from outside the
-requested range.  Fill-delivered objects are governed by the Location filter in
+requested range.  Because updating filters is asynchronous,
+subscribers can receive objects outside the current filter.
+
+Fill-delivered objects are governed by the Location filter in
 FILL_PARAMETERS (see {{fill-semantics}}).
 
 ### Fill Semantics {#fill-semantics}
@@ -1624,17 +1630,18 @@ inside FILL_PARAMETERS is zero-length, the fill range is the entire track up to
 Because the fill range is specified independently of the subscription's
 Location filter, a subscriber can retrieve a range of Groups prior to the live
 edge while the subscription itself starts at the Next Group.  If the fill range
-is empty, the publisher does not open a fill fetch stream.
+is empty, or starts after Largest Object, the publisher does not open a fill fetch stream.
 
 The fill fetch stream inherits the subscription's parameters, including
-subscriber priority and authorization; parameters carried inside
+subscriber priority, range filters and authorization; parameters carried inside
 FILL_PARAMETERS override them for the fill fetch stream.  FILL_TIMEOUT (see
 {{fill-timeout}}) applies to fill fetch streams in the same way it applies to a
 FETCH.
 
 The FETCH_HEADER on the fill fetch stream carries the Request ID of the message
 that initiated it: the SUBSCRIBE Request ID for the initial fill, or the
-REQUEST_UPDATE Request ID for a subsequent fill.  A subscription can have
+REQUEST_UPDATE Request ID for a subsequent fill.  As a result of
+REQUEST_UPDATE, a subscription can have
 multiple fill fetch streams open at once, each identified by its Request ID;
 opening a new fill fetch stream does not implicitly cancel any previously
 opened fill fetch streams.
@@ -1642,8 +1649,8 @@ opened fill fetch streams.
 An object delivered on the fill fetch stream is **fill-delivered**.  When the
 fill range overlaps the subscription's Location filter, an object can be both
 fill-delivered and subscription-delivered.  A subscriber that wants each Object
-delivered exactly once specifies a fill range that ends immediately before the
-start of the subscription's Location filter.
+delivered exactly once uses the Next Object Subscription Location Filter coupled
+with an open-ended fill range, which the publisher will end at Largest Object.
 
 #### Opening and Closing Fill Fetch Streams
 
@@ -1655,15 +1662,14 @@ REQUEST_UPDATE that carries FILL_PARAMETERS while Forward State is 1.
   open one either.
 - A REQUEST_UPDATE that does not carry FILL_PARAMETERS does not open a new fill
   fetch stream.
-- When the subscription is cancelled with STOP_SENDING on the bidi stream, the
-  publisher MUST reset any open fill fetch streams.
+- When the subscription is cancelled, the publisher MUST reset any open fill fetch streams.
 
 The publisher signals that the fill is complete by closing the stream with a
 FIN once all objects in the fill range have been delivered.  Because there is
 no REQUEST_ERROR associated with a fill fetch stream, the publisher signals a
-fill failure by resetting the stream; it can open a fill fetch stream and reset
+fill failure by resetting the stream; it MUST open a fill fetch stream and reset
 it immediately after the FETCH_HEADER if necessary.  A subscriber can cancel a
-fill fetch stream independently by sending STOP_SENDING on it.  Resetting or
+fill fetch stream independently using STOP_SENDING.  Resetting or
 cancelling a fill fetch stream, by either endpoint, does not affect the
 subscription, which continues to deliver objects using subscribe subgroups and
 datagrams.
@@ -1740,7 +1746,7 @@ to further restrict which tracks and objects pass all filter criteria.
 This includes all Range Filters {{range-filters}} and Location
 Filters {{location-filters}}, which can be evaluated in any order.
 The Forward parameter is also a type of filter.  The publisher MUST
-forward only subscription-delivered objects that pass all filters.
+forward only objects that pass all filters.
 
 ~~~
 Pass = Forward AND Location Filters AND Range Filters
@@ -1765,7 +1771,7 @@ the current Group from its start.
 To join a Track at a past Group, the subscriber sends a SUBSCRIBE with a
 FILL_PARAMETERS parameter whose Location filter selects the intended Groups,
 which can be relative.  The publisher delivers the fill range on a fill fetch
-stream and delivers newly published or received Objects in subgroups or
+stream and subscription-delivered Objects in subgroups or
 datagrams (see {{fill-semantics}}).
 
 To join a Track at the next Group, the subscriber sends a SUBSCRIBE with
@@ -2861,6 +2867,10 @@ The following parameters MAY appear inside FILL_PARAMETERS:
 | 0x20 | SUBSCRIBER_PRIORITY | {{subscriber-priority}} |
 | 0x21 | LOCATION_FILTER | {{location-filter}} |
 | 0x22 | GROUP_ORDER | {{group-order}} |
+| 0x25 | SUBGROUP_FILTER | {{range-filters}} |
+| 0x26 | OBJECTID_FILTER | {{range-filters}} |
+| 0x27 | PRIORITY_FILTER | {{range-filters}} |
+| 0x28 | OBJECT_PROPERTY_FILTER | {{range-filters}} |
 
 The LOCATION_FILTER inside FILL_PARAMETERS selects the fill range and is
 evaluated using the rules for a Fetch (see {{location-filters}}); it is
@@ -3673,10 +3683,6 @@ A sender MUST NOT destroy subscription state until it sends PUBLISH_DONE, though
 it can choose to stop sending objects (and thus send PUBLISH_DONE) for any
 reason.
 
-A publisher MAY delay sending PUBLISH_DONE after the end of a Track if it
-intends to allow subscribers to request fills (see {{fill-semantics}}) of the
-completed Track. PUBLISH_DONE ends the subscription, after which no further fill
-fetch streams can be opened.
 
 A subscriber that receives PUBLISH_DONE SHOULD set a timer of at least the
 larger of SUBGROUP_DELIVERY_TIMEOUT or OBJECT_DELIVERY_TIMEOUT in case some


### PR DESCRIPTION
A revision of #1642, this PR allows any range of objects passed to subscription to be satisfied.  The portion of the range before Largest Object comes on a "fill fetch stream" -- a unidirectional stream beginning with a FETCH_HEADER.

- Renamed AbsoluteStart/Range filters to AbsoluteStart/RangeFill, and added a new filter: RelativeStartFill.
- Defined the semantics of fill-fetch and the streams are opened and closed
- Added a FILL_PARAMETERS parameter, which carries the fill-specific versions of SUBSCRIBER_PRIORITY, GROUP_ORDER, etc
- Updated the priority algorithm to explain how to order objects on fill-fetch vs the live portion of a subscription
  - Different Groups, same Group Order -> object's group determines
  - Different Groups and Different Group Order -> live wins
  - Same Group -> fill-fetch wins
- Explained how PUBLISH_OK and REQUEST_UPDATE work with new filter types
- Removed the Joining version of FETCH and removed the "standalone" monikker
- Minor updates to PUBLISH_DONE to include fill-fetch streams in stream count, and allow the publisher to delay the message
- INVALID_RANGE now only applies to FETCH

Fixes: #1039
Fixes: #1313
Fixes: #1614