### PR TITLE
Call the forwarding state paused

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1909,7 +1909,7 @@ that specify otherwise.
 ## Paused Subscription Handling
 
 If one or more downstream subscribers to a track are not paused, the relay
-MUST resume the upstream subscription, if paused, in order to receive and
+MUST have an unpaused upstream subscription, in order to receive and
 forward the requested Objects. When all downstream subscribers are paused, the
 relay chooses whether to pause upstream at its discretion, considering the
 following

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -625,13 +625,6 @@ to a SUBSCRIBE. A subscriber MUST send exactly one PUBLISH_OK
 ({{message-request-ok}}) or PUBLISH_ERROR in response to a PUBLISH. The peer
 SHOULD close the session with a protocol error if it receives more than one.
 
-All `Established` subscriptions have a Forward State which is either 0 or 1.
-The publisher does not send Objects if the Forward State is 0, and does send them
-if the Forward State is 1.  The initiator of the subscription sets the initial
-Forward State in either PUBLISH or SUBSCRIBE.  The subscriber can send
-REQUEST_UPDATE to update the Forward State. Control messages, such as
-PUBLISH_DONE ({{message-publish-done}}) are sent regardless of the forward state.
-
 Either endpoint can initiate a subscription to a track without exchanging any
 prior messages other than SETUP.  Relays MUST NOT send any PUBLISH messages
 without knowing the client is interested in and authorized to receive the
@@ -663,12 +656,25 @@ incurring additional latency.
 Publishers MAY start sending Objects on PUBLISH-initiated subscriptions before
 receiving a PUBLISH_OK response to reduce latency.  Doing so can consume
 unnecessary resources in cases where the Subscriber rejects the subscription
-with PUBLISH_ERROR or sets Forward=0 in REQUEST_UPDATE. It can also result in
+with PUBLISH_ERROR or pauses the subscription (see below). It can also result in
 the Subscriber dropping Objects if its buffering limits are exceeded (see
 {{datagrams}} and {{subgroup-header}}).
 
 An object published or received in a subgroup or datagram is
 **subscription-delivered**.
+
+### Pausing Subscriptions {#pausing-subscriptions}
+
+An `Established` subscription is either paused or not paused. The publisher does
+not send Objects on a paused subscription, and does send them when it is not
+paused.  Control messages, such as PUBLISH_DONE ({{message-publish-done}}), are
+sent regardless of whether the subscription is paused.
+
+The initiator of the subscription sets the initial state by including the
+FORWARD parameter ({{forward-parameter}}) in PUBLISH or SUBSCRIBE. The
+subscriber can pause an `Established` subscription by sending REQUEST_UPDATE
+with FORWARD set to 0, or resume it by sending REQUEST_UPDATE with FORWARD set
+to 1.
 
 ### Subscription State Management
 
@@ -1005,11 +1011,12 @@ with an open-ended fill range, which the publisher will end at Largest Object.
 ### Opening and Closing Fill Fetch Streams
 
 A publisher opens a fill fetch stream when it processes a SUBSCRIBE or
-REQUEST_UPDATE that carries FILL_PARAMETERS while Forward State is 1.
+REQUEST_UPDATE that carries FILL_PARAMETERS while the subscription is not
+paused (see {{pausing-subscriptions}}).
 
-- FILL_PARAMETERS carried while Forward State is 0 opens no fill fetch stream.
-  Transitioning to Forward State 1 without re-sending FILL_PARAMETERS does not
-  open one either.
+- FILL_PARAMETERS carried while the subscription is paused opens no fill fetch
+  stream.  Resuming the subscription without re-sending FILL_PARAMETERS does
+  not open one either.
 - A REQUEST_UPDATE that does not carry FILL_PARAMETERS does not open a new fill
   fetch stream.
 - When the subscription is cancelled, the publisher MUST reset any open fill fetch streams.
@@ -1899,20 +1906,22 @@ A cache MUST store all fields of an Object defined in {{object-header}},
 with the exception of any Object Properties ({{object-properties}})
 that specify otherwise.
 
