### PR TITLE
Clarify who a subscriber can send requests to

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1193,10 +1193,15 @@ subscribers, it is not a full-fledged routing protocol and does not protect
 against loops and other phenomena. In particular, PUBLISH_NAMESPACE SHOULD NOT
 be used to find paths through richly connected networks of relays.
 
-A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If it
+An End Subscriber is not restricted in which publisher it contacts: it
+MAY send a SUBSCRIBE, FETCH or TRACK_STATUS for a track to any publisher,
+including one from which it has not received a PUBLISH_NAMESPACE. If it
 has accepted a PUBLISH_NAMESPACE with a namespace that exactly matches the
 namespace for that track, it SHOULD only request it from the senders of those
 PUBLISH_NAMESPACE messages.
+
+A Relay is more restricted: it sends these requests only to matching
+publishers, as described in {{publisher-interactions}}.
 
 ## Filtering SUBSCRIBE_TRACKS
 


### PR DESCRIPTION
The sentence about sending to any publisher was read as a rule about how many publishers a request goes to, rather than about which publishers a subscriber is permitted to contact. Say what the permission is in contrast to, add TRACK_STATUS, and note that a Relay is limited to matching publishers, pointing at the rules for selecting among them.

This is qualifying an existing MAY and adding TRACK_STATUS.  I think this was the underlying intent so I marked Editorial but could mark Ed&Min Design too.

Fixes: #1701