### PR TITLE
Define host resolution for moqt URIs

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -931,6 +931,15 @@ TODO: Add URI scheme security considerations per RFC 7595 Section 3.7
 
 TODO: Add internationalization statement per RFC 7595 Section 3.6.
 
+The client resolves the `host` subcomponent of the `authority` to one or
+more network addresses, most commonly using DNS A and AAAA records.
+
+When SVCB-compatible records {{?RFC9460}} are published for the `authority`,
+a client MAY use them to learn the server's endpoints and supported ALPN
+protocols before connecting. A client using WebTransport resolves the
+`https` URI derived in {{webtransport}} using HTTPS resource records as for
+any `https` origin.
+
 If the port is omitted in the URI, a default port of 443 is used.
 
 The client MAY use either native QUIC or WebTransport. On a QUIC connection,

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -940,6 +940,7 @@ protocols before connecting. A client using WebTransport resolves the
 `https` URI derived in {{webtransport}} using HTTPS resource records as for
 any `https` origin.
 TODO: reference moqt SVCB record draft once available.
+
 If the port is omitted in the URI, a default port of 443 is used.
 
 The client MAY use either native QUIC or WebTransport. On a QUIC connection,

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -939,7 +939,7 @@ a client MAY use them to learn the server's endpoints and supported ALPN
 protocols before connecting. A client using WebTransport resolves the
 `https` URI derived in {{webtransport}} using HTTPS resource records as for
 any `https` origin.
-
+TODO: reference moqt SVCB record draft once available.
 If the port is omitted in the URI, a default port of 443 is used.
 
 The client MAY use either native QUIC or WebTransport. On a QUIC connection,

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -932,7 +932,7 @@ TODO: Add URI scheme security considerations per RFC 7595 Section 3.7
 TODO: Add internationalization statement per RFC 7595 Section 3.6.
 
 The client resolves the `host` subcomponent of the `authority` to one or
-more network addresses, most commonly using DNS A and AAAA records.
+more network addresses, most commonly using DNS A {{?RFC1035}} and AAAA {{?RFC3596}} records.
 
 When SVCB-compatible records {{?RFC9460}} are published for the `authority`,
 a client MAY use them to learn the server's endpoints and supported ALPN


### PR DESCRIPTION
Specify that the host is resolved to network addresses (A/AAAA) and allow optional use of SVCB/HTTPS records to discover endpoints and supported ALPN protocols before connecting.

Fixes: #1696