### PR TITLE
Remove relay exception for reordering or dropping objects

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1974,7 +1974,7 @@ to the priority (see {{priorities}}) and delivery timeout (see
 {{delivery-timeouts}}).
 
 A relay MUST NOT reorder or drop objects received on a multi-object stream when
-forwarding to subscribers, unless it has application specific information.
+forwarding to subscribers.
 
 Relays MAY aggregate authorized subscriptions for a given Track when
 multiple subscribers request the same Track. Subscription aggregation


### PR DESCRIPTION
The "unless it has application specific information" carve-out invited relays to justify reordering or dropping objects on a multi-object stream. Extensions that legitimately change forwarding behavior do so as negotiated extensions, not as unspecified application-specific behavior.

Fixes: #1705