### PR TITLE
Restructure Publisher and Namespace Discovery, Give Subscribe Tracks it's own section

### DIFF
--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1234,8 +1234,42 @@ The receiver of a REQUEST_OK or REQUEST_ERROR ought to
 forward the result to the application, so the application can decide which other
 publishers to contact, if any.
 
+The publisher will respond with SUBSCRIBE_NAMESPACE_OK or
+SUBSCRIBE_NAMESPACE_ERROR on the response half of the stream. If the subscriber
+receives any message other than a SUBSCRIBE_NAMESPACE_OK or a
+SUBSCRIBE_NAMESPACE_ERROR as the first message on the response half of the
+stream, then it MUST close the session with a PROTOCOL_VIOLATION. If the
+SUBSCRIBE_NAMESPACE is successful, the publisher will send matching NAMESPACE
+messages on the response stream. If it is an error, the stream will be
+immediately closed via FIN. When there are changes to the namespaces being
+published and the subscriber is subscribed to them, the publisher sends the
+corresponding NAMESPACE or NAMESPACE_DONE messages.
+
+Within a session, if a publisher receives a SUBSCRIBE_NAMESPACE with a
+Track Namespace Prefix that shares a common prefix with an established
+SUBSCRIBE_NAMESPACE, it MUST respond with SUBSCRIBE_NAMESPACE_ERROR with
+error code `PREFIX_OVERLAP`.  SUBSCRIBE_NAMESPACE and SUBSCRIBE_TRACKS have
+independent overlap spaces (see {{subscribe-tracks}}).
+
+The publisher MUST ensure the subscriber is authorized to perform this
+namespace subscription.
+
+The publisher MUST NOT send NAMESPACE_DONE for a namespace suffix before the
+corresponding NAMESPACE. If a subscriber receives a NAMESPACE_DONE before the
+corresponding NAMESPACE, it MUST close the session with a 'PROTOCOL_VIOLATION'.
+
 A SUBSCRIBE_NAMESPACE or SUBSCRIBE_TRACKS is cancelled as described in
 {{request-cancellation}}, by resetting or sending STOP_SENDING on the stream.
+
+### Namespace Subscription State Management
+
+If the publisher is unable to send NAMESPACE or NAMESPACE_DONE messages in a
+timely manner because the SUBSCRIBE_NAMESPACE response stream is blocked by flow
+control, the publisher MAY reset the SUBSCRIBE_NAMESPACE response stream.  When
+a subscriber receives a stream reset or FIN on a SUBSCRIBE_NAMESPACE response
+stream, it SHOULD treat this as though each active namespace received a
+NAMESPACE_DONE. Subscriptions established via PUBLISH on separate bidi streams
+are not affected by closure of the SUBSCRIBE_NAMESPACE stream.
 
 ## Publishing Namespaces
 
@@ -1244,6 +1278,9 @@ PUBLISH_NAMESPACE indicates to the subscriber that the publisher has tracks
 available in namespaces matching the Track Namespace Prefix it carries (see
 {{namespace-prefix-matching}}). A subscriber MAY send SUBSCRIBE or FETCH for
 tracks in a namespace without having received a PUBLISH_NAMESPACE for it.
+
+The receiver verifies the publisher is authorized to publish tracks under this
+prefix.
 
 If a publisher is the Original Publisher for one or more tracks in a given
 namespace, or is a relay that has received an authorized PUBLISH_NAMESPACE for
@@ -3452,8 +3489,6 @@ REQUEST_UPDATE.
 The publisher sends the PUBLISH_NAMESPACE message as the first message on a
 new bidi stream to advertise that it has tracks available in namespaces
 matching a Track Namespace Prefix.
