### PR TITLE
Complete the REDIRECT applicability list

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2948,8 +2948,9 @@ REDIRECT:
 location specified in the Redirect structure. The requester SHOULD establish a
 new session to the provided URI (if present) and retry the request using the
 Full Track Name from the Redirect (if present). This error code can appear in
-response to SUBSCRIBE, FETCH, TRACK_STATUS, PUBLISH_NAMESPACE and
-SUBSCRIBE_NAMESPACE. Relays are not required to follow redirects from upstream
+response to SUBSCRIBE, FETCH, TRACK_STATUS, PUBLISH, PUBLISH_NAMESPACE,
+SUBSCRIBE_NAMESPACE, and SUBSCRIBE_TRACKS. Relays are not required to follow
+redirects from upstream
 and MAY forward a REDIRECT response to matching downstream requests. A relay
 MAY cache a REDIRECT response for a Full Track Name for up to Retry Interval
 milliseconds and use it to respond to subsequent matching requests without


### PR DESCRIPTION
REDIRECT could be returned for any request that an endpoint declines but that may succeed elsewhere, but PUBLISH and SUBSCRIBE_TRACKS were missing from the list of messages it can appear in response to. Add them.

Fixes: #1725