### PR TITLE
Remove duplicate relay object payload modification text

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -493,8 +493,7 @@ payload portion may be encrypted, in which case it is only visible to the
 Original Publisher and End Subscribers. The Original Publisher is solely
 responsible for the content of the object payload. This includes the
 underlying encoding, compression, any end-to-end encryption, or
-authentication. A relay MUST NOT combine, split, or otherwise modify object
-payloads.
+authentication.
 
 Objects within a Group are in ascending order by Object ID.
 


### PR DESCRIPTION
The normative statement that a relay MUST NOT combine, split, or otherwise modify object payloads appeared in both the Object Data Model introduction and Relay Object Handling. Keep it in Relay Object Handling, where the surrounding text already requires relays to treat the payload as opaque.

Fixes: #1715