### PR TITLE
Recommend Immutable Properties for relay-visible, unmodifiable data

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3865,8 +3865,9 @@ to MOQT Object distribution. Any Object metadata never intended to be accessed
 by the transport or Relays SHOULD be serialized as part of the Object payload
 and not as an Object Property.
 
-Object Properties that are intended to be visible to relays but not modified by
-them SHOULD be serialized within Immutable Properties ({{immutable-properties}}).
+Object Properties set by the Original Publisher that are intended to be visible
+to relays, but not modified by them, SHOULD be placed in Immutable Properties
+({{immutable-properties}}), which enables end-to-end authentication schemes.
 
 Object Properties are serialized as a length in bytes followed by
 Key-Value-Pairs (see {{moq-key-value-pair}}).

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3861,6 +3861,9 @@ to MOQT Object distribution. Any Object metadata never intended to be accessed
 by the transport or Relays SHOULD be serialized as part of the Object payload
 and not as an Object Property.
 
+Object Properties that are intended to be visible to relays but not modified by
+them SHOULD be serialized within Immutable Properties ({{immutable-properties}}).
+
 Object Properties are serialized as a length in bytes followed by
 Key-Value-Pairs (see {{moq-key-value-pair}}).
 


### PR DESCRIPTION
The Object Properties section did not guide authors toward Immutable Properties for data that relays should see but not change. Add a SHOULD pointing at Immutable Properties for that case.

Fixes: #1729