### PR TITLE
Note that Client and Server are transport roles only

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -179,11 +179,13 @@ Application:
 
 Client:
 
-: The party initiating a Transport Session.
+: The party initiating a Transport Session.  A Client can be a Publisher, a
+  Subscriber, or both.
 
 Server:
 
-: The party accepting an incoming Transport Session.
+: The party accepting an incoming Transport Session.  A Server can be a
+  Publisher, a Subscriber, or both.
 
 Endpoint:
 


### PR DESCRIPTION
A Publisher or Subscriber can be either party to the Transport Session, but the terminology did not say so, leaving readers to infer that a Server is a Publisher.

Fixes: #1217