### PR TITLE
Clarify the Original Publisher establishes Delivery Mode

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -334,7 +334,7 @@ Object ID: The order of the object within the group.
 
 Publisher Priority: An integer indicating the publisher's priority for the Object ({{priorities}}).
 
-Delivery Mode: An enumeration indicating whether an Object is sent in a Subgroup or Datagram. In a subscription, an Object MUST be sent according to its Delivery Mode.
+Delivery Mode: An enumeration indicating whether an Object is sent in a Subgroup or Datagram. The Original Publisher establishes an Object's Delivery Mode by how it first transmits the Object. In a subscription, an Object MUST be sent according to its Delivery Mode.
 
 Subgroup ID: The identifier of the Object's Subgroup (see {{model-subgroup}}) within the Group. Objects sent in Datagrams do not have a Subgroup ID.
 


### PR DESCRIPTION
The definition said an Object MUST be sent according to its Delivery Mode, which is circular for the Original Publisher: it is the act of first transmitting the Object that establishes the mode. Add a sentence making that explicit, so the existing MUST reads as a constraint on publishers that received the Object with its mode already determined.

Fixes: #1227