-## Forward Handling
+## Paused Subscription Handling
 
-If one or more downstream subscribers to a track have Forward=1, the relay
-MUST set Forward=1 upstream in order to receive and forward the requested
-Objects. When no downstream subscriber has Forward=1, the relay chooses the
-upstream Forward value at its discretion, considering the following
+If one or more downstream subscribers to a track are not paused, the relay
+MUST resume the upstream subscription, if paused, in order to receive and
+forward the requested Objects. When all downstream subscribers are paused, the
+relay chooses whether to pause upstream at its discretion, considering the
+following
 tradeoffs and deployment considerations:
 
-  - Setting Forward=1 upstream starts object delivery and pre-warms the
-    relay's cache, so objects are available when a downstream subscriber
-    sets Forward=1. This reduces latency but consumes upstream and publisher
-    resources for content no downstream subscriber is currently receiving.
-  - Setting Forward=0 upstream avoids that work, at the cost of higher
-    latency when forwarding is later enabled.
+  - Leaving the upstream subscription unpaused starts object delivery and
+    pre-warms the relay's cache, so objects are available when a downstream
+    subscriber resumes. This reduces latency but consumes upstream and
+    publisher resources for content no downstream subscriber is currently
+    receiving.
+  - Pausing the upstream subscription avoids that work, at the cost of higher
+    latency when delivery is later resumed.
 
 ## Multiple Publishers
 
@@ -1997,8 +2006,8 @@ to the old relay can be cancelled (see {{request-cancellation}}).
 There are two ways to publish through a relay:
 
 1. Send a PUBLISH message for a specific Track to the relay. The relay MAY
-pause the Subscription with REQUEST_UPDATE in Forward State=0 until there are
-known subscribers for new Tracks.
+pause the Subscription with REQUEST_UPDATE (see {{pausing-subscriptions}})
+until there are known subscribers for new Tracks.
 
 2. Send a PUBLISH_NAMESPACE message for a Track Namespace Prefix to the relay.
 This enables the relay to send SUBSCRIBE or FETCH messages to publishers for
@@ -2050,12 +2059,12 @@ a SUBSCRIBE with FILL_PARAMETERS or FETCHes (see {{fill-semantics}}).
 
 When a Relay receives an authorized SUBSCRIBE for a Track with one or more
 `Established` upstream subscriptions, it MUST reply with SUBSCRIBE_OK.  If the
-SUBSCRIBE has Forward State=1 and the upstream subscriptions are in Forward
-State=0, the Relay MUST send REQUEST_UPDATE with Forward=1 to all publishers.
+SUBSCRIBE is not paused and the upstream subscriptions are paused, the Relay
+MUST resume the upstream subscriptions with REQUEST_UPDATE to all publishers.
 If there are no `Established` upstream subscriptions for the requested Track, the Relay
 MUST send a SUBSCRIBE request to each publisher that has published the
-subscription's namespace or prefix thereof.  If the SUBSCRIBE has Forward=1,
-then the Relay MUST use Forward=1 when subscribing upstream.
+subscription's namespace or prefix thereof.  If the SUBSCRIBE is not paused,
+then the Relay MUST NOT pause when subscribing upstream.
 
 When a relay receives an incoming PUBLISH message, it MUST send a PUBLISH
 request to each subscriber that has sent SUBSCRIBE_TRACKS for the Track's
@@ -2066,9 +2075,9 @@ MUST NOT also forward the PUBLISH to that subscriber.
 
 When a relay receives an authorized PUBLISH message for a
 Track that has `Established` downstream subscriptions, it MUST respond with
-PUBLISH_OK.  If at least one downstream subscriber for the Track has
-Forward State=1, the Relay MUST change the Forward State to 1 with
-REQUEST_UPDATE.
+PUBLISH_OK.  If at least one downstream subscriber for the Track is not
+paused, the Relay MUST resume the upstream subscription with REQUEST_UPDATE,
+if paused.
 
 When a relay receives an authorized PUBLISH_NAMESPACE for a namespace that
 matches one or more existing subscriptions to other upstream sessions, it MUST
