### PR TITLE
Say how a non-Normal Object encodes Properties in a Subgroup

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -4419,7 +4419,7 @@ fields are present in the header:
   in all Objects in this Subgroup. When set to 1, the Object Properties structure
   defined in {{object-properties}} is present in all Objects; Objects with no
   properties or non-Normal status set Properties Length to 0. When set to 0, the
-  field is never present.
+  field is never present in this Subgroup.
 
 * The **SUBGROUP_ID_MODE** field (bits 1-2, mask 0x06) is a two-bit field that
   determines the encoding of the Subgroup ID. To extract this value, perform a

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -4418,7 +4418,8 @@ fields are present in the header:
 * The **PROPERTIES** bit (0x01) indicates when the Properties field is present
   in all Objects in this Subgroup. When set to 1, the Object Properties structure
   defined in {{object-properties}} is present in all Objects; Objects with no
-  properties set Properties Length to 0. When set to 0, the field is never present.
+  properties or non-Normal status set Properties Length to 0. When set to 0, the
+  field is never present.
 
 * The **SUBGROUP_ID_MODE** field (bits 1-2, mask 0x06) is a two-bit field that
   determines the encoding of the Subgroup ID. To extract this value, perform a


### PR DESCRIPTION
Object Properties already says an Object with a status other than Normal cannot carry Properties, but the SUBGROUP_HEADER PROPERTIES bit applies to every Object on the stream, so such an Object still has the field and needs a length. Say it is 0, which also removes the asymmetry with Object Datagram that made the rule look like it was missing for Subgroups.

Fixes: #1908