### PR TITLE
Discuss upstream filter aggregation tradeoffs

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1980,7 +1980,8 @@ multiple subscribers request the same Track. Subscription aggregation
 allows relays to make only a single upstream subscription for the
 Track. The published content received from the upstream subscription
 request is cached and shared among the pending subscribers.
-Because MOQT restricts widening a subscription, relays that
+Because changing the range of an established subscription is not retroactive
+and can create gaps that require FETCH requests to fill, relays that
 aggregate upstream subscriptions can subscribe using the Largest Object
 filter to avoid churn as downstream subscribers with disparate filters
 subscribe and unsubscribe from a Track.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2309,13 +2309,13 @@ allows relays to make only a single upstream subscription for the
 Track. The published content received from the upstream subscription
 request is cached and shared among the pending subscribers.
 Because changing the range of an established subscription is not retroactive
-and can create gaps that require FETCH requests to fill, relays that
-aggregate upstream subscriptions can subscribe using the Largest Object
-Location filter to avoid churn as downstream subscribers with disparate filters
-subscribe and unsubscribe from a Track. Aggregating subscriptions can also
-help relays conserve resources especially with disparate filters or
-SUBSCRIBE_TRACKS in a namespace with a large number of Tracks
-(see {{large-namespaces}}).
+and can create gaps that require a fill fetch stream (see {{fill-semantics}})
+or a FETCH to fill, relays that aggregate upstream subscriptions can subscribe
+using a Location Filter that starts at the Next Object to avoid churn as
+downstream subscribers with disparate filters subscribe and unsubscribe from
+a Track. Aggregating subscriptions can also help relays conserve resources
+especially with disparate filters or SUBSCRIBE_TRACKS in a namespace with a
+large number of Tracks (see {{large-namespaces}}).
 
 A subscriber remains subscribed to a Track at a Relay until it unsubscribes, the
 upstream publisher terminates the subscription, or the subscription expires (see

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2308,14 +2308,14 @@ multiple subscribers request the same Track. Subscription aggregation
 allows relays to make only a single upstream subscription for the
 Track. The published content received from the upstream subscription
 request is cached and shared among the pending subscribers.
-Because changing the range of an established subscription is not retroactive
-and can create gaps that require a fill fetch stream (see {{fill-semantics}})
-or a FETCH to fill, relays that aggregate upstream subscriptions can subscribe
-using a Location Filter that starts at the Next Object to avoid churn as
-downstream subscribers with disparate filters subscribe and unsubscribe from
-a Track. Aggregating subscriptions can also help relays conserve resources
-especially with disparate filters or SUBSCRIBE_TRACKS in a namespace with a
-large number of Tracks (see {{large-namespaces}}).
+Relays that aggregate subscriptions MAY combine filters from downstream
+subscribers on the upstream subscription, up to the peer's MAX_FILTER_RANGES.
+If adding filters to an upstream subscription is not possible, the relay can either
+remove some or all filters, or make additional subscriptions to the same Track.
+Multiple subscriptions to the same Track with non-disjoint filter sets will result in
+duplicate objects arriving at the relay.  Using wider upstream filters can protect the
+relay from churn as subscribers with disparate filters subscribe and unsubscribe from
+a Track, at the cost of receiving more objects.
 
 A subscriber remains subscribed to a Track at a Relay until it unsubscribes, the
 upstream publisher terminates the subscription, or the subscription expires (see


### PR DESCRIPTION
Draft-14 forbade the widening of subscriptions, but draft-18 doesn't. I'm making changes to a section of text that mentions that widening subscriptions is not allowed.

Fixes: #1826 