### PR TITLE
Remove statement about "re-requesting" objects

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -4474,8 +4474,8 @@ relay MUST NOT start forwarding any individual Object received through this
 subscription or fetch after the specified number of milliseconds has elapsed
 since the beginning of the Object was received.  This means Objects earlier in a
 multi-object stream will expire earlier than Objects later in the stream. Once
-Objects have expired from cache, their state becomes unknown, and a relay that
-handles a downstream request that includes those Objects re-requests them.
+Objects have expired from cache, their state becomes unknown (see
+{{model-object}}).
 
 If MAX_CACHE_DURATION is not sent by the publisher, the Objects
 can be cached until implementation constraints cause them to be evicted.


### PR DESCRIPTION
This is in MAX_CACHE_DURATION.  The important bit is that after expiration, the object's state becomes unknown.  I referenced the object model section, which spells out that objects have 3 distinct states (unknown, known, known not to exist).

Fixes: #1732