### PR TITLE
Note that Subgroup end is signaled by stream FIN, not Object Status

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3846,6 +3846,10 @@ not exist.
 
 All of those SHOULD be cached.
 
+There is no Object Status value indicating the end of a Subgroup. The end of a
+Subgroup is signaled by closing its stream with a FIN
+(see {{closing-subgroup-streams}}).
+
 Any other value SHOULD be treated as a protocol error and the session SHOULD
 be closed with a `PROTOCOL_VIOLATION` ({{session-termination}}).
 Any object with a status code other than zero MUST have an empty payload.


### PR DESCRIPTION
Clarify in the Object Status section that there is no End of Subgroup status value because the end of a Subgroup is signaled by closing its stream with a FIN.

Fixes: #1728