### PR TITLE
Note that RESET_STREAM_AT can be supported but unused

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -261,7 +261,7 @@ This document uses stream management terms described in {{?RFC9000, Section
 1.3}} including STOP_SENDING, RESET_STREAM, and FIN. It also uses
 RESET_STREAM_AT from {{!I-D.draft-ietf-quic-reliable-stream-reset}}.
 RESET_STREAM_AT can be used by MOQT, but the protocol is also designed to work
-correctly when the extension is not supported.
+correctly when the extension is not used or not supported.
 
 When this document says an endpoint "resets" a stream, it means the endpoint
 sends a RESET_STREAM or RESET_STREAM_AT frame on that stream (see


### PR DESCRIPTION
The protocol works whether the extension is unavailable or simply not chosen for a given stream, which is a case the surrounding text already contemplates when it points at the considerations for choosing between RESET_STREAM and RESET_STREAM_AT.

Addresses part of #1038