### PR TITLE
Scope the auth token cache overflow rule to non-SETUP registrations

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2503,9 +2503,10 @@ By registering a Token, the sender is requiring the receiver to store the Token
 Alias and Token Value until they are deleted, or the Session ends. The receiver
 can protect its resources by sending a Setup Option defining the
 MAX_AUTH_TOKEN_CACHE_SIZE limit (see {{max-auth-token-cache-size}}) it is
-willing to accept. If a registration is attempted which would cause this limit
-to be exceeded, the receiver MUST terminate the Session with a
-`AUTH_TOKEN_CACHE_OVERFLOW` error.
+willing to accept. If a registration outside of SETUP is attempted which would
+cause this limit to be exceeded, the receiver MUST terminate the Session with
+an `AUTH_TOKEN_CACHE_OVERFLOW` error.  Registrations in SETUP are handled as
+described in {{setup-auth-token}}.
 
 An Authorization Token MAY be repeated within a message as long as the
 combination of Token Type and Token Value are unique after resolving any

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -2503,7 +2503,7 @@ By registering a Token, the sender is requiring the receiver to store the Token
 Alias and Token Value until they are deleted, or the Session ends. The receiver
 can protect its resources by sending a Setup Option defining the
 MAX_AUTH_TOKEN_CACHE_SIZE limit (see {{max-auth-token-cache-size}}) it is
-willing to accept. If a registration outside of SETUP is attempted which would
+willing to accept. If a registration outside of SETUP is attempted that would
 cause this limit to be exceeded, the receiver MUST terminate the Session with
 an `AUTH_TOKEN_CACHE_OVERFLOW` error.  Registrations in SETUP are handled as
 described in {{setup-auth-token}}.


### PR DESCRIPTION
Authorization Token Compression required terminating the session on a registration that exceeds MAX_AUTH_TOKEN_CACHE_SIZE, while the SETUP option requires not doing that and treating the registration as USE_VALUE instead, because SETUP messages can cross in flight. Neither referenced the other. State the general rule's scope and point at the SETUP case.

Fixes: #1271