### PR TITLE
Recommend Secure Objects for confidentiality from relays

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -4710,6 +4710,12 @@ access to media objects, object sizes and traffic patterns enable
 analysis of content. Track namespace and track name can also be
 analyzed and correlated between end subscribers by relays.
 
+Consistent with the principle of confidential operation by default,
+content that must not be exposed to relays can be kept confidential by
+applying end-to-end object encryption, for example using Secure Objects
+({{I-D.ietf-moq-secure-objects}}), so that relays retain access only to
+the metadata required for forwarding.
+
 The end-to-end media security is handled by mechanisms external to this
 specification. They need to provide source authenticity and
 confidentiality. MOQT's object model does enable both the object

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -4747,17 +4747,11 @@ Consistent with the principle of confidential operation by default,
 content that must not be exposed to relays can be kept confidential by
 applying end-to-end object encryption, for example using Secure Objects
 ({{I-D.ietf-moq-secure-objects}}), so that relays retain access only to
-the metadata required for forwarding.
-
-The end-to-end media security is handled by mechanisms external to this
-specification. They need to provide source authenticity and
-confidentiality. MOQT's object model does enable both the object
-data itself as well as Object Properties to be confidentiality and
-integrity protected. MOQT also supports Object Properties being
-integrity protected but not encrypted.
-
-Current proposals for media security include:
- - An E2EE scheme based on SFRAME: {{I-D.ietf-moq-secure-objects}}.
+the metadata required for forwarding. Such end-to-end security
+mechanisms are external to this specification and additionally provide
+source authenticity. MOQT's object model enables both the object data
+and Object Properties to be confidentiality and integrity protected, or
+integrity protected only.
 
 Secure key distribution for end-to-end encryption is specific to the
 encryption system and deployment, and outside the scope of this document.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -4744,8 +4744,7 @@ analysis of content. Track namespace and track name can also be
 analyzed and correlated between end subscribers by relays.
 
 Consistent with the principle of confidential operation by default,
-content that must not be exposed to relays can be kept confidential by
-applying end-to-end object encryption, for example using Secure Objects
+publishers can apply end-to-end object encryption, for example using Secure Objects
 ({{I-D.ietf-moq-secure-objects}}), so that relays retain access only to
 the metadata required for forwarding. Such end-to-end security
 mechanisms are external to this specification and additionally provide


### PR DESCRIPTION
Note in Media Security that, consistent with confidential operation by default, content that must not be exposed to relays can be protected with end-to-end object encryption such as Secure Objects, leaving relays only the metadata needed for forwarding.

I wonder if an overview draft pointing at both is better than creating a circular reference, but let's do this for now at least.

Fixes: #1711