### PR TITLE
Define Subscription in Terms and Definitions

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -255,6 +255,11 @@ Track:
 
 : A track is a collection of groups. See ({{model-track}}).
 
+Subscription:
+
+: An ongoing relationship in which a publisher delivers newly published
+  objects from a track to a subscriber. See ({{subscriptions}}).
+
 ## Stream Management Terms
 
 This document uses stream management terms described in {{?RFC9000, Section


### PR DESCRIPTION
The terms list uses subscription to define Publisher and End Subscriber but never defines it, and the definition in Publishing and Receiving Tracks is several hundred lines later. Add an entry that points at it, following the pattern used for Group, Subgroup, Object and Track.

Fixes: #1226