### PR TITLE
Add security consideration for logging untrusted string fields

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -5145,6 +5145,15 @@ Operators are advised that detailed implementation identification
 facilitates the same privacy concerns as persistent identifiers, since it
 enables correlation of sessions across time.
 
+## Logging of Untrusted String Fields {#logging-untrusted-strings}
+
+The Reason Phrase ({{reason-phrase}}) and MOQT_IMPLEMENTATION option
+({{moqt-implementation}}) carry sender-controlled text that is commonly written
+to logs. Even though these fields are UTF-8 encoded, an endpoint that logs or
+renders them SHOULD sanitize them first (for example, by escaping bytes outside
+the printable ASCII range), since unsanitized values can enable log injection or
+terminal escape sequence injection.
+
 # Grease {#grease}
 
 To ensure that implementations correctly handle unknown values and do not


### PR DESCRIPTION
Recommend endpoints sanitize the Reason Phrase and MOQT_IMPLEMENTATION fields before logging or rendering them, rather than restricting their encoding, to avoid creating a new error condition.

Fixes: #1234
Fixes: #1668

Both fields may be removed later; see #273 (Reason Phrase) and #1745 (MOQT_IMPLEMENTATION).