-The receiver verifies the publisher is authorized to publish tracks under this
-prefix.
 
 ~~~
 PUBLISH_NAMESPACE Message {
@@ -3506,38 +3541,6 @@ SUBSCRIBE_NAMESPACE Message {
 
 * Parameters: The parameters are defined in {{message-params}}.  The only
   parameter that can appear in a SUBSCRIBE_NAMESPACE is AUTHORIZATION_TOKEN.
-
-The publisher will respond with SUBSCRIBE_NAMESPACE_OK or
-SUBSCRIBE_NAMESPACE_ERROR on the response half of the stream. If the subscriber
-receives any message other than a SUBSCRIBE_NAMESPACE_OK or a
-SUBSCRIBE_NAMESPACE_ERROR as the first message on the response half of the
-stream, then it MUST close the session with a PROTOCOL_VIOLATION. If the
-SUBSCRIBE_NAMESPACE is successful, the publisher will send matching NAMESPACE
-messages on the response stream. If it is an error, the stream will be
-immediately closed via FIN. When there are changes to the namespaces being
-published and the subscriber is subscribed to them, the publisher sends the
-corresponding NAMESPACE or NAMESPACE_DONE messages.
-
-Within a session, if a publisher receives a SUBSCRIBE_NAMESPACE with a
-Track Namespace Prefix that shares a common prefix with an established
-SUBSCRIBE_NAMESPACE, it MUST respond with SUBSCRIBE_NAMESPACE_ERROR with
-error code `PREFIX_OVERLAP`.  SUBSCRIBE_NAMESPACE and SUBSCRIBE_TRACKS have
-independent overlap spaces (see {{message-subscribe-tracks}}).
-
-The publisher MUST ensure the subscriber is authorized to perform this
-namespace subscription.
-
-The publisher MUST NOT send NAMESPACE_DONE for a namespace suffix before the
-corresponding NAMESPACE. If a subscriber receives a NAMESPACE_DONE before the
-corresponding NAMESPACE, it MUST close the session with a 'PROTOCOL_VIOLATION'.
-
-If the publisher is unable to send NAMESPACE or NAMESPACE_DONE messages in a
-timely manner because the SUBSCRIBE_NAMESPACE response stream is blocked by flow
-control, the publisher MAY reset the SUBSCRIBE_NAMESPACE response stream.  When
-a subscriber receives a stream reset or FIN on a SUBSCRIBE_NAMESPACE response
-stream, it SHOULD treat this as though each active namespace received a
-NAMESPACE_DONE. Subscriptions established via PUBLISH on separate bidi streams
-are not affected by closure of the SUBSCRIBE_NAMESPACE stream.
 
 ## NAMESPACE {#message-namespace}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1329,6 +1329,38 @@ stream, it SHOULD treat this as though each active namespace received a
 NAMESPACE_DONE. Subscriptions established via PUBLISH on separate bidi streams
 are not affected by closure of the SUBSCRIBE_NAMESPACE stream.
 
+## Namespace Discovery Example
+
+In the following example, a subscriber asks a relay for namespaces under a
+prefix, a publisher subsequently advertises a matching namespace to that relay,
+and the relay passes it on.  When the publisher withdraws its advertisement, the
+relay tells the subscriber the namespace is gone.
+
+~~~
+ Publisher                    Relay                   Subscriber
+     |                          |                          |
+     |                          |   SUBSCRIBE_NAMESPACE    |
+     |                          |        (example)         |
+     |                          |<-------------------------|
+     |                          |  SUBSCRIBE_NAMESPACE_OK  |
+     |    PUBLISH_NAMESPACE     |------------------------->|
+     |      (example-123)       |                          |
+     |------------------------->|                          |
+     |   PUBLISH_NAMESPACE_OK   |        NAMESPACE         |
+     |<-------------------------|          (123)           |
+     |                          |------------------------->|
+     | cancel PUBLISH_NAMESPACE |                          |
+     |------------------------->|                          |
+     |                          |      NAMESPACE_DONE      |
+     |                          |          (123)           |
+     |                          |------------------------->|
+     |                          |                          |
+~~~
+{: #namespace-discovery-flow title="Namespace discovery through a relay"}
+
+The NAMESPACE and NAMESPACE_DONE messages carry only the suffix `123`, because
+the prefix `example` is already known from the SUBSCRIBE_NAMESPACE.
+
 # Object Transmission
 
 ## Priorities {#priorities}

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1095,6 +1095,9 @@ SUBSCRIBE_TRACKS requests track subscriptions: the publisher sends PUBLISH
 messages for tracks within matching namespaces, excluding tracks published
 by the subscriber.
 
+A SUBSCRIBE_TRACKS with zero Track Namespace fields indicates the sender is
+interested in all tracks from the receiver.
+
 SUBSCRIBE_TRACKS is not required for a publisher to send PUBLISH messages to
 a subscriber.  It is useful for subscribers that are
 only interested in or authorized to access a subset of available tracks.
@@ -1117,6 +1120,8 @@ overlap spaces (see {{subscribing-to-namespaces}}).
 The publisher MUST ensure the subscriber is authorized to perform this
 namespace subscription.
 
+A SUBSCRIBE_TRACKS is cancelled as described in
+{{request-cancellation}}, by resetting or sending STOP_SENDING on the stream.
 Cancelling SUBSCRIBE_TRACKS does not prohibit original publishers
 from sending further PUBLISH messages, but relays MUST NOT
 send any further PUBLISH messages to a client without knowing the client is
@@ -1208,8 +1213,8 @@ The syntax of these messages is described in {{message}}.
 ## Subscribing to Namespaces {#subscribing-to-namespaces}
 
 If the subscriber is aware of a namespace of interest, it can send
-SUBSCRIBE_NAMESPACE or SUBSCRIBE_TRACKS to publishers/relays it has established
-a session with. The Track Namespace Prefix carried in these messages is
+SUBSCRIBE_NAMESPACE to publishers/relays it has established
+a session with. The Track Namespace Prefix it carries is
 compared against the namespaces known to the receiver using Namespace Prefix
 Matching ({{namespace-prefix-matching}}).
 
@@ -1218,15 +1223,15 @@ NAMESPACE and NAMESPACE_DONE messages for namespaces matching the prefix,
 including echoing back Track Namespaces under the prefix that have been published
 to it.
 
-Either message with zero Track Namespace fields indicates the sender is
-interested in all namespaces or all tracks from the receiver, respectively.
+A SUBSCRIBE_NAMESPACE with zero Track Namespace fields indicates the sender is
+interested in all namespaces from the receiver.
 
 By sending SUBSCRIBE_NAMESPACE, the subscriber indicates that it trusts the
 relay to be authoritative for namespaces matching the requested prefix.
 NAMESPACE messages received on the SUBSCRIBE_NAMESPACE response stream inherit
 this trust and do not independently carry authorization.
 
-The subscriber sends SUBSCRIBE_NAMESPACE or SUBSCRIBE_TRACKS on a new
+The subscriber sends SUBSCRIBE_NAMESPACE on a new
 bidirectional stream and the publisher MUST send a single REQUEST_OK or
 REQUEST_ERROR as the first message on the bidirectional stream in response.
 
@@ -1258,7 +1263,7 @@ The publisher MUST NOT send NAMESPACE_DONE for a namespace suffix before the
 corresponding NAMESPACE. If a subscriber receives a NAMESPACE_DONE before the
 corresponding NAMESPACE, it MUST close the session with a 'PROTOCOL_VIOLATION'.
 
-A SUBSCRIBE_NAMESPACE or SUBSCRIBE_TRACKS is cancelled as described in
+A SUBSCRIBE_NAMESPACE is cancelled as described in
 {{request-cancellation}}, by resetting or sending STOP_SENDING on the stream.
 
 ### Namespace Subscription State Management

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1207,8 +1207,62 @@ previous MOQT messages besides SETUP. However, SUBSCRIBE_NAMESPACE, SUBSCRIBE_TR
 PUBLISH_NAMESPACE messages provide an in-band means of discovery of publishers
 for a namespace.
 
+While PUBLISH_NAMESPACE indicates to relays how to connect publishers and
+subscribers, it is not a full-fledged routing protocol and does not protect
+against loops and other phenomena. In particular, PUBLISH_NAMESPACE SHOULD NOT
+be used to find paths through richly connected networks of relays.
+
 The syntax of these messages is described in {{message}}.
 
+
+## Publishing Namespaces
+
+A publisher MAY send PUBLISH_NAMESPACE messages to any subscriber. A
+PUBLISH_NAMESPACE indicates to the subscriber that the publisher has tracks
+available in namespaces matching the Track Namespace Prefix it carries (see
+{{namespace-prefix-matching}}). A subscriber MAY send SUBSCRIBE or FETCH for
+tracks in a namespace without having received a PUBLISH_NAMESPACE for it.
+
+The receiver verifies the publisher is authorized to publish tracks under this
+prefix.
+
+If a publisher is the Original Publisher for one or more tracks in a given
+namespace, or is a relay that has received an authorized PUBLISH_NAMESPACE for
+that namespace from an upstream publisher, it MUST send a NAMESPACE message
+that includes this namespace to any subscriber that has sent a
+SUBSCRIBE_NAMESPACE whose prefix matches this namespace.
+
+A subscriber can receive a PUBLISH_NAMESPACE on a request stream for a
+namespace that falls within an active SUBSCRIBE_NAMESPACE prefix. This
+occurs when SUBSCRIBE_NAMESPACE or its response is in flight at the same time
+as a PUBLISH_NAMESPACE, or when an original publisher sends PUBLISH_NAMESPACE
+to advertise namespaces within the prefix being discovered. Such a
+PUBLISH_NAMESPACE is valid and MAY carry an AUTHORIZATION TOKEN parameter.
+Its lifetime is independent of the SUBSCRIBE_NAMESPACE stream.
+
+An endpoint SHOULD report the reception of a PUBLISH_NAMESPACE_OK or
+PUBLISH_NAMESPACE_ERROR to the application to inform the search for additional
+subscribers for a namespace, or to abandon the attempt to publish under this
+namespace. A subscriber MUST send exactly one PUBLISH_NAMESPACE_OK or
+PUBLISH_NAMESPACE_ERROR as the first message on the bidi stream in response to
+a PUBLISH_NAMESPACE. The publisher SHOULD close the session with a protocol
+error if it receives more than one.
+
+A PUBLISH_NAMESPACE is withdrawn by cancelling the request
+(see {{request-cancellation}}), although it is not a protocol error for
+the subscriber to send a SUBSCRIBE or FETCH message for a track in a
+namespace after the namespace is withdrawn.
+
+A subscriber can cancel the request (see {{request-cancellation}}) to revoke
+acceptance of a PUBLISH_NAMESPACE. If the reason for cancellation is expiration
+of authorization credentials, the publisher can send PUBLISH_NAMESPACE again
+on a new bidi stream with refreshed authorization, or close the stream and
+discard associated state.
+
+A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If it
+has accepted a PUBLISH_NAMESPACE with a namespace that exactly matches the
+namespace for that track, it SHOULD only request it from the senders of those
+PUBLISH_NAMESPACE messages.
 
 ## Subscribing to Namespaces {#subscribing-to-namespaces}
 
@@ -1275,61 +1329,6 @@ a subscriber receives a stream reset or FIN on a SUBSCRIBE_NAMESPACE response
 stream, it SHOULD treat this as though each active namespace received a
 NAMESPACE_DONE. Subscriptions established via PUBLISH on separate bidi streams
 are not affected by closure of the SUBSCRIBE_NAMESPACE stream.
-
-## Publishing Namespaces
-
-A publisher MAY send PUBLISH_NAMESPACE messages to any subscriber. A
-PUBLISH_NAMESPACE indicates to the subscriber that the publisher has tracks
-available in namespaces matching the Track Namespace Prefix it carries (see
-{{namespace-prefix-matching}}). A subscriber MAY send SUBSCRIBE or FETCH for
-tracks in a namespace without having received a PUBLISH_NAMESPACE for it.
-
-The receiver verifies the publisher is authorized to publish tracks under this
-prefix.
-
-If a publisher is the Original Publisher for one or more tracks in a given
-namespace, or is a relay that has received an authorized PUBLISH_NAMESPACE for
-that namespace from an upstream publisher, it MUST send a NAMESPACE message
-that includes this namespace to any subscriber that has sent a
-SUBSCRIBE_NAMESPACE whose prefix matches this namespace.
-
-A subscriber can receive a PUBLISH_NAMESPACE on a request stream for a
-namespace that falls within an active SUBSCRIBE_NAMESPACE prefix. This
-occurs when SUBSCRIBE_NAMESPACE or its response is in flight at the same time
-as a PUBLISH_NAMESPACE, or when an original publisher sends PUBLISH_NAMESPACE
-to advertise namespaces within the prefix being discovered. Such a
-PUBLISH_NAMESPACE is valid and MAY carry an AUTHORIZATION TOKEN parameter.
-Its lifetime is independent of the SUBSCRIBE_NAMESPACE stream.
-
-An endpoint SHOULD report the reception of a PUBLISH_NAMESPACE_OK or
-PUBLISH_NAMESPACE_ERROR to the application to inform the search for additional
-subscribers for a namespace, or to abandon the attempt to publish under this
-namespace. A subscriber MUST send exactly one PUBLISH_NAMESPACE_OK or
-PUBLISH_NAMESPACE_ERROR as the first message on the bidi stream in response to
-a PUBLISH_NAMESPACE. The publisher SHOULD close the session with a protocol
-error if it receives more than one.
-
-A PUBLISH_NAMESPACE is withdrawn by cancelling the request
-(see {{request-cancellation}}), although it is not a protocol error for
-the subscriber to send a SUBSCRIBE or FETCH message for a track in a
-namespace after the namespace is withdrawn.
-
-A subscriber can cancel the request (see {{request-cancellation}}) to revoke
-acceptance of a PUBLISH_NAMESPACE. If the reason for cancellation is expiration
-of authorization credentials, the publisher can send PUBLISH_NAMESPACE again
-on a new bidi stream with refreshed authorization, or close the stream and
-discard associated state.
-
-While PUBLISH_NAMESPACE indicates to relays how to connect publishers and
-subscribers, it is not a full-fledged routing protocol and does not protect
-against loops and other phenomena. In particular, PUBLISH_NAMESPACE SHOULD NOT
-be used to find paths through richly connected networks of relays.
-
-A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If it
-has accepted a PUBLISH_NAMESPACE with a namespace that exactly matches the
-namespace for that track, it SHOULD only request it from the senders of those
-PUBLISH_NAMESPACE messages.
-
 
 # Object Transmission
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -92,7 +92,7 @@ This document describes the MOQT protocol and is structured as follows:
 * The core concepts and functionality are described first
   * Section 2 {{model}} Object Data Model describes how Objects, Tracks and Namespaces relate
   * Section 3 {{publishing-and-receiving-tracks}} Describes how Objects in Tracks are Published and Retrieved.
-  * Section 4 {{track-discovery}} Describes mechanisms for discovering Namespaces and Tracks
+  * Section 4 {{track-discovery}} Describes mechanisms for discovering Publishers and Namespaces
 
 * Next, the document describes how Objects are transmitted and MOQT Sessions
   * Section 5 {{object-transmission}} Describes ways MOTQ allows a subscriber to influence Object transmission order
@@ -1195,24 +1195,22 @@ SHOULD take the following action:
 
 * For PUBLISH: do not publish the track to that subscriber.
 
-# Namespace Discovery {#track-discovery}
+# Publisher and Namespace Discovery {#track-discovery}
 
-Discovery of MOQT servers is always done out-of-band. Namespace discovery can be
-done in the context of an established MOQT session using SUBSCRIBE_NAMESPACE
-(see {{subscribing-to-namespaces}}).
+Given sufficient out-of-band information, it is valid for a subscriber to
+retrieve tracks from a publisher (including a relay) without any previous MOQT
+messages besides SETUP.  However, MOQT provides in-band messages for a publisher
+to advertise the namespaces it has tracks in, and for a subscriber to enumerate
+the namespaces a publisher knows.
 
-Given sufficient out of band information, it is valid for a subscriber to send a
-SUBSCRIBE or FETCH message to a publisher (including a relay) without any
-previous MOQT messages besides SETUP. However, SUBSCRIBE_NAMESPACE, SUBSCRIBE_TRACKS, PUBLISH and
-PUBLISH_NAMESPACE messages provide an in-band means of discovery of publishers
-for a namespace.
+Discovery of MOQT servers is always done out-of-band: MOQT does not specify how
+an endpoint learns where to establish a session. The discovery described in this
+section takes place within an established session.
 
 While PUBLISH_NAMESPACE indicates to relays how to connect publishers and
 subscribers, it is not a full-fledged routing protocol and does not protect
 against loops and other phenomena. In particular, PUBLISH_NAMESPACE SHOULD NOT
 be used to find paths through richly connected networks of relays.
-
-The syntax of these messages is described in {{message}}.
 
 
 ## Publishing Namespaces

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -1089,6 +1089,69 @@ that starts at the Next Group and NEW_GROUP_REQUEST equal to 0.  The value of
 DYNAMIC_GROUPS in SUBSCRIBE_OK will indicate if the publisher supports dynamic
 groups. A publisher that does will begin the next group as soon as practical.
 
+## Subscribing to Tracks by Prefix {#subscribe-tracks}
+
+SUBSCRIBE_TRACKS requests track subscriptions: the publisher sends PUBLISH
+messages for tracks within matching namespaces, excluding tracks published
+by the subscriber.
+
+SUBSCRIBE_TRACKS is not required for a publisher to send PUBLISH messages to
+a subscriber.  It is useful for subscribers that are
+only interested in or authorized to access a subset of available tracks.
+
+The publisher will respond with SUBSCRIBE_TRACKS_OK or SUBSCRIBE_TRACKS_ERROR
+on the response half of the stream. If the subscriber receives any message
+other than a SUBSCRIBE_TRACKS_OK or a SUBSCRIBE_TRACKS_ERROR as the first
+message on the response half of the stream, then it MUST close the session with
+a PROTOCOL_VIOLATION. If the SUBSCRIBE_TRACKS is successful, the publisher will
+send PUBLISH messages on new bidirectional streams for tracks within matching
+namespaces. If it is an error, the stream will be closed via FIN after
+SUBSCRIBE_TRACKS_ERROR is sent.
+
+Within a session, if a publisher receives a SUBSCRIBE_TRACKS with a
+Track Namespace Prefix that shares a common prefix with an established
+SUBSCRIBE_TRACKS, it MUST respond with SUBSCRIBE_TRACKS_ERROR with error code
+`PREFIX_OVERLAP`.  SUBSCRIBE_TRACKS and SUBSCRIBE_NAMESPACE have independent
+overlap spaces (see {{subscribing-to-namespaces}}).
+
+The publisher MUST ensure the subscriber is authorized to perform this
+namespace subscription.
+
+Cancelling SUBSCRIBE_TRACKS does not prohibit original publishers
+from sending further PUBLISH messages, but relays MUST NOT
+send any further PUBLISH messages to a client without knowing the client is
+interested in and authorized to receive the content.
+
+### Filtering SUBSCRIBE_TRACKS
+
+Range Filters {{range-filters}} can be used in SUBSCRIBE_TRACKS to filter
+Tracks in a namespace using the Track Property Filter. Objects published in
+the resulting Subscriptions can be filtered by any Range Filter.
+
+### Parameters on SUBSCRIBE_TRACKS {#parameters-on-subscribe-tracks}
+
+Any Parameter that can be specified on a Subscription (ie: in SUBSCRIBE) is valid
+in SUBSCRIBE_TRACKS, unless otherwise specified. These parameters are used by the
+publisher as the initial Subscription parameters when a PUBLISH is sent as a result of
+SUBSCRIBE_TRACKS. These Parameters are explicitly communicated in PUBLISH.
+When omitted by the publisher in PUBLISH, the subscriber uses the default value for each.
+
+To join Tracks initiated via the resulting PUBLISHes, the subscriber can specify a
+Location Filter and optionally include FILL_PARAMETERS, as described in {{joining-tracks}}.
+
+### Skipped Tracks
+
+If a Subscription cannot be created because there are no available bidirectional
+streams or any other reason, the Publisher sends a PUBLISH_SKIPPED message on the
+SUBSCRIBE_TRACKS response stream to indicate the Full Track Name of the
+Subscription that was not created. The Publisher MUST NOT send a PUBLISH for a
+Track for a given SUBSCRIBE_TRACKS after PUBLISH_SKIPPED has been sent,
+scoped to a single PUBLISH.  If, for example, the publisher disconnects from
+a relay and later reconnects and sends a new PUBLISH, the relay MAY send the new
+PUBLISH downstream.
+If desired, the subscriber can issue a SUBSCRIBE to establish a subscription to
+that track.
+
 ## Mandatory to Understand Track Properties {#mandatory-track-properties}
 
 Property types in the range 0x4000-0x7FFF are designated as Mandatory Track
@@ -1155,10 +1218,6 @@ NAMESPACE and NAMESPACE_DONE messages for namespaces matching the prefix,
 including echoing back Track Namespaces under the prefix that have been published
 to it.
 
-SUBSCRIBE_TRACKS requests track subscriptions: the publisher sends PUBLISH
-messages for tracks within matching namespaces, excluding tracks published
-by the subscriber.
-
 Either message with zero Track Namespace fields indicates the sender is
 interested in all namespaces or all tracks from the receiver, respectively.
 
@@ -1171,27 +1230,12 @@ The subscriber sends SUBSCRIBE_NAMESPACE or SUBSCRIBE_TRACKS on a new
 bidirectional stream and the publisher MUST send a single REQUEST_OK or
 REQUEST_ERROR as the first message on the bidirectional stream in response.
 
-If a Subscription cannot be created because there are no available bidirectional
-streams or any other reason, the Publisher sends a PUBLISH_SKIPPED message on the
-SUBSCRIBE_TRACKS response stream to indicate the Full Track Name of the
-Subscription that was not created. The Publisher MUST NOT send a PUBLISH for a
-Track for a given SUBSCRIBE_TRACKS after PUBLISH_SKIPPED has been sent,
-scoped to a single PUBLISH.  If, for example, the publisher disconnects from
-a relay and later reconnects and sends a new PUBLISH, the relay MAY send the new
-PUBLISH downstream.
-If desired, the subscriber can issue a SUBSCRIBE to establish a subscription to
-that track.
-
 The receiver of a REQUEST_OK or REQUEST_ERROR ought to
 forward the result to the application, so the application can decide which other
 publishers to contact, if any.
 
 A SUBSCRIBE_NAMESPACE or SUBSCRIBE_TRACKS is cancelled as described in
 {{request-cancellation}}, by resetting or sending STOP_SENDING on the stream.
-Cancelling SUBSCRIBE_TRACKS does not prohibit original publishers
-from sending further PUBLISH messages, but relays MUST NOT
-send any further PUBLISH messages to a client without knowing the client is
-interested in and authorized to receive the content.
 
 ## Publishing Namespaces
 
@@ -1243,23 +1287,6 @@ A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If it
 has accepted a PUBLISH_NAMESPACE with a namespace that exactly matches the
 namespace for that track, it SHOULD only request it from the senders of those
 PUBLISH_NAMESPACE messages.
-
-## Filtering SUBSCRIBE_TRACKS
-
-Range Filters {{range-filters}} can be used in SUBSCRIBE_TRACKS to filter
-Tracks in a namespace using the Track Property Filter. Objects published in
-the resulting Subscriptions can be filtered by any Range Filter.
-
-### Relay Resource Protection in Large Namespaces {#large-namespaces}
-
-Relays SHOULD aggregate and propagate filters upstream on subscriptions,
-especially namespace subscriptions,
-to conserve and protect their resources from excessive load.  They MAY
-also impose limits on the number of publishers in a namespace, by rejecting
-or closing namespace subscriptions with the error NAMESPACE_TOO_LARGE, or
-CONFLICTING_FILTERS if too many disjoint filters are requested on downstream
-subscriptions across a large number of subscribers, or PREFIX_OVERLAP if different
-subscribers force an aggregated upstream subscription to overlap.
 
 
 # Object Transmission
@@ -2012,6 +2039,17 @@ all `Established` subscriptions to the new relay. The new relay will send a
 response to the subscribes and if they are successful, the subscriptions
 to the old relay can be cancelled (see {{request-cancellation}}).
 
+
+## Relay Resource Protection in Large Namespaces {#large-namespaces}
+
+Relays SHOULD aggregate and propagate filters upstream on subscriptions,
+especially namespace subscriptions,
+to conserve and protect their resources from excessive load.  They MAY
+also impose limits on the number of publishers in a namespace, by rejecting
+or closing namespace subscriptions with the error NAMESPACE_TOO_LARGE, or
+CONFLICTING_FILTERS if too many disjoint filters are requested on downstream
+subscriptions across a large number of subscribers, or PREFIX_OVERLAP if different
+subscribers force an aggregated upstream subscription to overlap.
 
 ## Publisher Interactions
 
@@ -3577,39 +3615,6 @@ SUBSCRIBE_TRACKS Message {
   AUTHORIZATION_TOKEN, FORWARD, GROUP_ORDER, SUBGROUP_FILTER, OBJECTID_FILTER,
   PRIORITY_FILTER, OBJECT_PROPERTY_FILTER, TRACK_PROPERTY_FILTER and
   INCLUDE_PROPERTIES.
-
-The publisher will respond with SUBSCRIBE_TRACKS_OK or SUBSCRIBE_TRACKS_ERROR
-on the response half of the stream. If the subscriber receives any message
-other than a SUBSCRIBE_TRACKS_OK or a SUBSCRIBE_TRACKS_ERROR as the first
-message on the response half of the stream, then it MUST close the session with
-a PROTOCOL_VIOLATION. If the SUBSCRIBE_TRACKS is successful, the publisher will
-send PUBLISH messages on new bidirectional streams for tracks within matching
-namespaces. If it is an error, the stream will be closed via FIN after
-SUBSCRIBE_TRACKS_ERROR is sent.
-
-Within a session, if a publisher receives a SUBSCRIBE_TRACKS with a
-Track Namespace Prefix that shares a common prefix with an established
-SUBSCRIBE_TRACKS, it MUST respond with SUBSCRIBE_TRACKS_ERROR with error code
-`PREFIX_OVERLAP`.  SUBSCRIBE_TRACKS and SUBSCRIBE_NAMESPACE have independent
-overlap spaces (see {{message-subscribe-ns}}).
-
-The publisher MUST ensure the subscriber is authorized to perform this
-namespace subscription.
-
-SUBSCRIBE_TRACKS is not required for a publisher to send PUBLISH messages to
-a subscriber.  It is useful for subscribers that are
-only interested in or authorized to access a subset of available tracks.
-
-### Parameters on SUBSCRIBE_TRACKS {#parameters-on-subscribe-tracks}
-
-Any Parameter that can be specified on a Subscription (ie: in SUBSCRIBE) is valid
-in SUBSCRIBE_TRACKS, unless otherwise specified. These parameters are used by the
-publisher as the initial Subscription parameters when a PUBLISH is sent as a result of
-SUBSCRIBE_TRACKS. These Parameters are explicitly communicated in PUBLISH.
-When omitted by the publisher in PUBLISH, the subscriber uses the default value for each.
-
-To join Tracks initiated via the resulting PUBLISHes, the subscriber can specify a
-Location Filter and optionally include FILL_PARAMETERS, as described in {{joining-tracks}}.
 
 ## PUBLISH_SKIPPED {#message-publish-skipped}
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -500,15 +500,19 @@ Namespace Fields or Track Name such that exact comparison works.
 
 ### Namespace Prefix Matching {#namespace-prefix-matching}
 
-To perform a namespace prefix match, the fields in the Track Namespace are
-matched sequentially, requiring an exact match for each field. If the published
-or subscribed Track Namespace has the same or fewer fields than the Track
-Namespace in the message, it qualifies as a match.
+To perform a namespace prefix match, the fields of the prefix are compared
+sequentially against the leading fields of the Track Namespace or Full Track
+Name being matched, requiring an exact match for each field.  The prefix
+matches if it has the same or fewer fields.
 
-For example:
-A SUBSCRIBE message with namespace=(foo, bar) and name=x will match sessions
-that sent PUBLISH_NAMESPACE messages with namespace=(foo) or namespace=(foo,
-bar).  It will not match a session with namespace=(foobar).
+The examples below use the serialized name format from
+{{namespace-name-format}}.
+
+The name `foo-bar--x` matches the prefixes `foo` and `foo-bar`.  It does not
+match `foobar`.
+
+The prefix `example.2ecom-123` matches the namespaces `example.2ecom-123-100`
+and `example.2ecom-123-200`.
 
 ### Reserved Namespaces {#reserved-namespaces}
 
@@ -1207,49 +1211,37 @@ Discovery of MOQT servers is always done out-of-band: MOQT does not specify how
 an endpoint learns where to establish a session. The discovery described in this
 section takes place within an established session.
 
-While PUBLISH_NAMESPACE indicates to relays how to connect publishers and
-subscribers, it is not a full-fledged routing protocol and does not protect
-against loops and other phenomena. In particular, PUBLISH_NAMESPACE SHOULD NOT
-be used to find paths through richly connected networks of relays.
-
-
 ## Publishing Namespaces
 
 A publisher MAY send PUBLISH_NAMESPACE messages to any subscriber. A
 PUBLISH_NAMESPACE indicates to the subscriber that the publisher has tracks
 available in namespaces matching the Track Namespace Prefix it carries (see
-{{namespace-prefix-matching}}). A subscriber MAY send SUBSCRIBE or FETCH for
-tracks in a namespace without having received a PUBLISH_NAMESPACE for it.
+{{namespace-prefix-matching}}). A subscriber MAY send SUBSCRIBE, FETCH or
+TRACK_STATUS for tracks in a namespace without having received a
+PUBLISH_NAMESPACE for it.
 
 The receiver verifies the publisher is authorized to publish tracks under this
 prefix.
 
-If a publisher is the Original Publisher for one or more tracks in a given
-namespace, or is a relay that has received an authorized PUBLISH_NAMESPACE for
-that namespace from an upstream publisher, it MUST send a NAMESPACE message
-that includes this namespace to any subscriber that has sent a
-SUBSCRIBE_NAMESPACE whose prefix matches this namespace.
-
-A subscriber can receive a PUBLISH_NAMESPACE on a request stream for a
-namespace that falls within an active SUBSCRIBE_NAMESPACE prefix. This
-occurs when SUBSCRIBE_NAMESPACE or its response is in flight at the same time
-as a PUBLISH_NAMESPACE, or when an original publisher sends PUBLISH_NAMESPACE
-to advertise namespaces within the prefix being discovered. Such a
-PUBLISH_NAMESPACE is valid and MAY carry an AUTHORIZATION TOKEN parameter.
-Its lifetime is independent of the SUBSCRIBE_NAMESPACE stream.
-
-An endpoint SHOULD report the reception of a PUBLISH_NAMESPACE_OK or
-PUBLISH_NAMESPACE_ERROR to the application to inform the search for additional
-subscribers for a namespace, or to abandon the attempt to publish under this
-namespace. A subscriber MUST send exactly one PUBLISH_NAMESPACE_OK or
+A subscriber MUST send exactly one PUBLISH_NAMESPACE_OK or
 PUBLISH_NAMESPACE_ERROR as the first message on the bidi stream in response to
 a PUBLISH_NAMESPACE. The publisher SHOULD close the session with a protocol
 error if it receives more than one.
 
+An endpoint SHOULD report the reception of a PUBLISH_NAMESPACE_OK or
+PUBLISH_NAMESPACE_ERROR to the application to inform the search for additional
+subscribers for a namespace, or to abandon the attempt to publish under this
+namespace.
+
+If a subscriber
+has accepted a PUBLISH_NAMESPACE with a namespace that exactly matches the
+namespace for a given track, it SHOULD only request it from the senders of those
+PUBLISH_NAMESPACE messages.
+
 A PUBLISH_NAMESPACE is withdrawn by cancelling the request
 (see {{request-cancellation}}), although it is not a protocol error for
-the subscriber to send a SUBSCRIBE or FETCH message for a track in a
-namespace after the namespace is withdrawn.
+the subscriber to send a SUBSCRIBE, FETCH or TRACK_STATUS message for a track
+in a namespace after the namespace is withdrawn.
 
 A subscriber can cancel the request (see {{request-cancellation}}) to revoke
 acceptance of a PUBLISH_NAMESPACE. If the reason for cancellation is expiration
@@ -1257,10 +1249,10 @@ of authorization credentials, the publisher can send PUBLISH_NAMESPACE again
 on a new bidi stream with refreshed authorization, or close the stream and
 discard associated state.
 
-A subscriber MAY send a SUBSCRIBE or FETCH for a track to any publisher. If it
-has accepted a PUBLISH_NAMESPACE with a namespace that exactly matches the
-namespace for that track, it SHOULD only request it from the senders of those
-PUBLISH_NAMESPACE messages.
+While PUBLISH_NAMESPACE indicates to relays how to connect publishers and
+subscribers, it is not a full-fledged routing protocol and does not protect
+against loops and other phenomena. In particular, PUBLISH_NAMESPACE SHOULD NOT
+be used to find paths through richly connected networks of relays.
 
 ## Subscribing to Namespaces {#subscribing-to-namespaces}
 
@@ -1270,37 +1262,31 @@ a session with. The Track Namespace Prefix it carries is
 compared against the namespaces known to the receiver using Namespace Prefix
 Matching ({{namespace-prefix-matching}}).
 
-SUBSCRIBE_NAMESPACE requests namespace discovery: the publisher sends relevant
-NAMESPACE and NAMESPACE_DONE messages for namespaces matching the prefix,
-including echoing back Track Namespaces under the prefix that have been published
-to it.
+SUBSCRIBE_NAMESPACE requests namespace discovery: the publisher responds with
+NAMESPACE and NAMESPACE_DONE messages.
 
 A SUBSCRIBE_NAMESPACE with zero Track Namespace fields indicates the sender is
 interested in all namespaces from the receiver.
 
-By sending SUBSCRIBE_NAMESPACE, the subscriber indicates that it trusts the
-relay to be authoritative for namespaces matching the requested prefix.
-NAMESPACE messages received on the SUBSCRIBE_NAMESPACE response stream inherit
-this trust and do not independently carry authorization.
-
-The subscriber sends SUBSCRIBE_NAMESPACE on a new
-bidirectional stream and the publisher MUST send a single REQUEST_OK or
-REQUEST_ERROR as the first message on the bidirectional stream in response.
-
-The receiver of a REQUEST_OK or REQUEST_ERROR ought to
-forward the result to the application, so the application can decide which other
-publishers to contact, if any.
-
-The publisher will respond with SUBSCRIBE_NAMESPACE_OK or
-SUBSCRIBE_NAMESPACE_ERROR on the response half of the stream. If the subscriber
-receives any message other than a SUBSCRIBE_NAMESPACE_OK or a
+The subscriber sends SUBSCRIBE_NAMESPACE on a new bidirectional stream. The
+publisher MUST send a single SUBSCRIBE_NAMESPACE_OK or
 SUBSCRIBE_NAMESPACE_ERROR as the first message on the response half of the
-stream, then it MUST close the session with a PROTOCOL_VIOLATION. If the
-SUBSCRIBE_NAMESPACE is successful, the publisher will send matching NAMESPACE
-messages on the response stream. If it is an error, the stream will be
-immediately closed via FIN. When there are changes to the namespaces being
-published and the subscriber is subscribed to them, the publisher sends the
-corresponding NAMESPACE or NAMESPACE_DONE messages.
+stream; if the subscriber receives any other message first, it MUST close the
+session with a PROTOCOL_VIOLATION.
+
+On success, the publisher MUST send a NAMESPACE message for each namespace it
+knows that matches the Track Namespace Prefix, and further NAMESPACE or
+NAMESPACE_DONE messages as that set changes.  A publisher knows a namespace if
+it is the Original Publisher for one or more tracks in it, or is a relay that
+has received an authorized PUBLISH_NAMESPACE for it from an upstream publisher.
+On error, the stream is immediately closed via FIN.
+
+The namespace in a NAMESPACE message is itself a prefix; tracks can exist in
+namespaces matching it.  A NAMESPACE_DONE indicates the publisher intends to
+stop serving new subscriptions for tracks within that namespace.
+
+The subscriber ought to forward the result to the application, so the
+application can decide which other publishers to contact, if any.
 
 Within a session, if a publisher receives a SUBSCRIBE_NAMESPACE with a
 Track Namespace Prefix that shares a common prefix with an established
@@ -1308,15 +1294,30 @@ SUBSCRIBE_NAMESPACE, it MUST respond with SUBSCRIBE_NAMESPACE_ERROR with
 error code `PREFIX_OVERLAP`.  SUBSCRIBE_NAMESPACE and SUBSCRIBE_TRACKS have
 independent overlap spaces (see {{subscribe-tracks}}).
 
-The publisher MUST ensure the subscriber is authorized to perform this
-namespace subscription.
-
 The publisher MUST NOT send NAMESPACE_DONE for a namespace suffix before the
 corresponding NAMESPACE. If a subscriber receives a NAMESPACE_DONE before the
 corresponding NAMESPACE, it MUST close the session with a 'PROTOCOL_VIOLATION'.
 
+A subscriber can receive a PUBLISH_NAMESPACE on a request stream for a
+namespace that falls within an active SUBSCRIBE_NAMESPACE prefix. This
+occurs when SUBSCRIBE_NAMESPACE or its response is in flight at the same time
+as a PUBLISH_NAMESPACE, or when an original publisher sends PUBLISH_NAMESPACE
+to advertise namespaces within the prefix being discovered. Such a
+PUBLISH_NAMESPACE is valid and MAY carry an AUTHORIZATION TOKEN parameter.
+Its lifetime is independent of the SUBSCRIBE_NAMESPACE stream.
+
 A SUBSCRIBE_NAMESPACE is cancelled as described in
 {{request-cancellation}}, by resetting or sending STOP_SENDING on the stream.
+
+### Namespace Subscription Authorization
+
+The publisher MUST ensure the subscriber is authorized to perform a
+namespace subscription.
+
+By sending SUBSCRIBE_NAMESPACE, the subscriber indicates that it trusts the
+relay to be authoritative for namespaces matching the requested prefix.
+NAMESPACE messages received on the SUBSCRIBE_NAMESPACE response stream inherit
+this trust and do not independently carry authorization.
 
 ### Namespace Subscription State Management
 
@@ -3534,12 +3535,8 @@ SUBSCRIBE_NAMESPACE Message {
 * Request ID: See {{request-id}}.
 
 * Track Namespace Prefix: A Track Namespace structure as described in
-  {{track-namespace-structure}}.  This prefix is matched against track
-  namespaces known to the publisher.  For example, using the serialized format
-  from {{namespace-name-format}}, if the publisher is a relay that has received
-  PUBLISH_NAMESPACE messages for namespaces `example.2ecom-123-100` and
-  `example.2ecom-123-200`, a SUBSCRIBE_NAMESPACE for `example.2ecom-123` would
-  match both.
+  {{track-namespace-structure}}, matched as a prefix (see
+  {{namespace-prefix-matching}}).
 
 * Parameters: The parameters are defined in {{message-params}}.  The only
   parameter that can appear in a SUBSCRIBE_NAMESPACE is AUTHORIZATION_TOKEN.
@@ -3550,10 +3547,7 @@ The NAMESPACE message is similar to the PUBLISH_NAMESPACE message, except
 it is sent on the response stream of a SUBSCRIBE_NAMESPACE request.
 All NAMESPACE messages are in response to a SUBSCRIBE_NAMESPACE, so only
 the namespace tuples after the 'Track Namespace Prefix' are included
-in the 'Track Namespace Suffix'.  The Track Namespace Prefix from the
-SUBSCRIBE_NAMESPACE followed by the Track Namespace Suffix is the Track
-Namespace Prefix the publisher advertised, so tracks can exist in
-namespaces matching that prefix (see {{namespace-prefix-matching}}).
+in the 'Track Namespace Suffix'.
 
 ~~~
 NAMESPACE Message {
@@ -3571,9 +3565,9 @@ NAMESPACE Message {
 
 ## NAMESPACE_DONE {#message-namespace-done}
 
-The publisher sends the `NAMESPACE_DONE` control message to indicate its
-intent to stop serving new subscriptions for tracks within the provided Track
-Namespace. All NAMESPACE_DONE messages are in response to a SUBSCRIBE_NAMESPACE,
+The publisher sends the `NAMESPACE_DONE` control message on the response stream
+of a SUBSCRIBE_NAMESPACE request. All NAMESPACE_DONE messages are in response to
+a SUBSCRIBE_NAMESPACE,
 so only the namespace tuples after the 'Track Namespace Prefix' are included
 in the 'Track Namespace Suffix'.
 

--- a/draft-ietf-moq-transport.md
+++ b/draft-ietf-moq-transport.md
@@ -498,6 +498,18 @@ information in these fields, for example by restricting them to UTF-8. Any such
 specification needs to specify the canonicalization into the bytes in the Track
 Namespace Fields or Track Name such that exact comparison works.
 
+### Namespace Prefix Matching {#namespace-prefix-matching}
+
+To perform a namespace prefix match, the fields in the Track Namespace are
+matched sequentially, requiring an exact match for each field. If the published
+or subscribed Track Namespace has the same or fewer fields than the Track
+Namespace in the message, it qualifies as a match.
+
+For example:
+A SUBSCRIBE message with namespace=(foo, bar) and name=x will match sessions
+that sent PUBLISH_NAMESPACE messages with namespace=(foo) or namespace=(foo,
+bar).  It will not match a session with namespace=(foobar).
+
 ### Reserved Namespaces {#reserved-namespaces}
 
 MOQT reserves all Track Namespace values whose first tuple field begins with
@@ -2033,17 +2045,9 @@ A Relay connects publishers and subscribers by managing sessions based on the
 Track Namespace or Full Track Name. When a SUBSCRIBE message is sent, its Full
 Track Name is matched exactly against existing upstream subscriptions.
 
-Namespace Prefix Matching is further used to decide which publishers receive a
-SUBSCRIBE and which subscribers receive a PUBLISH. In this process, the fields
-in the Track Namespace are matched sequentially, requiring an exact match for
-each field. If the published or subscribed Track Namespace has the same or fewer
-fields than the Track Namespace in the message, it qualifies as a match.
-{: #namespace-prefix-matching}
-
-For example:
-A SUBSCRIBE message with namespace=(foo, bar) and name=x will match sessions
-that sent PUBLISH_NAMESPACE messages with namespace=(foo) or namespace=(foo,
-bar).  It will not match a session with namespace=(foobar).
+Namespace Prefix Matching ({{namespace-prefix-matching}}) is further used to
+decide which publishers receive a SUBSCRIBE and which subscribers receive a
+PUBLISH.
 
 Relays MUST send SUBSCRIBE messages to all matching publishers. This includes
 matching both Established subscriptions on the Full Track Name and Namespace


### PR DESCRIPTION
- Namespace Prefix Matching gets its own section under Track.
- SUBSCRIBE_TRACKS moves to its own section under Publishing and Receiving
  Tracks — it creates subscriptions rather than discovering namespaces.
- Behavior is hoisted out of the five namespace message sections, which now
  carry only a diagram and fields.
- Publishing now precedes Subscribing, and section 4 is tightened: response
  handling was stated three times, authorization in three places.
- A ladder diagram shows the publisher → relay → subscriber path.
- Editorial cleanup of some prose
- 
sentence-diff (from `draft-21-retro`) against  main: 

2343 of 2379 sentences unchanged.

 * modified 21
 * added 22
 * removed 23
