### PR TITLE
Remove stray relay prioritization SHOULD

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2116,8 +2116,7 @@ A relay MUST NOT modify Object fields when forwarding, except for
 Object Properties as specified in {{properties}}.
 
 A relay MUST treat the object payload as opaque.  A relay MUST NOT
-combine, split, or otherwise modify object payloads.  A relay SHOULD
-prioritize sending Objects based on {{priorities}}.
+combine, split, or otherwise modify object payloads.
 
 # Control Messages {#message}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2118,6 +2118,8 @@ Object Properties as specified in {{properties}}.
 A relay MUST treat the object payload as opaque.  A relay MUST NOT
 combine, split, or otherwise modify object payloads.
 
+Relays prioritize forwarded Objects as described in {{priorities}}.
+
 # Control Messages {#message}
 
 MOQT uses a pair of unidirectional streams to exchange control messages, as


### PR DESCRIPTION
"A relay SHOULD prioritize sending Objects based on {{priorities}}" in Relay Object Handling restated normative requirements from the Priorities section as a weaker SHOULD, muddying which requirements apply. Remove it; the Priorities section is authoritative.

Fixes: #1716