### PR TITLE
Remove leftover MUST forward PUBLISH_NAMESPACE

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1997,8 +1997,7 @@ bar).  It will not match a session with namespace=(foobar).
 
 Relays MUST send SUBSCRIBE messages to all matching publishers. This includes
 matching both Established subscriptions on the Full Track Name and Namespace
-Prefix Matching against published Namespaces.  Relays MUST forward
-PUBLISH_NAMESPACE or PUBLISH messages to all matching subscribers.
+Prefix Matching against published Namespaces.
 
 When a Relay needs to make an upstream FETCH request, it determines the
 available publishers using the same matching rules as SUBSCRIBE. When more than
@@ -2024,14 +2023,18 @@ holding a downstream SUBSCRIBE awaiting a publisher for this Track (see
 {{rendezvous-timeout}}), it MUST proceed with the SUBSCRIBE and
 MUST NOT also forward the PUBLISH to that subscriber.
 
-When a relay receives an authorized PUBLISH_NAMESPACE for a namespace that
-matches one or more existing subscriptions to other upstream sessions, it MUST
-send a SUBSCRIBE to the publisher that sent the PUBLISH_NAMESPACE for each
-matching subscription.  When it receives an authorized PUBLISH message for a
+When a relay receives an authorized PUBLISH message for a
 Track that has `Established` downstream subscriptions, it MUST respond with
 PUBLISH_OK.  If at least one downstream subscriber for the Track has
 Forward State=1, the Relay MUST change the Forward State to 1 with
 REQUEST_UPDATE.
+
+When a relay receives an authorized PUBLISH_NAMESPACE for a namespace that
+matches one or more existing subscriptions to other upstream sessions, it MUST
+send a SUBSCRIBE to the publisher that sent the PUBLISH_NAMESPACE for each
+matching subscription. A Relay does not send PUBLISH_NAMESPACE to a subscriber;
+it advertises namespaces by sending NAMESPACE in response to a matching
+SUBSCRIBE_NAMESPACE (see {{subscribing-to-namespaces}}).
 
 If a Session is closed due to an unknown or invalid control message or Object,
 the Relay MUST NOT propagate that message or Object to another Session, because


### PR DESCRIPTION
Publisher Interactions said:

  Relays MUST forward PUBLISH_NAMESPACE or PUBLISH messages to all
  matching subscribers.

Both halves of that sentence are gone.

The PUBLISH half was a duplicate. The rule it restated is four paragraphs below it, and is more precise: a relay sends PUBLISH to each subscriber that has sent SUBSCRIBE_TRACKS for the Track's namespace or a prefix thereof, except where the relay is holding a downstream SUBSCRIBE awaiting a publisher for that Track. Nothing is lost by deleting the shorter version.

The PUBLISH_NAMESPACE half was a leftover and did not describe real behavior. A relay that receives an authorized PUBLISH_NAMESPACE records the sender as a source for that prefix, and sends it a SUBSCRIBE for each existing subscription the prefix matches. It advertises namespaces downstream with NAMESPACE in response to a matching SUBSCRIBE_NAMESPACE. Say so alongside the rule for handling a received PUBLISH_NAMESPACE, since the draft never stated it anywhere and implementers were forwarding PUBLISH_NAMESPACE for conformance.

Also split the paragraph that covered PUBLISH_NAMESPACE and PUBLISH handling together, so each message has its own.

Refs: #1854