@@ -3180,9 +3189,9 @@ send PUBLISH_ERROR with error code `UNINTERESTED`, and abandon reading any
 publisher initiated streams associated with that subscription using a
 STOP_SENDING frame.
 
-A publisher that sends the FORWARD parameter ({{forward-parameter}}) equal to 0
-indicates that it will not transmit any objects until the subscriber sets the
-Forward State to 1. If the FORWARD parameter is omitted or equal to 1, the
+A publisher that pauses the subscription (see {{pausing-subscriptions}})
+indicates that it will not transmit any objects until the subscriber resumes
+it. If the subscription is not paused, the
 publisher will start transmitting objects immediately, possibly before
 PUBLISH_OK. Delivery starts at the Next Object relative to the Largest Object
 at the time the publisher begins sending.
@@ -4040,18 +4049,19 @@ PUBLISH, or REQUEST_UPDATE_OK
 The FORWARD parameter (Parameter Type 0x10) is a uint8. It MAY appear in
 SUBSCRIBE, REQUEST_UPDATE (for a subscription or a SUBSCRIBE_TRACKS request),
 PUBLISH, SUBSCRIBE_TRACKS and PUBLISH_STATE_NOTIFY. It
-specifies the Forwarding State on affected subscriptions (see {{subscriptions}}).
+specifies whether affected subscriptions are paused (see
+{{pausing-subscriptions}}).
 The allowed values are 0 (don't forward) or 1 (forward). If an endpoint receives
 a value outside this range, it MUST close the session with `PROTOCOL_VIOLATION`.
 
-In the case of a REQUEST_UPDATE for SUBSCRIBE_TRACKS, it specifies the
-Forwarding State on future subscriptions that match the prefix. Existing
+In the case of a REQUEST_UPDATE for SUBSCRIBE_TRACKS, it specifies whether
+future subscriptions that match the prefix are paused. Existing
 subscriptions are unaffected.
 
 If the parameter is omitted from REQUEST_UPDATE or PUBLISH_STATE_NOTIFY,
 the value for the subscription remains unchanged.  If the parameter is omitted
 from any other message, the default value is 1.  When sent in
-PUBLISH_STATE_NOTIFY, it reports the Forwarding State now in effect at the
+PUBLISH_STATE_NOTIFY, it reports whether the subscription is paused at the
 publisher.
 
 ### NEW GROUP REQUEST Parameter {#new-group-request}
@@ -4612,7 +4622,7 @@ not limited to:
 * A publisher's decision to end the subscription early
 * A REQUEST_UPDATE moving the subscription's End Group to a smaller Group or
   the Start Location to a larger Location
-* Omitting a Subgroup Object due to the subscriber's Forward State
+* Omitting a Subgroup Object because the subscription is paused
 
 When RESET_STREAM_AT is used, the
 reliable_size SHOULD include the stream header so the receiver can identify the
@@ -4685,8 +4695,8 @@ Subgroups in a Group at once.
 
 A publisher that receives a STOP_SENDING on a Subgroup stream SHOULD NOT attempt
 to open a new stream to deliver additional Objects in that Subgroup.  However,
-if the publisher subsequently receives a REQUEST_UPDATE that changes the Forward
-State from 0 to 1, it MAY open a new stream to deliver Objects in that Subgroup,
+if the publisher subsequently receives a REQUEST_UPDATE that resumes the
+subscription, it MAY open a new stream to deliver Objects in that Subgroup,
 as the update indicates the subscriber has renewed interest in forwarded Objects.
 
 The application SHOULD use a relevant error code when resetting a stream,


### PR DESCRIPTION
FORWARD itself is unchanged, and there's a new Pausing Subscriptions section for the rest of the draft to point at. The wording comes from #1825, which also removes FORWARD in favor of an empty Location Filter; that part is left for #1352.

Fixes: #1694