### PR TITLE
Clarify forwarding preference order in scheduling

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1792,7 +1792,7 @@ the objects SHOULD be selected as follows:
    one with **the lowest Subgroup ID** (for objects with forwarding preference
    Subgroup), or **the lowest Object ID** (for objects with forwarding preference
    Datagram) is scheduled to be sent first.  If the two objects have
-   different Forwarding Preferences the order is implementation dependent.
+   different Forwarding Preferences the datagram is sent first.
 
 The definition of "scheduled to be sent first" in the algorithm is implementation
 dependent and is constrained by the prioritization interface of the underlying


### PR DESCRIPTION
Two Objects
Same Request
Same Sub Pri
Same Pub Pri
One Subgroup, One datagram --> datagram wins

Fixes: #1702