### PR TITLE
Add LOCATION_FILTER forms table and error handling

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3740,8 +3740,7 @@ the filter is interpreted:
   * If only two fields are present, they are StartGroup and StartObject.
   * If only three fields are present, they are StartGroup, StartObject, and EndGroupDelta.
 
-The table below summarizes the resulting forms, which are specified in detail in
-the remainder of this section.
+The table below summarizes the encodings.
 
 | Fields present | Start Location | End Location |
 |:---------------|:---------------|:-------------|

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3758,8 +3758,9 @@ the start Location from relative to absolute.  For example, `{StartGroup=1}`
 starts at the current Group, whereas `{StartGroup=1, StartObject=0}` starts at
 the first Object of Group 1.
 
-If a field extends beyond the end of the parameter, or more than four fields
-are present, the endpoint MUST close the session with a `PROTOCOL_VIOLATION`.
+If a field extends beyond the end of the parameter, more than four fields
+are present, or an integer field extends beyond the given Length, the
+endpoint MUST close the session with a `PROTOCOL_VIOLATION`.
 
 A length of 0 indicates no filter, for example to remove the filter in REQUEST_UPDATE.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3753,11 +3753,6 @@ The table below summarizes the encodings.
 | StartGroup, StartObject, EndGroupDelta, EndObject | absolute: `{StartGroup, StartObject}` | `{StartGroup + EndGroupDelta, EndObject}` |
 {: #location-filter-forms title="Location Filter forms"}
 
-Note that adding StartObject to a filter that carries only StartGroup changes
-the start Location from relative to absolute.  For example, `{StartGroup=1}`
-starts at the current Group, whereas `{StartGroup=1, StartObject=0}` starts at
-the first Object of Group 1.
-
 If a field extends beyond the end of the parameter, more than four fields
 are present, or an integer field extends beyond the given Length, the
 endpoint MUST close the session with a `PROTOCOL_VIOLATION`.

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3733,10 +3733,11 @@ LOCATION_FILTER Parameter {
 }
 ~~~
 
-The optional fields are decoded in the order shown until Length bytes have been
-consumed.  How many fields are decoded determines which fields they are, and how
+The optional variable-length integer fields are decoded in the order shown until Length bytes have been
+consumed.  A length of 0 indicates no filter, for example to remove the filter in REQUEST_UPDATE.
+How many fields are decoded determines which fields they are, and how
 the filter is interpreted:
-  * If only one field is present, it is StartGroup.
+  * If only one field is present, it is a relative StartGroup.
   * If only two fields are present, they are StartGroup and StartObject.
   * If only three fields are present, they are StartGroup, StartObject, and EndGroupDelta.
 
@@ -3745,9 +3746,9 @@ The table below summarizes the encodings.
 | Fields present | Start Location | End Location |
 |:---------------|:---------------|:-------------|
 | none (Length 0) | no filter | no filter |
-| StartGroup | relative: `{Largest Object.Group + 1 - StartGroup, 0}` | open-ended (Fetch: `Largest Object`) |
-| StartGroup, StartObject, both 0 | `Next Object` | open-ended (Fetch: `Largest Object`) |
-| StartGroup, StartObject, not both 0 | absolute: `{StartGroup, StartObject}` | open-ended (Fetch: `Largest Object`) |
+| StartGroup | relative: `{Largest Object.Group + 1 - StartGroup, 0}` | open-ended |
+| StartGroup, StartObject, both 0 | `Next Object` | open-ended |
+| StartGroup, StartObject, not both 0 | absolute: `{StartGroup, StartObject}` | open-ended |
 | StartGroup, StartObject, EndGroupDelta | absolute: `{StartGroup, StartObject}` | last Object of Group `StartGroup + EndGroupDelta` |
 | StartGroup, StartObject, EndGroupDelta, EndObject | absolute: `{StartGroup, StartObject}` | `{StartGroup + EndGroupDelta, EndObject}` |
 {: #location-filter-forms title="Location Filter forms"}
@@ -3780,10 +3781,7 @@ computed value is set to 0; if greater than 2^64 - 1, it is set to 2^64 - 1.
 Otherwise, all fields are absolute.  EndGroupDelta is delta
 encoded from StartGroup, but both the start and end groups are absolute, not
 relative to `Largest Object`.  If StartGroup + EndGroupDelta exceeds 2^64 - 1,
-the endpoint MUST close the session with a `PROTOCOL_VIOLATION`.  If
-EndGroupDelta is 0 and EndObject is less than StartObject, the filter selects no
-Objects; the receiver MUST reject the request with REQUEST_ERROR with error code
-`INVALID_RANGE`.
+the endpoint MUST close the session with a `PROTOCOL_VIOLATION`.
 
 When EndGroupDelta and EndObject are omitted from a subscription filter, the
 subscription is open-ended. When they are omitted from a Fetch, the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -946,7 +946,7 @@ response (see {{message-fetch}}).  This is called a fill fetch stream.
 The **fill range** is the range of Locations selected by the Location filter
 inside FILL_PARAMETERS, or the subscription's Location filter if it is
 omitted. The filter is evaluated using the rules for a Fetch in
-{{location-filters}}, so the fill range never extends beyond `Largest
+{{location-filter}}, so the fill range never extends beyond `Largest
 Object`. When the subscription has no Location filter, or the LOCATION_FILTER
 inside FILL_PARAMETERS is zero-length, the fill range is the entire track up to
 `Largest Object`.  The subscriber learns the `Largest Object` from the
@@ -2935,7 +2935,7 @@ limited by the MAX_REQUEST_UPDATES Setup Option ({{max-request-updates}}).
 If a parameter previously set on the request is not present in
 `REQUEST_UPDATE`, its value remains unchanged.
 
-There is no mechanism to remove a parameter from a request.
+There is no generic mechanism to remove a parameter from a request.
 
 The format of REQUEST_UPDATE is as follows:
 
@@ -3733,11 +3733,35 @@ LOCATION_FILTER Parameter {
 }
 ~~~
 
-Length (in bytes) determines how many optional vi64 fields are present.
-A length of 0 indicates no filter, for example to remove the filter in REQUEST_UPDATE.
+The optional fields are decoded in the order shown until Length bytes have been
+consumed.  How many fields are decoded determines which fields they are, and how
+the filter is interpreted:
   * If only one field is present, it is StartGroup.
   * If only two fields are present, they are StartGroup and StartObject.
   * If only three fields are present, they are StartGroup, StartObject, and EndGroupDelta.
+
+The table below summarizes the resulting forms, which are specified in detail in
+the remainder of this section.
+
+| Fields present | Start Location | End Location |
+|:---------------|:---------------|:-------------|
+| none (Length 0) | no filter | no filter |
+| StartGroup | relative: `{Largest Object.Group + 1 - StartGroup, 0}` | open-ended (Fetch: `Largest Object`) |
+| StartGroup, StartObject, both 0 | `Next Object` | open-ended (Fetch: `Largest Object`) |
+| StartGroup, StartObject, not both 0 | absolute: `{StartGroup, StartObject}` | open-ended (Fetch: `Largest Object`) |
+| StartGroup, StartObject, EndGroupDelta | absolute: `{StartGroup, StartObject}` | last Object of Group `StartGroup + EndGroupDelta` |
+| StartGroup, StartObject, EndGroupDelta, EndObject | absolute: `{StartGroup, StartObject}` | `{StartGroup + EndGroupDelta, EndObject}` |
+{: #location-filter-forms title="Location Filter forms"}
+
+Note that adding StartObject to a filter that carries only StartGroup changes
+the start Location from relative to absolute.  For example, `{StartGroup=1}`
+starts at the current Group, whereas `{StartGroup=1, StartObject=0}` starts at
+the first Object of Group 1.
+
+If a field extends beyond the end of the parameter, or more than four fields
+are present, the endpoint MUST close the session with a `PROTOCOL_VIOLATION`.
+
+A length of 0 indicates no filter, for example to remove the filter in REQUEST_UPDATE.
 
 If only StartGroup is present, it is a relative number of groups prior to the Next Group,
 hence the start Location is `{Largest Object.Group + 1 - StartGroup, 0}`. For example:
@@ -3757,7 +3781,10 @@ computed value is set to 0; if greater than 2^64 - 1, it is set to 2^64 - 1.
 Otherwise, all fields are absolute.  EndGroupDelta is delta
 encoded from StartGroup, but both the start and end groups are absolute, not
 relative to `Largest Object`.  If StartGroup + EndGroupDelta exceeds 2^64 - 1,
-the endpoint MUST close the session with a `PROTOCOL_VIOLATION`.
+the endpoint MUST close the session with a `PROTOCOL_VIOLATION`.  If
+EndGroupDelta is 0 and EndObject is less than StartObject, the filter selects no
+Objects; the receiver MUST reject the request with REQUEST_ERROR with error code
+`INVALID_RANGE`.
 
 When EndGroupDelta and EndObject are omitted from a subscription filter, the
 subscription is open-ended. When they are omitted from a Fetch, the

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -3757,8 +3757,6 @@ If a field extends beyond the end of the parameter, more than four fields
 are present, or an integer field extends beyond the given Length, the
 endpoint MUST close the session with a `PROTOCOL_VIOLATION`.
 
-A length of 0 indicates no filter, for example to remove the filter in REQUEST_UPDATE.
-
 If only StartGroup is present, it is a relative number of groups prior to the Next Group,
 hence the start Location is `{Largest Object.Group + 1 - StartGroup, 0}`. For example:
   * StartGroup=0 will start at the Next Group


### PR DESCRIPTION
The LOCATION_FILTER encoding infers which optional fields are present from how many fit in Length, but the forms were only described in running prose. Added a summary table of the six forms and a note that adding StartObject to a StartGroup-only filter switches the start Location from relative to absolute, which is easy to trip over.

Reworded the Length paragraph: byte length does not by itself give the field count, since a 2-byte Length is either one 2-byte varint or two 1-byte varints. Fields are decoded in order until Length is consumed.

Two previously undefined cases now have handling. A field extending past the end of the parameter, or more than four fields, is a session error. An inverted range within a single group (EndGroupDelta of 0 and EndObject below StartObject) is rejected with INVALID_RANGE. Group inversion needs no rule, since EndGroupDelta is unsigned.

Also fixed the Fill Semantics cross-reference for the Fetch evaluation rules, which pointed at the Location Filters concept section rather than the parameter section that states them, and qualified "no mechanism to remove a parameter" in REQUEST_UPDATE as "no generic mechanism", since LOCATION_FILTER and the Range Filters both define a zero-length form that does exactly that.

Fixes #1347