### PR TITLE
Fix section 15.8 1-byte application-specific reservation

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -5033,7 +5033,7 @@ the length field.
 
 * MOQ Properties - we wish to define the following registration policies:
   - 0x00 to 0x77: Standards Action or IESG Approval (1-byte encoding)
-  - 0x78 to 0x7F: Reserved for application-specific use (1-byte encoding,
+  - 0x38 to 0x3F: Reserved for application-specific use (1-byte encoding,
     no registration permitted)
   - 0x80 to 0x37FF: Specification Required (2-byte encoding)
   - 0x3800 to 0x3FFF: Reserved for application-specific use (2-byte encoding,


### PR DESCRIPTION
Section 2.5 reserves 0x38 to 0x3F and 0x3800 to 0x3FFF for application use, but section 15.8 reserves 0x78 to 0x7F.

This addresses #1646