### PR TITLE
Preserve the SUBGROUP_HEADER PROPERTIES bit when forwarding

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2068,7 +2068,7 @@ The PROPERTIES bit in the SUBGROUP_HEADER ({{subgroup-header}}) applies to
 every Object on the stream, so a relay selects its value when it opens the
 stream downstream, before it has received the rest of the Subgroup. A relay
 that does not add Object Properties of its own SHOULD use the value it
-received from upstream. A relay that might add Object Properties MUST set the
+received from upstream. A relay that might add Object Properties needs to set the
 bit to 1; Objects with no Object Properties then encode a Properties Length
 of 0.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2064,6 +2064,14 @@ Object Properties as specified in {{properties}}.
 A relay MUST treat the object payload as opaque.  A relay MUST NOT
 combine, split, or otherwise modify object payloads.
 
+The PROPERTIES bit in the SUBGROUP_HEADER ({{subgroup-header}}) applies to
+every Object on the stream, so a relay selects its value when it opens the
+stream downstream, before it has received the rest of the Subgroup. A relay
+that does not add Object Properties of its own SHOULD use the value it
+received from upstream. A relay that might add Object Properties MUST set the
+bit to 1; Objects with no Object Properties then encode a Properties Length
+of 0.
+
 Relays prioritize forwarded Objects as described in {{priorities}}.
 
 # Notational Conventions and Common Structures


### PR DESCRIPTION
The PROPERTIES bit applies to every Object on a Subgroup stream, so a relay picks its value when opening the stream downstream, before it has received the rest of the Subgroup. Clearing the bit and then receiving an Object with Properties leaves no legal encoding, since a relay is required to forward Properties.

Tell relays to carry the upstream value over, and to set the bit when they might add Properties of their own.

Fixes: #1073