### PR TITLE
Say that relays do not send namespace requests to subscribers

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1901,6 +1901,13 @@ the content associated with the Track. The authorization information can be part
 of request itself or part of the encompassing session. The specifics of how a
 relay authorizes a user are outside the scope of this specification.
 
+A relay MUST NOT send PUBLISH_NAMESPACE or SUBSCRIBE_NAMESPACE to a subscriber.
+Everything a relay sends downstream is solicited: it sends NAMESPACE and
+NAMESPACE_DONE on the response stream of a SUBSCRIBE_NAMESPACE
+({{subscribing-to-namespaces}}), and PUBLISH in response to a SUBSCRIBE_TRACKS
+({{message-subscribe-tracks}}).  A subscriber that has sent neither receives
+neither.
+
 The relay MUST have an `Established` upstream subscription before sending
 SUBSCRIBE_OK in response to a downstream SUBSCRIBE.  If a relay does not have
 sufficient information to send a FETCH_OK immediately in response to a FETCH, it
@@ -1997,8 +2004,8 @@ bar).  It will not match a session with namespace=(foobar).
 
 Relays MUST send SUBSCRIBE messages to all matching publishers. This includes
 matching both Established subscriptions on the Full Track Name and Namespace
-Prefix Matching against published Namespaces.  Relays MUST forward
-PUBLISH_NAMESPACE or PUBLISH messages to all matching subscribers.
+Prefix Matching against published Namespaces.  Relays MUST send PUBLISH
+messages to all matching subscribers.
 
 When a Relay needs to make an upstream FETCH request, it determines the
 available publishers using the same matching rules as SUBSCRIBE. When more than


### PR DESCRIPTION
Fixes: #1854

Publisher Interactions currently says:

> Relays MUST forward PUBLISH_NAMESPACE or PUBLISH messages to all matching subscribers.

That contradicts the intended design. A relay advertises namespaces downstream by sending NAMESPACE on the response stream of a SUBSCRIBE_NAMESPACE, and offers tracks by sending PUBLISH in response to a SUBSCRIBE_TRACKS. It does not send PUBLISH_NAMESPACE to subscribers.

It also does not follow from the Namespace Prefix Matching rules stated immediately above it, which describe matching for SUBSCRIBE and PUBLISH only:

> Namespace Prefix Matching is further used to decide which publishers receive a SUBSCRIBE and which subscribers receive a PUBLISH.

This PR:

- Drops PUBLISH_NAMESPACE from that requirement.
- Adds a statement in Subscriber Interactions that a relay does not send PUBLISH_NAMESPACE or SUBSCRIBE_NAMESPACE to a subscriber, and that everything it sends downstream is solicited.

The draft constrains unsolicited PUBLISH ("Relays MUST NOT send any PUBLISH messages without knowing the client is interested in and authorized to receive the content") but had no equivalent for PUBLISH_NAMESPACE, which left implementers to infer the rule.