### PR TITLE
Relay-to-relay is out of scope

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1826,6 +1826,10 @@ validating subscribe and publish requests at the edge of a network.
 Relays are endpoints, which means they terminate Transport Sessions in order to
 have visibility of MOQT Object metadata.
 
+For the purposes of this specification, a connected set of relays is a single
+MOQT relay.  How relays within such a set interconnect, and use cases built on
+relay to relay communication, are out of scope.
+
 ## Caching Relays
 
 Relays MAY cache Objects, but are not required to.
@@ -5138,10 +5142,9 @@ cause issues with latency sensitive applications.
 
 # Security Considerations {#security}
 
-MOQT is a protocol used hop-by-hop between original
-publishers to relay, (possibly) relay to relay, and relay to end
-subscribers. Thus, the security considerations need to consider first
-what happens between two Endpoints, but also consider the impacts end to
+MOQT is a protocol used hop-by-hop between original publishers to relay and
+relay to end subscribers. Thus, the security considerations need to consider
+first what happens between two Endpoints, but also consider the impacts end to
 end over several hops of MOQT.
 
 MOQT uses a trust model where on each hop the Endpoints need to be

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -5142,9 +5142,10 @@ cause issues with latency sensitive applications.
 
 # Security Considerations {#security}
 
-MOQT is a protocol used hop-by-hop between original publishers to relays and
-relays to end subscribers. Thus, the security considerations need to consider
-first what happens between two Endpoints, but also consider the impacts end to
+MOQT is a protocol used hop-by-hop between original
+publishers to relay, (possibly) relay to relay, and relay to end
+subscribers. Thus, the security considerations need to consider first
+what happens between two Endpoints, but also consider the impacts end to
 end over several hops of MOQT.
 
 MOQT uses a trust model where on each hop the Endpoints need to be

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1826,9 +1826,9 @@ validating subscribe and publish requests at the edge of a network.
 Relays are endpoints, which means they terminate Transport Sessions in order to
 have visibility of MOQT Object metadata.
 
-For the purposes of this specification, a coordinated set of relays are treated as a single
-MOQT relay.  How relays within such a set interconnect, and use cases built on
-relay to relay communication, are out of scope.
+For the purposes of this specification, a coordinated set of relays are treated
+as a single MOQT relay.  How relays within such a set interconnect, and use
+cases built on relay to relay communication, are out of scope.
 
 ## Caching Relays
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1826,7 +1826,7 @@ validating subscribe and publish requests at the edge of a network.
 Relays are endpoints, which means they terminate Transport Sessions in order to
 have visibility of MOQT Object metadata.
 
-For the purposes of this specification, a connected set of relays is a single
+For the purposes of this specification, a coordinated set of relays is a single
 MOQT relay.  How relays within such a set interconnect, and use cases built on
 relay to relay communication, are out of scope.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1826,7 +1826,7 @@ validating subscribe and publish requests at the edge of a network.
 Relays are endpoints, which means they terminate Transport Sessions in order to
 have visibility of MOQT Object metadata.
 
-For the purposes of this specification, a coordinated set of relays is a single
+For the purposes of this specification, a coordinated set of relays are treated as a single
 MOQT relay.  How relays within such a set interconnect, and use cases built on
 relay to relay communication, are out of scope.
 
@@ -5142,8 +5142,8 @@ cause issues with latency sensitive applications.
 
 # Security Considerations {#security}
 
-MOQT is a protocol used hop-by-hop between original publishers to relay and
-relay to end subscribers. Thus, the security considerations need to consider
+MOQT is a protocol used hop-by-hop between original publishers to relays and
+relays to end subscribers. Thus, the security considerations need to consider
 first what happens between two Endpoints, but also consider the impacts end to
 end over several hops of MOQT.
 


### PR DESCRIPTION
The draft describes relay behavior for a single relay but never says how a deployment of several interconnected relays is modeled, leaving readers to ask whether relay to relay communication is specified. Say that such a set is one MOQT relay and that how it interconnects is out of scope, and drop the reference to a relay to relay hop from Security Considerations.